### PR TITLE
[3593](Feature): Focus implementation for Secure Fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ buildServer.json
 /Package.resolved
 
 .docc-temp
+
+.claude/

--- a/Example/Sources/SwiftUIExample/Components/StyledCardFieldContainer.swift
+++ b/Example/Sources/SwiftUIExample/Components/StyledCardFieldContainer.swift
@@ -11,10 +11,17 @@ struct StyledCardFieldContainer<Content: View>: View {
     @Binding public var isValid: Bool
     let content: Content
     let paddingContent = EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 12)
+    let onTap: (() -> Void)?
 
-    init(title: String, isValid: Binding<Bool>, @ViewBuilder content: () -> Content) {
+    init(
+        title: String,
+        isValid: Binding<Bool>,
+        onTap: (() -> Void)? = nil,
+        @ViewBuilder content: () -> Content
+    ) {
         self.title = title
         self._isValid = isValid
+        self.onTap = onTap
         self.content = content()
     }
 
@@ -33,6 +40,10 @@ struct StyledCardFieldContainer<Content: View>: View {
                             .stroke(self.isValid ? Color(.systemGray4) : Color.red, lineWidth: 1)
                     )
             }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            self.onTap?()
         }
     }
 }

--- a/Example/Sources/SwiftUIExample/Sections/CardInformationSection.swift
+++ b/Example/Sources/SwiftUIExample/Sections/CardInformationSection.swift
@@ -24,6 +24,10 @@ struct CardInformationSection: View {
     @Binding var cardNumberTextField: CardNumberTextField?
     @Binding var securityTextField: SecurityCodeTextField?
     @Binding var expirationDateTextField: ExpirationDateTextfield?
+
+    @State private var cardFieldIsFocused = false
+    @State private var securityFieldIsFocused = false
+    @State private var expirationFieldIsFocused = false
     
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -49,7 +53,11 @@ struct CardInformationSection: View {
      * The logo is automatically updated when the payment method is detected
      */
     private var cardNumberField: some View {
-        StyledCardFieldContainer(title: "Card Number", isValid: .constant(viewModel.cardNumberIsValid)) {
+        StyledCardFieldContainer(
+            title: "Card Number",
+            isValid: .constant(viewModel.cardNumberIsValid),
+            onTap: { self.focusField(card: true) }
+        ) {
             HStack {
                 cardNumber
                 cardLogo
@@ -74,6 +82,7 @@ struct CardInformationSection: View {
             style: style,
             mask: viewModel.maskCardNumber,
             placeholder: "Número do cartão",
+            isFocused: self.$cardFieldIsFocused,
             /// Track input length for UX feedback
             onLengthChanged: { length in
                 print("length")
@@ -95,6 +104,7 @@ struct CardInformationSection: View {
             /// Useful for triggering final validations or UI updates
             onLastFourDigitsFilled: { lastFour in
                 DebugLogger.shared.log(type: .function, title: "onLastFourDigitsFilled", object: lastFour)
+                self.focusField(security: true)
             },
             
             /// Focus Change Handler
@@ -137,18 +147,27 @@ struct CardInformationSection: View {
      */
     private var securityAndExpirationFields: some View {
         HStack(spacing: 16) {
-            StyledCardFieldContainer(title: "Security Code", isValid: .constant(viewModel.securityCodeIsValid)) {
+            StyledCardFieldContainer(
+                title: "Security Code",
+                isValid: .constant(viewModel.securityCodeIsValid),
+                onTap: { self.focusField(security: true) }
+            ) {
                 securityCode
                     .frame(height: 44)
             }
 
-            StyledCardFieldContainer(title: "Expiration Date", isValid: .constant(viewModel.expirationDateIsValid)) {
+            StyledCardFieldContainer(
+                title: "Expiration Date",
+                isValid: .constant(viewModel.expirationDateIsValid),
+                onTap: { self.focusField(expiration: true) }
+            ) {
                 /// CoreMethods ExpirationDateTextFieldView
                 /// Handles MM/YY or MM/YYYY format with automatic validation
                 ExpirationDateTextFieldView(
                     textField: self.$expirationDateTextField,
                     style: style,
                     placeholder: "MM/YY",
+                    isFocused: self.$expirationFieldIsFocused,
                     
                     /// Track input length for UX feedback
                     onLengthChanged: { length in
@@ -158,6 +177,7 @@ struct CardInformationSection: View {
                     /// Called when date format is complete
                     onInputFilled: {
                         DebugLogger.shared.log(type: .function, title: "onInputFilled - ExpirationDateTextFieldView")
+                        self.focusField()
                     },
                     
                     /// Update validation state on focus loss
@@ -192,6 +212,7 @@ struct CardInformationSection: View {
             textField: self.$securityTextField,
             style: style,
             placeholder: "CVV",
+            isFocused: self.$securityFieldIsFocused,
             
             /// Track input progress for UX feedback
             onLengthChanged: { length in
@@ -201,6 +222,7 @@ struct CardInformationSection: View {
             /// Called when required length is reached
             onInputFilled: {
                 DebugLogger.shared.log(type: .function, title: "onInputFilled - SecurityCodeTextFieldView")
+                self.focusField(expiration: true)
             },
             
             /// Update validation state when field loses focus
@@ -223,5 +245,17 @@ struct CardInformationSection: View {
         )
         /// Apply dynamic length limit based on detected card type
         .maxLength(viewModel.maxLengthSecurityCode)
+    }
+
+    private func focusField(card: Bool = false, security: Bool = false, expiration: Bool = false) {
+        if self.cardFieldIsFocused != card {
+            self.cardFieldIsFocused = card
+        }
+        if self.securityFieldIsFocused != security {
+            self.securityFieldIsFocused = security
+        }
+        if self.expirationFieldIsFocused != expiration {
+            self.expirationFieldIsFocused = expiration
+        }
     }
 }

--- a/Sources/CoreMethods/CoreMethods.swift
+++ b/Sources/CoreMethods/CoreMethods.swift
@@ -507,6 +507,27 @@ internal extension CoreMethods {
         documentNumber: String? = nil,
         cardID: String? = nil
     ) async throws -> CardToken {
+        if let month = expirationDateMonth, month.isEmpty { throw CoreMethodsError.expirationDateInvalid }
+        if let year = expirationDateYear, year.isEmpty { throw CoreMethodsError.expirationDateInvalid }
+
+        if let cardNumber = cardNumber, !cardNumber.isEmpty {
+            let bin = CardNumber.getBin(cardNumber)
+            let params = PaymentMethodsParams(
+                bin: bin,
+                processingMode: ProcessingMode.aggregator.rawValue
+            )
+            
+            if let paymentMethod = try await self.paymentMethodUseCase.getPaymentMethods(params: params).first {
+                if let securityCode = securityCode, paymentMethod.card?.securityCode.mode == "mandatory" {
+                    let requiredLength = paymentMethod.card?.securityCode.length ?? 3
+                    
+                    if securityCode.isEmpty || securityCode.count != requiredLength {
+                        throw CoreMethodsError.securityCodeInvalid
+                    }
+                }
+            }
+        }
+        
         return try await executeWithTracking(
             operation: {
                 let response = try await self.generateTokenUseCase

--- a/Sources/CoreMethods/CoreMethods.swift
+++ b/Sources/CoreMethods/CoreMethods.swift
@@ -526,6 +526,8 @@ internal extension CoreMethods {
                     }
                 }
             }
+        } else if cardID == nil {
+            throw CoreMethodsError.cardNumberInvalid
         }
         
         return try await executeWithTracking(

--- a/Sources/CoreMethods/CoreMethods.swift
+++ b/Sources/CoreMethods/CoreMethods.swift
@@ -507,29 +507,6 @@ internal extension CoreMethods {
         documentNumber: String? = nil,
         cardID: String? = nil
     ) async throws -> CardToken {
-        if let month = expirationDateMonth, month.isEmpty { throw CoreMethodsError.expirationDateInvalid }
-        if let year = expirationDateYear, year.isEmpty { throw CoreMethodsError.expirationDateInvalid }
-
-        if let cardNumber = cardNumber, !cardNumber.isEmpty {
-            let bin = CardNumber.getBin(cardNumber)
-            let params = PaymentMethodsParams(
-                bin: bin,
-                processingMode: ProcessingMode.aggregator.rawValue
-            )
-            
-            if let paymentMethod = try await self.paymentMethodUseCase.getPaymentMethods(params: params).first {
-                if let securityCode = securityCode, paymentMethod.card?.securityCode.mode == "mandatory" {
-                    let requiredLength = paymentMethod.card?.securityCode.length ?? 3
-                    
-                    if securityCode.isEmpty || securityCode.count != requiredLength {
-                        throw CoreMethodsError.securityCodeInvalid
-                    }
-                }
-            }
-        } else if cardID == nil {
-            throw CoreMethodsError.cardNumberInvalid
-        }
-        
         return try await executeWithTracking(
             operation: {
                 let response = try await self.generateTokenUseCase

--- a/Sources/CoreMethods/Internal/Helpers/TextFieldFocusHelper.swift
+++ b/Sources/CoreMethods/Internal/Helpers/TextFieldFocusHelper.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+enum TextFieldFocusHelper {
+    static func makeFocusHandler(
+        focusState: Binding<Bool>,
+        onFocusChanged: ((Bool) -> Void)?
+    ) -> (Bool) -> Void {
+        { focus in
+            onFocusChanged?(focus)
+            guard focusState.wrappedValue != focus else { return }
+            DispatchQueue.main.async {
+                focusState.wrappedValue = focus
+            }
+        }
+    }
+
+    static func syncFocus(
+        _ uiView: PCITextField,
+        shouldBeFocused: Bool
+    ) {
+        guard shouldBeFocused != uiView.isInputFocused else { return }
+        DispatchQueue.main.async {
+            if shouldBeFocused {
+                uiView.focus()
+            } else {
+                uiView.resignFocus()
+            }
+        }
+    }
+}

--- a/Sources/CoreMethods/Presentation/PCIFieldState/PCIFieldState.swift
+++ b/Sources/CoreMethods/Presentation/PCIFieldState/PCIFieldState.swift
@@ -88,6 +88,11 @@ final class PCIFieldState: UIView {
         set { self.textField.keyboardAppearance = newValue }
     }
 
+    /// Indicates whether the underlying text field currently has focus
+    override var isFocused: Bool {
+        return self.textField.isFirstResponder
+    }
+
     // MARK: - Initialization
 
     init(configuration: Configuration) {
@@ -129,6 +134,15 @@ final class PCIFieldState: UIView {
     func setStyle(_ style: Style) {
         self.style = style
         configureStyles()
+    }
+
+    func focus() {
+        guard self.isEnabled else { return }
+        self.textField.becomeFirstResponder()
+    }
+
+    func resignFocus() {
+        self.textField.resignFirstResponder()
     }
 }
 

--- a/Sources/CoreMethods/Public/UI/Fields/CardNumber/CardNumberTextFieldView.swift
+++ b/Sources/CoreMethods/Public/UI/Fields/CardNumber/CardNumberTextFieldView.swift
@@ -146,13 +146,10 @@ public struct CardNumberTextFieldView: UIViewRepresentable {
         textField.onBinChanged = self.onBinChanged
         textField.onLastFourDigitsFilled = self.onLastFourDigitsFilled
         
-        textField.onFocusChanged = { focus in
-            self.onFocusChanged(focus)
-            guard self.focusState.wrappedValue != focus else { return }
-            DispatchQueue.main.async {
-                self.focusState.wrappedValue = focus
-            }
-        }
+        textField.onFocusChanged = TextFieldFocusHelper.makeFocusHandler(
+            focusState: self.focusState,
+            onFocusChanged: self.onFocusChanged
+        )
         textField.onError = self.onError
 
         Task { @MainActor in
@@ -176,16 +173,7 @@ public struct CardNumberTextFieldView: UIViewRepresentable {
         uiView.setMask(pattern: self.mask)
         uiView.setMaxLength(self.maxLength)
 
-        let shouldFocus = self.shouldBeFocused
-        if shouldFocus != uiView.isInputFocused {
-            DispatchQueue.main.async {
-                if shouldFocus {
-                    uiView.focus()
-                } else {
-                    uiView.resignFocus()
-                }
-            }
-        }
+        TextFieldFocusHelper.syncFocus(uiView, shouldBeFocused: self.shouldBeFocused)
     }
 }
 

--- a/Sources/CoreMethods/Public/UI/Fields/CardNumber/CardNumberTextFieldView.swift
+++ b/Sources/CoreMethods/Public/UI/Fields/CardNumber/CardNumberTextFieldView.swift
@@ -49,6 +49,13 @@ public struct CardNumberTextFieldView: UIViewRepresentable {
     /// Whether the text field is enabled for user interaction.
     @Binding var isEnabled: Bool
 
+    /// Binding that controls the focus state of the text field.
+    private var focusBinding: Binding<Bool>
+
+    private var isFieldFocused: Bool {
+        self.focusBinding.wrappedValue
+    }
+
     /// The appearance style of the keyboard.
     public var keyboardAppearance: UIKeyboardAppearance
 
@@ -81,6 +88,7 @@ public struct CardNumberTextFieldView: UIViewRepresentable {
     ///   - mask: The formatting mask to apply to the card number (e.g., "#### #### #### ####").
     ///   - placeholder: Optional placeholder text to display when the field is empty.
     ///   - isEnabled: Whether the text field is enabled for user interaction.
+    ///   - isFocused: Binding that controls whether the field should be focused.
     ///   - keyboardAppearance: The appearance style of the keyboard.
     ///   - onBinChanged: Callback triggered when the card BIN (first 6 digits) changes.
     ///   - onLastFourDigitsFilled: Callback triggered when the last four digits of the card number are filled.
@@ -95,6 +103,7 @@ public struct CardNumberTextFieldView: UIViewRepresentable {
         mask: String = "#### #### #### #######",
         placeholder: String? = nil,
         isEnabled: Binding<Bool> = .constant(true),
+        isFocused: Binding<Bool> = .constant(false),
         keyboardAppearance: UIKeyboardAppearance = .default,
         onLengthChanged: ((Int) -> Void)? = nil,
         onBinChanged: @escaping ((String) -> Void),
@@ -107,6 +116,7 @@ public struct CardNumberTextFieldView: UIViewRepresentable {
         self.mask = mask
         self.placeholder = placeholder
         self._isEnabled = isEnabled
+        self.focusBinding = isFocused
         self.keyboardAppearance = keyboardAppearance
         self.onLengthChanged = onLengthChanged
         self.onBinChanged = onBinChanged
@@ -135,11 +145,21 @@ public struct CardNumberTextFieldView: UIViewRepresentable {
         textField.onLengthChanged = self.onLengthChanged
         textField.onBinChanged = self.onBinChanged
         textField.onLastFourDigitsFilled = self.onLastFourDigitsFilled
-        textField.onFocusChanged = self.onFocusChanged
+        textField.onFocusChanged = { focus in
+            self.onFocusChanged(focus)
+            guard self.focusBinding.wrappedValue != focus else { return }
+            DispatchQueue.main.async {
+                self.focusBinding.wrappedValue = focus
+            }
+        }
         textField.onError = self.onError
 
         Task { @MainActor in
             self.textField = textField
+        }
+
+        if self.isFieldFocused {
+            textField.focus()
         }
 
         return textField
@@ -154,6 +174,17 @@ public struct CardNumberTextFieldView: UIViewRepresentable {
         uiView.setStyle(self.style)
         uiView.setMask(pattern: self.mask)
         uiView.setMaxLength(self.maxLength)
+
+        let shouldFocus = self.isFieldFocused
+        if shouldFocus != uiView.isInputFocused {
+            DispatchQueue.main.async {
+                if shouldFocus {
+                    uiView.focus()
+                } else {
+                    uiView.resignFocus()
+                }
+            }
+        }
     }
 }
 

--- a/Sources/CoreMethods/Public/UI/Fields/CardNumber/CardNumberTextFieldView.swift
+++ b/Sources/CoreMethods/Public/UI/Fields/CardNumber/CardNumberTextFieldView.swift
@@ -50,10 +50,10 @@ public struct CardNumberTextFieldView: UIViewRepresentable {
     @Binding var isEnabled: Bool
 
     /// Binding that controls the focus state of the text field.
-    private var focusBinding: Binding<Bool>
+    private var focusState: Binding<Bool>
 
-    private var isFieldFocused: Bool {
-        self.focusBinding.wrappedValue
+    private var shouldBeFocused: Bool {
+        self.focusState.wrappedValue
     }
 
     /// The appearance style of the keyboard.
@@ -116,7 +116,7 @@ public struct CardNumberTextFieldView: UIViewRepresentable {
         self.mask = mask
         self.placeholder = placeholder
         self._isEnabled = isEnabled
-        self.focusBinding = isFocused
+        self.focusState = isFocused
         self.keyboardAppearance = keyboardAppearance
         self.onLengthChanged = onLengthChanged
         self.onBinChanged = onBinChanged
@@ -145,11 +145,12 @@ public struct CardNumberTextFieldView: UIViewRepresentable {
         textField.onLengthChanged = self.onLengthChanged
         textField.onBinChanged = self.onBinChanged
         textField.onLastFourDigitsFilled = self.onLastFourDigitsFilled
+        
         textField.onFocusChanged = { focus in
             self.onFocusChanged(focus)
-            guard self.focusBinding.wrappedValue != focus else { return }
+            guard self.focusState.wrappedValue != focus else { return }
             DispatchQueue.main.async {
-                self.focusBinding.wrappedValue = focus
+                self.focusState.wrappedValue = focus
             }
         }
         textField.onError = self.onError
@@ -158,7 +159,7 @@ public struct CardNumberTextFieldView: UIViewRepresentable {
             self.textField = textField
         }
 
-        if self.isFieldFocused {
+        if self.shouldBeFocused {
             textField.focus()
         }
 
@@ -175,7 +176,7 @@ public struct CardNumberTextFieldView: UIViewRepresentable {
         uiView.setMask(pattern: self.mask)
         uiView.setMaxLength(self.maxLength)
 
-        let shouldFocus = self.isFieldFocused
+        let shouldFocus = self.shouldBeFocused
         if shouldFocus != uiView.isInputFocused {
             DispatchQueue.main.async {
                 if shouldFocus {

--- a/Sources/CoreMethods/Public/UI/Fields/ExpirationDate/ExpirationDateTextFieldView.swift
+++ b/Sources/CoreMethods/Public/UI/Fields/ExpirationDate/ExpirationDateTextFieldView.swift
@@ -1,6 +1,7 @@
 #if SWIFT_PACKAGE
     import MPCore
 #endif
+import Foundation
 import SwiftUI
 
 /// A SwiftUI component that provides a text field specifically designed for inputting credit card expiration dates.
@@ -34,7 +35,12 @@ public struct ExpirationDateTextFieldView: UIViewRepresentable {
     private var format: ExpirationDateTextfield.Format
     private var placeholder: String?
     @Binding private var isEnabled: Bool
+    private var focusBinding: Binding<Bool>
     private var keyboardAppearance: UIKeyboardAppearance
+
+    private var isFieldFocused: Bool {
+        self.focusBinding.wrappedValue
+    }
 
     // MARK: - Callbacks
 
@@ -63,6 +69,7 @@ public struct ExpirationDateTextFieldView: UIViewRepresentable {
     ///   - placeholder: Optional placeholder text to display when the field is empty.
     ///   - isEnabled: Whether the text field is enabled for user interaction.
     ///   - keyboardAppearance: The appearance style of the keyboard.
+    ///   - isFocused: Binding used to programmatically control focus.
     ///   - onLengthChanged: Callback triggered when the input length changes.
     ///   - onInputFilled: Callback triggered when the input is completely filled.
     ///   - onFocusChanged: Callback triggered when the focus state changes.
@@ -94,6 +101,7 @@ public struct ExpirationDateTextFieldView: UIViewRepresentable {
         format: ExpirationDateTextfield.Format = .short,
         placeholder: String? = nil,
         isEnabled: Binding<Bool> = .constant(true),
+        isFocused: Binding<Bool> = .constant(false),
         keyboardAppearance: UIKeyboardAppearance = .default,
         onLengthChanged: ((Int) -> Void)? = nil,
         onInputFilled: (() -> Void)? = nil,
@@ -104,6 +112,7 @@ public struct ExpirationDateTextFieldView: UIViewRepresentable {
         self.format = format
         self.placeholder = placeholder
         self._isEnabled = isEnabled
+        self.focusBinding = isFocused
         self.keyboardAppearance = keyboardAppearance
         self.onLengthChanged = onLengthChanged
         self.onInputFilled = onInputFilled
@@ -127,11 +136,21 @@ public struct ExpirationDateTextFieldView: UIViewRepresentable {
 
         textField.onLengthChanged = self.onLengthChanged
         textField.onInputFilled = self.onInputFilled
-        textField.onFocusChanged = self.onFocusChanged
+        textField.onFocusChanged = { focus in
+            self.onFocusChanged?(focus)
+            guard self.focusBinding.wrappedValue != focus else { return }
+            DispatchQueue.main.async {
+                self.focusBinding.wrappedValue = focus
+            }
+        }
         textField.onError = self.onError
 
         Task { @MainActor in
             self.textField = textField
+        }
+
+        if self.isFieldFocused {
+            textField.focus()
         }
 
         return textField
@@ -144,6 +163,17 @@ public struct ExpirationDateTextFieldView: UIViewRepresentable {
         uiView.isEnabled = self.isEnabled
         uiView.keyboardAppearance = self.keyboardAppearance
         uiView.setStyle(self.style)
+
+        let shouldFocus = self.isFieldFocused
+        if shouldFocus != uiView.isInputFocused {
+            DispatchQueue.main.async {
+                if shouldFocus {
+                    uiView.focus()
+                } else {
+                    uiView.resignFocus()
+                }
+            }
+        }
     }
 }
 

--- a/Sources/CoreMethods/Public/UI/Fields/ExpirationDate/ExpirationDateTextFieldView.swift
+++ b/Sources/CoreMethods/Public/UI/Fields/ExpirationDate/ExpirationDateTextFieldView.swift
@@ -136,13 +136,10 @@ public struct ExpirationDateTextFieldView: UIViewRepresentable {
 
         textField.onLengthChanged = self.onLengthChanged
         textField.onInputFilled = self.onInputFilled
-        textField.onFocusChanged = { focus in
-            self.onFocusChanged?(focus)
-            guard self.focusState.wrappedValue != focus else { return }
-            DispatchQueue.main.async {
-                self.focusState.wrappedValue = focus
-            }
-        }
+        textField.onFocusChanged = TextFieldFocusHelper.makeFocusHandler(
+            focusState: self.focusState,
+            onFocusChanged: self.onFocusChanged
+        )
         textField.onError = self.onError
 
         Task { @MainActor in
@@ -164,16 +161,7 @@ public struct ExpirationDateTextFieldView: UIViewRepresentable {
         uiView.keyboardAppearance = self.keyboardAppearance
         uiView.setStyle(self.style)
 
-        let shouldFocus = self.shouldBeFocused
-        if shouldFocus != uiView.isInputFocused {
-            DispatchQueue.main.async {
-                if shouldFocus {
-                    uiView.focus()
-                } else {
-                    uiView.resignFocus()
-                }
-            }
-        }
+        TextFieldFocusHelper.syncFocus(uiView, shouldBeFocused: self.shouldBeFocused)
     }
 }
 

--- a/Sources/CoreMethods/Public/UI/Fields/ExpirationDate/ExpirationDateTextFieldView.swift
+++ b/Sources/CoreMethods/Public/UI/Fields/ExpirationDate/ExpirationDateTextFieldView.swift
@@ -35,11 +35,11 @@ public struct ExpirationDateTextFieldView: UIViewRepresentable {
     private var format: ExpirationDateTextfield.Format
     private var placeholder: String?
     @Binding private var isEnabled: Bool
-    private var focusBinding: Binding<Bool>
+    private var focusState: Binding<Bool>
     private var keyboardAppearance: UIKeyboardAppearance
 
-    private var isFieldFocused: Bool {
-        self.focusBinding.wrappedValue
+    private var shouldBeFocused: Bool {
+        self.focusState.wrappedValue
     }
 
     // MARK: - Callbacks
@@ -112,7 +112,7 @@ public struct ExpirationDateTextFieldView: UIViewRepresentable {
         self.format = format
         self.placeholder = placeholder
         self._isEnabled = isEnabled
-        self.focusBinding = isFocused
+        self.focusState = isFocused
         self.keyboardAppearance = keyboardAppearance
         self.onLengthChanged = onLengthChanged
         self.onInputFilled = onInputFilled
@@ -138,9 +138,9 @@ public struct ExpirationDateTextFieldView: UIViewRepresentable {
         textField.onInputFilled = self.onInputFilled
         textField.onFocusChanged = { focus in
             self.onFocusChanged?(focus)
-            guard self.focusBinding.wrappedValue != focus else { return }
+            guard self.focusState.wrappedValue != focus else { return }
             DispatchQueue.main.async {
-                self.focusBinding.wrappedValue = focus
+                self.focusState.wrappedValue = focus
             }
         }
         textField.onError = self.onError
@@ -149,7 +149,7 @@ public struct ExpirationDateTextFieldView: UIViewRepresentable {
             self.textField = textField
         }
 
-        if self.isFieldFocused {
+        if self.shouldBeFocused {
             textField.focus()
         }
 
@@ -164,7 +164,7 @@ public struct ExpirationDateTextFieldView: UIViewRepresentable {
         uiView.keyboardAppearance = self.keyboardAppearance
         uiView.setStyle(self.style)
 
-        let shouldFocus = self.isFieldFocused
+        let shouldFocus = self.shouldBeFocused
         if shouldFocus != uiView.isInputFocused {
             DispatchQueue.main.async {
                 if shouldFocus {

--- a/Sources/CoreMethods/Public/UI/Fields/PCITextField.swift
+++ b/Sources/CoreMethods/Public/UI/Fields/PCITextField.swift
@@ -144,4 +144,23 @@ extension PCITextField {
     public func clear() {
         self.input.clear()
     }
+
+    /// Gives focus to the underlying secure field
+    @discardableResult
+    public func focus() -> Self {
+        self.input.focus()
+        return self
+    }
+
+    /// Resigns focus from the underlying secure field
+    @discardableResult
+    public func resignFocus() -> Self {
+        self.input.resignFocus()
+        return self
+    }
+
+    /// Indicates if the underlying secure field is focused
+    public var isInputFocused: Bool {
+        return self.input.isFocused
+    }
 }

--- a/Sources/CoreMethods/Public/UI/Fields/SecurityCode/SecurityCodeTextFieldView.swift
+++ b/Sources/CoreMethods/Public/UI/Fields/SecurityCode/SecurityCodeTextFieldView.swift
@@ -130,13 +130,10 @@ public struct SecurityCodeTextFieldView: UIViewRepresentable {
 
         textField.onLengthChanged = self.onLengthChanged
         textField.onInputFilled = self.onInputFilled
-        textField.onFocusChanged = { focus in
-            self.onFocusChanged?(focus)
-            guard self.focusState.wrappedValue != focus else { return }
-            DispatchQueue.main.async {
-                self.focusState.wrappedValue = focus
-            }
-        }
+        textField.onFocusChanged = TextFieldFocusHelper.makeFocusHandler(
+            focusState: self.focusState,
+            onFocusChanged: self.onFocusChanged
+        )
         textField.onError = self.onError
 
         Task { @MainActor in
@@ -159,16 +156,7 @@ public struct SecurityCodeTextFieldView: UIViewRepresentable {
         uiView.setStyle(self.style)
         uiView.setMaxLength(self.maxLength)
 
-        let shouldFocus = self.shouldBeFocused
-        if shouldFocus != uiView.isInputFocused {
-            DispatchQueue.main.async {
-                if shouldFocus {
-                    uiView.focus()
-                } else {
-                    uiView.resignFocus()
-                }
-            }
-        }
+        TextFieldFocusHelper.syncFocus(uiView, shouldBeFocused: self.shouldBeFocused)
     }
 }
 

--- a/Sources/CoreMethods/Public/UI/Fields/SecurityCode/SecurityCodeTextFieldView.swift
+++ b/Sources/CoreMethods/Public/UI/Fields/SecurityCode/SecurityCodeTextFieldView.swift
@@ -44,10 +44,10 @@ public struct SecurityCodeTextFieldView: UIViewRepresentable {
     @Binding private var isEnabled: Bool
 
     /// Binding that controls the focus state of the text field.
-    private var focusBinding: Binding<Bool>
+    private var focusState: Binding<Bool>
 
-    private var isFieldFocused: Bool {
-        self.focusBinding.wrappedValue
+    private var shouldBeFocused: Bool {
+        self.focusState.wrappedValue
     }
 
     /// The appearance style of the keyboard.
@@ -104,7 +104,7 @@ public struct SecurityCodeTextFieldView: UIViewRepresentable {
         self.maxLength = maxLength
         self.placeholder = placeholder
         self._isEnabled = isEnabled
-        self.focusBinding = isFocused
+        self.focusState = isFocused
         self.keyboardAppearance = keyboardAppearance
         self.onLengthChanged = onLengthChanged
         self.onInputFilled = onInputFilled
@@ -132,9 +132,9 @@ public struct SecurityCodeTextFieldView: UIViewRepresentable {
         textField.onInputFilled = self.onInputFilled
         textField.onFocusChanged = { focus in
             self.onFocusChanged?(focus)
-            guard self.focusBinding.wrappedValue != focus else { return }
+            guard self.focusState.wrappedValue != focus else { return }
             DispatchQueue.main.async {
-                self.focusBinding.wrappedValue = focus
+                self.focusState.wrappedValue = focus
             }
         }
         textField.onError = self.onError
@@ -143,7 +143,7 @@ public struct SecurityCodeTextFieldView: UIViewRepresentable {
             self.textField = textField
         }
 
-        if self.isFieldFocused {
+        if self.shouldBeFocused {
             textField.focus()
         }
 
@@ -159,7 +159,7 @@ public struct SecurityCodeTextFieldView: UIViewRepresentable {
         uiView.setStyle(self.style)
         uiView.setMaxLength(self.maxLength)
 
-        let shouldFocus = self.isFieldFocused
+        let shouldFocus = self.shouldBeFocused
         if shouldFocus != uiView.isInputFocused {
             DispatchQueue.main.async {
                 if shouldFocus {

--- a/Sources/CoreMethods/Public/UI/Fields/SecurityCode/SecurityCodeTextFieldView.swift
+++ b/Sources/CoreMethods/Public/UI/Fields/SecurityCode/SecurityCodeTextFieldView.swift
@@ -1,6 +1,7 @@
 #if SWIFT_PACKAGE
     import MPCore
 #endif
+import Foundation
 import SwiftUI
 
 /// A SwiftUI component that provides a text field specifically designed for inputting credit card security codes (CVV/CVC).
@@ -42,6 +43,13 @@ public struct SecurityCodeTextFieldView: UIViewRepresentable {
     /// Whether the text field is enabled for user interaction.
     @Binding private var isEnabled: Bool
 
+    /// Binding that controls the focus state of the text field.
+    private var focusBinding: Binding<Bool>
+
+    private var isFieldFocused: Bool {
+        self.focusBinding.wrappedValue
+    }
+
     /// The appearance style of the keyboard.
     private var keyboardAppearance: UIKeyboardAppearance
 
@@ -72,6 +80,7 @@ public struct SecurityCodeTextFieldView: UIViewRepresentable {
     ///   - placeholder: Optional placeholder text to display when the field is empty.
     ///   - isEnabled: Whether the text field is enabled for user interaction.
     ///   - keyboardAppearance: The appearance style of the keyboard.
+    ///   - isFocused: Binding used to programmatically control focus.
     ///   - onLengthChanged: Callback triggered when the input length changes.
     ///   - onInputFilled: Callback triggered when the input is completely filled.
     ///   - onFocusChanged: Callback triggered when the focus state changes.
@@ -84,6 +93,7 @@ public struct SecurityCodeTextFieldView: UIViewRepresentable {
         maxLength: Int = 3,
         placeholder: String? = nil,
         isEnabled: Binding<Bool> = .constant(true),
+        isFocused: Binding<Bool> = .constant(false),
         keyboardAppearance: UIKeyboardAppearance = .default,
         onLengthChanged: ((Int) -> Void)? = nil,
         onInputFilled: (() -> Void)? = nil,
@@ -94,6 +104,7 @@ public struct SecurityCodeTextFieldView: UIViewRepresentable {
         self.maxLength = maxLength
         self.placeholder = placeholder
         self._isEnabled = isEnabled
+        self.focusBinding = isFocused
         self.keyboardAppearance = keyboardAppearance
         self.onLengthChanged = onLengthChanged
         self.onInputFilled = onInputFilled
@@ -119,11 +130,21 @@ public struct SecurityCodeTextFieldView: UIViewRepresentable {
 
         textField.onLengthChanged = self.onLengthChanged
         textField.onInputFilled = self.onInputFilled
-        textField.onFocusChanged = self.onFocusChanged
+        textField.onFocusChanged = { focus in
+            self.onFocusChanged?(focus)
+            guard self.focusBinding.wrappedValue != focus else { return }
+            DispatchQueue.main.async {
+                self.focusBinding.wrappedValue = focus
+            }
+        }
         textField.onError = self.onError
 
         Task { @MainActor in
             self.textField = textField
+        }
+
+        if self.isFieldFocused {
+            textField.focus()
         }
 
         return textField
@@ -137,6 +158,17 @@ public struct SecurityCodeTextFieldView: UIViewRepresentable {
         uiView.keyboardAppearance = self.keyboardAppearance
         uiView.setStyle(self.style)
         uiView.setMaxLength(self.maxLength)
+
+        let shouldFocus = self.isFieldFocused
+        if shouldFocus != uiView.isInputFocused {
+            DispatchQueue.main.async {
+                if shouldFocus {
+                    uiView.focus()
+                } else {
+                    uiView.resignFocus()
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds programmatic focus control (`isFocused` binding) to `CardNumberTextFieldView`, `SecurityCodeTextFieldView`, and `ExpirationDateTextFieldView`, enabling auto-advance between fields on input completion
- Moves card tokenization validation logic into `GenerateCardTokenUseCase`, removing responsibility from the UI layer
- Adds `CardNumberValidation` and related error types for card number validation
- Refactors tests to use `MockCoreMethodsRepository` instead of `MockURLSession` for more reliable test setup

## Changes

### Focus Management (SDK)
- Added `isFocused: Binding<Bool>` parameter to all three `UIViewRepresentable` text field views
- Added `focus()`, `resignFocus()`, and `isInputFocused` to `PCITextField`
- Focus state syncs bidirectionally between SwiftUI and UIKit via `updateUIView` and `onFocusChanged` callback

### Focus Management (Example App)
- `CardInformationSection` now auto-advances focus: card number → security code → expiration date → dismiss
- `StyledCardFieldContainer` supports `onTap` to focus the inner field when tapping the container area

### Validation
- `GenerateCardTokenUseCase` validates card fields before token creation, throwing `CoreMethodsError.invalidCardData`
- `CardNumber` uses internal constant for BIN length
- `PaymentMethodUseCase` injected into `GenerateCardTokenUseCase`

### Tests
- Replaced `MockURLSession` with `MockCoreMethodsRepository`
- Updated `MockAnalytics` to use continuations instead of callbacks
- Added `GenerateCardTokenUseCaseTests` for validation scenarios
- Added `CardTokenStub` for test data

## Test plan
- [ ] Verify auto-focus advances from card number → security code → expiration when input is filled
- [ ] Verify tapping a field container focuses the underlying text field
- [ ] Verify focus dismisses after expiration date is filled
- [ ] Verify token creation fails with `invalidCardData` when fields are invalid
- [ ] Run existing unit tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)