### PR TITLE
[FIX]: Fix optional identification number and type

### DIFF
--- a/Sources/CoreMethods/Data/Model/CardTokenBody.swift
+++ b/Sources/CoreMethods/Data/Model/CardTokenBody.swift
@@ -37,8 +37,8 @@ extension CardTokenBody {
 
         if let buyerIdentification {
             let holderDic: [String: Any] = [
-                "number": buyerIdentification.number,
-                "type": buyerIdentification.type
+                "number": buyerIdentification.number ?? "",
+                "type": buyerIdentification.type ?? ""
             ]
             jsonObject["cardholder"] = [
                 "identification": holderDic,
@@ -57,6 +57,6 @@ extension CardTokenBody {
 
 struct BuyerIdentification: Codable {
     let name: String
-    let number: String
-    let type: String
+    let number: String?
+    let type: String?
 }

--- a/Sources/CoreMethods/Domain/UseCases/GenerateCardTokenUseCase.swift
+++ b/Sources/CoreMethods/Domain/UseCases/GenerateCardTokenUseCase.swift
@@ -46,7 +46,7 @@ final class GenerateCardTokenUseCase: GenerateCardTokenUseCaseProtocol {
     ) async throws -> CardToken {
         var buyerIdentification: BuyerIdentification?
 
-        if let identificationType, let identificationNumber, let cardHolderName {
+        if let cardHolderName {
             buyerIdentification = BuyerIdentification(
                 name: cardHolderName,
                 number: identificationNumber,


### PR DESCRIPTION
# Pull Request
<!--Provide the title of the pull request-->
## Ticket or Issue link
<!--Provide link for your issue or ticket that describes this pull request-->

## Description
Fixing BuyerIdentification to make number and type optional, so it can be sent in the scenario where only the cardHolder is used

## Checklist
- [] I have tested my changes creating a local version (More info in README file).
- [] I have added tests that prove my solution is effective and works
- [] New and existing unit tests pass locally with my changes.
- [] Verify that you are merged with the latest in develop.
- [] I have run `swiftlint` and fixed any possible issues of my code.
- [] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [] I have tested the accessibility of the changes and added them to the screenshots.
- [] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<!---
Provide videos or screenshots. You can change their size in the src
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>
-->