### PR TITLE
[2643](Fix) Adds card number length tracking

### DIFF
--- a/Example/Sources/SwiftUIExample/Sections/CardInformationSection.swift
+++ b/Example/Sources/SwiftUIExample/Sections/CardInformationSection.swift
@@ -74,12 +74,20 @@ struct CardInformationSection: View {
             style: style,
             placeholder: "Número do cartão",
             
+            /// Track input length for UX feedback
+            onLengthChanged: { length in
+                print("length")
+                DebugLogger.shared.log(type: .function, title: "onLengthChanged - CardNumberTextFieldView", object: length)
+            },
+            
             /// BIN Change Handler - Core Integration Point
             /// Called when first 6-8 digits are entered
             /// Triggers payment method detection and installment lookup
             onBinChanged: { bin in
-                Task {
-                    await viewModel.handleBinChange(bin)
+                if !bin.isEmpty {
+                    Task {
+                        await viewModel.handleBinChange(bin)
+                    }
                 }
             },
             

--- a/Example/Sources/UIKit/CardFormViewController.swift
+++ b/Example/Sources/UIKit/CardFormViewController.swift
@@ -100,14 +100,16 @@ final class CardFormViewController: UIViewController {
 
         // Handle BIN number changes (first 6-8 digits)
         field.onBinChanged = { [weak self] bin in
-            Task { [weak self] in
-                
-                // Payment Method, Issuer and Installment call
-                // ViewModel Handle bin change use CoreMethods SDK to retrive card information and update UI
-                await self?.viewModel.handleBinChange(bin)
-                await self?.updateInstallmentsUI()
-                await self?.updateCardImageUI()
-                await self?.updateCardConfigurationUI()
+            if !bin.isEmpty {
+                Task { [weak self] in
+                    
+                    // Payment Method, Issuer and Installment call
+                    // ViewModel Handle bin change use CoreMethods SDK to retrive card information and update UI
+                    await self?.viewModel.handleBinChange(bin)
+                    await self?.updateInstallmentsUI()
+                    await self?.updateCardImageUI()
+                    await self?.updateCardConfigurationUI()
+                }
             }
         }
 
@@ -144,6 +146,16 @@ final class CardFormViewController: UIViewController {
                 type: .function,
                 title: "onError - CardNumberTextFieldView",
                 object: error
+            )
+        }
+        
+        // Handle length changes
+        field.onLengthChanged = { [weak self] length in
+            print("CardNumberField length:", length)
+            DebugLogger.shared.log(
+                type: .function,
+                title: "onLengthChanged - CardNumberField",
+                object: length
             )
         }
 

--- a/Sources/CoreMethods/Public/UI/Fields/CardNumber/CardNumberTextField.swift
+++ b/Sources/CoreMethods/Public/UI/Fields/CardNumber/CardNumberTextField.swift
@@ -57,6 +57,10 @@ public final class CardNumberTextField: PCITextField {
     /// Callback triggered when the field focus state changes.
     /// - Parameter isFocused: True when field gains focus, false when it loses focus
     public var onFocusChanged: ((Bool) -> Void)?
+    
+    /// Callback triggered when the length of input change
+    /// - Parameter length: Length of security code
+    public var onLengthChanged: ((Int) -> Void)?
 
     ///
     /// Callback triggered when a validation error occurs.
@@ -164,11 +168,13 @@ public final class CardNumberTextField: PCITextField {
             guard let self else { return }
             
             let inputLength = text.count
+            self.onLengthChanged?(inputLength)
+            
             let currentBin = getBin(text)
 
             let previousBinPrefix = self.previousBin
 
-            if inputLength >= self.binLength && currentBin != previousBinPrefix {
+            if inputLength >= self.binLength && currentBin != previousBinPrefix || inputLength == 0  {
                 self.previousBin = currentBin
                 self.onBinChanged?(currentBin)
             }

--- a/Sources/CoreMethods/Public/UI/Fields/CardNumber/CardNumberTextFieldView.swift
+++ b/Sources/CoreMethods/Public/UI/Fields/CardNumber/CardNumberTextFieldView.swift
@@ -100,7 +100,7 @@ public struct CardNumberTextFieldView: UIViewRepresentable {
         onBinChanged: @escaping ((String) -> Void),
         onLastFourDigitsFilled: @escaping ((String) -> Void),
         onFocusChanged: @escaping ((Bool) -> Void),
-        onError: @escaping ((CardNumberError) -> Void),
+        onError: @escaping ((CardNumberError) -> Void)
     ) {
         self.style = style
         self.maxLength = maxLength

--- a/Sources/CoreMethods/Public/UI/Fields/CardNumber/CardNumberTextFieldView.swift
+++ b/Sources/CoreMethods/Public/UI/Fields/CardNumber/CardNumberTextFieldView.swift
@@ -65,6 +65,9 @@ public struct CardNumberTextFieldView: UIViewRepresentable {
 
     /// A closure that is called when a validation error occurs.
     public var onError: (CardNumberError) -> Void
+    
+    /// A closure that is called when the input length changes.
+    public var onLengthChanged: ((Int) -> Void)?
 
     @Binding var textField: CardNumberTextField?
 
@@ -93,10 +96,11 @@ public struct CardNumberTextFieldView: UIViewRepresentable {
         placeholder: String? = nil,
         isEnabled: Binding<Bool> = .constant(true),
         keyboardAppearance: UIKeyboardAppearance = .default,
+        onLengthChanged: ((Int) -> Void)? = nil,
         onBinChanged: @escaping ((String) -> Void),
         onLastFourDigitsFilled: @escaping ((String) -> Void),
         onFocusChanged: @escaping ((Bool) -> Void),
-        onError: @escaping ((CardNumberError) -> Void)
+        onError: @escaping ((CardNumberError) -> Void),
     ) {
         self.style = style
         self.maxLength = maxLength
@@ -104,6 +108,7 @@ public struct CardNumberTextFieldView: UIViewRepresentable {
         self.placeholder = placeholder
         self._isEnabled = isEnabled
         self.keyboardAppearance = keyboardAppearance
+        self.onLengthChanged = onLengthChanged
         self.onBinChanged = onBinChanged
         self.onLastFourDigitsFilled = onLastFourDigitsFilled
         self.onFocusChanged = onFocusChanged
@@ -127,6 +132,7 @@ public struct CardNumberTextFieldView: UIViewRepresentable {
         textField.isEnabled = self.isEnabled
         textField.keyboardAppearance = self.keyboardAppearance
 
+        textField.onLengthChanged = self.onLengthChanged
         textField.onBinChanged = self.onBinChanged
         textField.onLastFourDigitsFilled = self.onLastFourDigitsFilled
         textField.onFocusChanged = self.onFocusChanged


### PR DESCRIPTION
# Pull Request
<!--Provide the title of the pull request-->
## Ticket or Issue link
[CHOAPIGIN-2643](https://mercadolibre.atlassian.net/browse/CHOAPIGIN-2643)

## Description
This update introduces a new `onLengthChanged` callback to monitor the length of the card number entered by the user.
It improves the card form's user experience by providing real-time feedback on the input progress.
Also, prevents bin change from being called with empty bin.

## Checklist
- [] I have tested my changes creating a local version (More info in README file).
- [] I have added tests that prove my solution is effective and works
- [] New and existing unit tests pass locally with my changes.
- [] Verify that you are merged with the latest in develop.
- [] I have run `swiftlint` and fixed any possible issues of my code.
- [] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [] I have tested the accessibility of the changes and added them to the screenshots.
- [] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<!---
Provide videos or screenshots. You can change their size in the src
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>
-->

[CHOAPIGIN-2643]: https://mercadolibre.atlassian.net/browse/CHOAPIGIN-2643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ