### PR TITLE
Fixed Token.swift, it was crashing with Test cards.

### DIFF
--- a/MercadoPagoSDK/MercadoPagoSDK/Token.swift
+++ b/MercadoPagoSDK/MercadoPagoSDK/Token.swift
@@ -9,60 +9,68 @@
 import Foundation
 
 public class Token : NSObject {
-    public var _id : String!
-    public var publicKey : String!
-    public var cardId : String!
-    public var luhnValidation : String!
-    public var status : String!
-    public var usedDate : String!
-    public var cardNumberLength : Int = 0
-    public var creationDate : NSDate!
-    public var truncCardNumber : String!
-    public var securityCodeLength : Int = 0
-    public var expirationMonth : Int = 0
-    public var expirationYear : Int = 0
-    public var lastModifiedDate : NSDate!
-    public var dueDate : NSDate!
+  public var _id : String!
+  public var publicKey : String!
+  public var cardId : String!
+  public var luhnValidation : String!
+  public var status : String!
+  public var usedDate : String!
+  public var cardNumberLength : Int = 0
+  public var creationDate : NSDate!
+  public var truncCardNumber : String!
+  public var securityCodeLength : Int = 0
+  public var expirationMonth : Int = 0
+  public var expirationYear : Int = 0
+  public var lastModifiedDate : NSDate!
+  public var dueDate : NSDate!
+  
+  public init (_id: String, publicKey: String, cardId: String!, luhnValidation: String!, status: String!,
+    usedDate: String!, cardNumberLength: Int, creationDate: NSDate!, truncCardNumber: String!,
+    securityCodeLength: Int, expirationMonth: Int, expirationYear: Int, lastModifiedDate: NSDate!,
+    dueDate: NSDate?) {
+      super.init()
+      self._id = _id
+      self.publicKey = publicKey
+      self.cardId = cardId
+      self.luhnValidation = luhnValidation
+      self.status = status
+      self.usedDate = usedDate
+      self.cardNumberLength = cardNumberLength
+      self.creationDate = creationDate
+      self.truncCardNumber = truncCardNumber
+      self.securityCodeLength = securityCodeLength
+      self.expirationMonth = expirationMonth
+      self.expirationYear = expirationYear
+      self.lastModifiedDate = lastModifiedDate
+      self.dueDate = dueDate
+  }
+  
+  public class func fromJSON(json : NSDictionary) -> Token {
+    let id = JSON(json["id"]!).asString!
+    let publicKey = JSON(json["public_key"]!).asString!
+    let cardId = JSON(json["card_id"]!).asString
+    let status = JSON(json["status"]!).asString
+    let luhn = json.isKeyValid("luhn_validation") ? JSON(json["luhn_validation"]!).asString : ""
+    let usedDate = json.isKeyValid("date_used") ? JSON(json["date_used"]!).asString : ""
+    let cardNumberLength = json.isKeyValid("card_number_length") ? JSON(json["card_number_length"]!).asInt! : 0
+    let creationDate = json.isKeyValid("date_created") ? Utils.getDateFromString(json["date_created"] as? String) : NSDate()
+    let truncCardNumber = json.isKeyValid("last_four_digits") ? JSON(json["last_four_digits"]!).asString : ""
+    let securityCodeLength = json.isKeyValid("security_code_length") ? JSON(json["security_code_length"]!).asInt! : 0
+    let expMonth = json.isKeyValid("expiration_month") ? JSON(json["expiration_month"]!).asInt! : 0
+    let expYear = json.isKeyValid("expiration_year") ? JSON(json["expiration_year"]!).asInt! : 0
+    let lastModifiedDate = json.isKeyValid("date_last_updated") ? Utils.getDateFromString(json["date_last_updated"] as? String) : NSDate()
+    let dueDate = json.isKeyValid("date_due") ? Utils.getDateFromString(json["date_due"] as? String) : NSDate()
     
-    public init (_id: String, publicKey: String, cardId: String!, luhnValidation: String!, status: String!,
-        usedDate: String!, cardNumberLength: Int, creationDate: NSDate!, truncCardNumber: String!,
-        securityCodeLength: Int, expirationMonth: Int, expirationYear: Int, lastModifiedDate: NSDate!,
-        dueDate: NSDate?) {
-            super.init()
-            self._id = _id
-            self.publicKey = publicKey
-            self.cardId = cardId
-            self.luhnValidation = luhnValidation
-            self.status = status
-            self.usedDate = usedDate
-            self.cardNumberLength = cardNumberLength
-            self.creationDate = creationDate
-            self.truncCardNumber = truncCardNumber
-            self.securityCodeLength = securityCodeLength
-            self.expirationMonth = expirationMonth
-            self.expirationYear = expirationYear
-            self.lastModifiedDate = lastModifiedDate
-            self.dueDate = dueDate
-    }
-    
-    public class func fromJSON(json : NSDictionary) -> Token {
-        let id = JSON(json["id"]!).asString!
-        let publicKey = JSON(json["public_key"]!).asString!
-        let cardId = json["card_id"] == nil ? nil : JSON(json["card_id"]!).asString
-        let status = JSON(json["status"]!).asString
-        let luhn = json["luhn_validation"] == nil ? nil : JSON(json["luhn_validation"]!).asString
-        let usedDate = json["used_date"] == nil ? nil : JSON(json["used_date"]!).asString
-        let cardNumberLength = json["card_number_length"] == nil ? 0 : JSON(json["card_number_length"]!).asInt!
-        let creationDate = Utils.getDateFromString(json["creation_date"] as? String)
-        let truncCardNumber = json["trunc_card_number"] == nil ? nil : JSON(json["trunc_card_number"]!).asString
-        let securityCodeLength = json["security_code_length"] == nil ? 0 : JSON(json["security_code_length"]!).asInt!
-        let expMonth = json["expiration_month"] == nil ? 0 : JSON(json["expiration_month"]!).asInt!
-        let expYear = json["expiration_year"] == nil ? 0 : JSON(json["expiration_year"]!).asInt!
-        let lastModifiedDate = Utils.getDateFromString(json["last_modified_date"] as? String)
-        let dueDate = Utils.getDateFromString(json["due_date"] as? String)
-        return Token(_id: id, publicKey: publicKey, cardId: cardId, luhnValidation: luhn, status: status,
-            usedDate: usedDate, cardNumberLength: cardNumberLength, creationDate: creationDate, truncCardNumber: truncCardNumber,
-            securityCodeLength: securityCodeLength, expirationMonth: expMonth, expirationYear: expYear, lastModifiedDate: lastModifiedDate,
-            dueDate: dueDate)
-    }
+    return Token(_id: id, publicKey: publicKey, cardId: cardId, luhnValidation: luhn, status: status,
+      usedDate: usedDate, cardNumberLength: cardNumberLength, creationDate: creationDate, truncCardNumber: truncCardNumber,
+      securityCodeLength: securityCodeLength, expirationMonth: expMonth, expirationYear: expYear, lastModifiedDate: lastModifiedDate,
+      dueDate: dueDate)
+  }
+}
+
+extension NSDictionary {
+  public func isKeyValid(dictKey : String) -> Bool {
+    let dictValue: AnyObject? = self[dictKey]
+    return (dictValue == nil || dictValue is NSNull) ? false : true
+  }
 }


### PR DESCRIPTION
The method "fromJSON" in Token.swift  was not validating <null> values in the JSON, and it was crashing in TEST environment. I added the needed validation, but all the properties are set as non-optional (!), but in Test the API is not giving me all the needed values in the JSON response.

It was working when I create a Token with a new card,  but was not working when I wanted to use one of the previously added cards (SavedCardToken way).

But again, it is working now with this changes, but I think the SDK, or at least some of the model objects need to be reviewed, because the API returns different things than what the SDK is expecting.