### PR TITLE
[CHOBK-3673] Error Messages 

### DIFF
--- a/Example/Sources/SwiftUIExample/CardFormView.swift
+++ b/Example/Sources/SwiftUIExample/CardFormView.swift
@@ -1,90 +1,93 @@
 import CoreMethods
 import SwiftUI
 
-/**
- * CardFormView - Main SwiftUI view demonstrating CoreMethods SDK integration
- * 
- * This example shows how to integrate the CoreMethods SDK for payment processing in a SwiftUI app.
- * Key features demonstrated:
- * - Card number, expiration date, and security code input validation
- * - Dynamic payment method detection based on card BIN
- * - Document type selection for user identification
- * - Installment options based on payment method
- * - Token creation for secure payment processing
- * 
- * Architecture Note: All CoreMethods SDK operations are centralized in CardFormViewModel
- * for better organization and single source of truth.
- */
+/// CardFormView - Main SwiftUI view demonstrating CoreMethods SDK integration
+/// 
+/// This example shows how to integrate the CoreMethods SDK for payment processing in a SwiftUI app.
+/// Key features demonstrated:
+/// - Card number, expiration date, and security code input validation
+/// - Dynamic payment method detection based on card BIN
+/// - Document type selection for user identification
+/// - Installment options based on payment method
+/// - Token creation for secure payment processing
+/// 
+/// Architecture Note: All CoreMethods SDK operations are centralized in CardFormViewModel
+/// for better organization and single source of truth.
 struct CardFormView: View {
     // MARK: - Properties
-    
+
     /// Custom styling for text fields - you can customize appearance to match your app's design
     private let style = TextFieldDefaultStyle()
         .textColor(UIColor.dynamicColor)
         .borderColor(.clear)
-    
+
     // MARK: - State
-    
+
     /// ViewModel containing all business logic and CoreMethods SDK operations
     @StateObject private var viewModel = CardFormViewModel()
-    
+
     /// Processing state for showing loading indicators during API calls
     @State private var isProcessing = false
-    
+
     // MARK: - TextFields
-    
+
     /// These are the CoreMethods SDK text field components that handle card input validation
     /// Store references to access validation states and data for token creation
     @State var cardNumberTextField: CardNumberTextField?
     @State var securityTextField: SecurityCodeTextField?
     @State var expirationDateTextField: ExpirationDateTextfield?
-    
+
     var body: some View {
         NavigationView {
             ScrollView {
                 VStack(spacing: 24) {
                     // MARK: - Card Input Section
-                    /// This section contains the core payment fields provided by CoreMethods SDK
+
+                    // This section contains the core payment fields provided by CoreMethods SDK
                     CardInformationSection(
-                        style: style,
-                        viewModel: viewModel,
-                        cardNumberTextField: $cardNumberTextField,
-                        securityTextField: $securityTextField,
-                        expirationDateTextField: $expirationDateTextField
+                        style: self.style,
+                        viewModel: self.viewModel,
+                        cardNumberTextField: self.$cardNumberTextField,
+                        securityTextField: self.$securityTextField,
+                        expirationDateTextField: self.$expirationDateTextField
                     )
-                    
+
                     // MARK: - Document Selection Section
-                    /// Required for compliance - users must provide identification
-                    /// Document types are fetched from CoreMethods SDK
+
+                    // Required for compliance - users must provide identification
+                    // Document types are fetched from CoreMethods SDK
                     DocumentSection(
-                        documents: $viewModel.documents,
-                        selectedType: $viewModel.selectedDocumentType,
-                        documentText: $viewModel.documentText
+                        documents: self.$viewModel.documents,
+                        selectedType: self.$viewModel.selectedDocumentType,
+                        documentText: self.$viewModel.documentText
                     )
-                    
+
                     // MARK: - Installment Options Section
-                    /// Shows available installment plans based on card type and amount
-                    /// Only displayed when installments are available
-                    if !viewModel.installments.isEmpty {
+
+                    // Shows available installment plans based on card type and amount
+                    // Only displayed when installments are available
+                    if !self.viewModel.installments.isEmpty {
                         InstallmentSection(
-                            installments: viewModel.installments,
-                            selectedPayerCost: $viewModel.selectedPayerCost,
-                            currencyFormatter: viewModel.currencyFormatter
+                            installments: self.viewModel.installments,
+                            selectedPayerCost: self.$viewModel.selectedPayerCost,
+                            currencyFormatter: self.viewModel.currencyFormatter
                         )
                     }
-                    
+
                     // MARK: - Payment Action Button
-                    /// Triggers the token creation process via ViewModel when all validations pass
+
+                    // Triggers the token creation process via ViewModel when all validations pass
                     PaymentButton(
-                        isProcessing: $isProcessing,
-                        amount: viewModel.amount,
-                        currencyFormatter: viewModel.currencyFormatter,
-                        action: handlePayButtonTapped
+                        isProcessing: self.$isProcessing,
+                        amount: self.viewModel.amount,
+                        currencyFormatter: self.viewModel.currencyFormatter,
+                        action: self.handlePayButtonTapped
                     )
-                    
+
                     // MARK: - Token Display
-                    /// Shows the generated token after successful creation
-                    /// In production, send this token to your backend for payment processing
+
+                    // Shows the generated token after successful creation
+                    // In production, send this token to your backend for payment processing
                     if let token = viewModel.token {
                         TokenDisplay(token: token)
                     }
@@ -94,51 +97,49 @@ struct CardFormView: View {
             .background(Color(.systemGroupedBackground).edgesIgnoringSafeArea(.all))
             .navigationTitle("Card Payment")
             .onAppear {
-                /// Initialize by fetching available document types via ViewModel
-                /// This is typically the first API call you'll make
+                // Initialize by fetching available document types via ViewModel
+                // This is typically the first API call you'll make
                 Task {
-                    await viewModel.getDocuments()
+                    await self.viewModel.getDocuments()
                 }
             }
         }
     }
-    
+
     // MARK: - Actions
-    
-    /**
-     * Main payment processing function
-     * 
-     * This demonstrates the complete flow for creating a payment token using the ViewModel:
-     * 1. Validate all required fields are available
-     * 2. Call ViewModel's createPaymentToken() method
-     * 3. Handle the response (token or error)
-     */
+
+    /// Main payment processing function
+    /// 
+    /// This demonstrates the complete flow for creating a payment token using the ViewModel:
+    /// 1. Validate all required fields are available
+    /// 2. Call ViewModel's createPaymentToken() method
+    /// 3. Handle the response (token or error)
     private func handlePayButtonTapped() {
         guard let cardNumberTextField = self.cardNumberTextField,
               let expirationTextField = self.expirationDateTextField,
               let securityCodeTextField = self.securityTextField else {
             return
         }
-        
-        isProcessing = true
-        
+
+        self.isProcessing = true
+
         Task {
             do {
-                /// Call ViewModel's createPaymentToken method
-                /// All CoreMethods SDK operations are centralized in the ViewModel
+                // Call ViewModel's createPaymentToken method
+                // All CoreMethods SDK operations are centralized in the ViewModel
                 let token = try await viewModel.createPaymentToken(
                     cardNumber: cardNumberTextField,
                     expirationDate: expirationTextField,
                     securityCode: securityCodeTextField,
                     cardHolderName: "APRO" // Use "APRO" for approved test transactions
                 )
-                
+
                 // Step 5: Handle successful response
                 await MainActor.run {
-                    isProcessing = false
+                    self.isProcessing = false
                     UIPasteboard.general.string = token
                 }
-                
+
             } catch let error as TokenzationError {
                 await MainActor.run {
                     isProcessing = false
@@ -146,7 +147,7 @@ struct CardFormView: View {
                 }
             } catch {
                 await MainActor.run {
-                    isProcessing = false
+                    self.isProcessing = false
                     print("Unexpected error: \(error.localizedDescription)")
                 }
             }
@@ -155,6 +156,7 @@ struct CardFormView: View {
 }
 
 // MARK: - Preview
+
 #Preview {
     CardFormView()
 }

--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
         
         .target(
             name: "MercadoPagoCheckout",
-            dependencies: ["MPComponents", "CoreMethods"]
+            dependencies: ["MPComponents", "CoreMethods", "MPCore"]
         ),
         .target(
             name: "MPComponents",

--- a/Sources/MPComponents/BaseElements/Message/MPMessage + ViewModifier.swift
+++ b/Sources/MPComponents/BaseElements/Message/MPMessage + ViewModifier.swift
@@ -12,9 +12,10 @@ struct MPMessageSnackbarModifier: ViewModifier {
     let text: String
     let state: MPMessageState
     let duration: MPMessageDuration
+    let bottomPadding: CGFloat
 
     @State private var hideWorkItem: DispatchWorkItem?
-    
+
     func body(content: Content) -> some View {
         content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -36,6 +37,7 @@ struct MPMessageSnackbarModifier: ViewModifier {
                 .onAppear { scheduleHide() }
                 .onDisappear { hideWorkItem?.cancel() }
             }
+            .padding(.bottom, bottomPadding)
         }
     }
     private func scheduleHide() {
@@ -60,14 +62,16 @@ package extension View {
         isPresented: Binding<Bool>,
         text: String,
         state: MPMessageState = .informative,
-        duration: MPMessageDuration = .normal
+        duration: MPMessageDuration = .normal,
+        bottomPadding: CGFloat = 0
     ) -> some View {
         modifier(
             MPMessageSnackbarModifier(
                 isPresented: isPresented,
                 text: text,
                 state: state,
-                duration: duration
+                duration: duration,
+                bottomPadding: bottomPadding
             )
         )
     }

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -4,8 +4,8 @@
 //
 //  Created by Guilherme Prata Costa on 11/12/25.
 //
-import SwiftUI
 import MPComponents
+import SwiftUI
 
 struct CardFormBrick: View {
     private enum Route: Hashable {
@@ -15,10 +15,10 @@ struct CardFormBrick: View {
 
     @State private var route: Route?
     @State private var paymentData: MPPaymentData
+    @State private var cardFormViewModel: CardFormViewModel
 
     private let themeDark: MPTheme
     private let themeLight: MPTheme
-    private let configuration: MercadoPagoCheckout.CheckoutConfiguration
 
     private let onResult: (MercadoPagoCheckoutResult) -> Void
 
@@ -32,10 +32,10 @@ struct CardFormBrick: View {
         self.onResult = onResult
         self.themeDark = appearance.dark
         self.themeLight = appearance.light
-        self.configuration = configuration
+        self._cardFormViewModel = State(initialValue: CardFormViewModel(configuration: configuration))
         self.paymentData = MPPaymentData(transactionAmount: configuration.type.configuration.amount ?? 0)
     }
-    
+
     var body: some View {
         ThemeProvider(
             light: self.themeLight,
@@ -43,66 +43,64 @@ struct CardFormBrick: View {
         ) {
             NavigationView {
                 ZStack {
-                    cardFormScreen()
-                    navigationLinks()
+                    self.cardFormScreen()
+                    self.navigationLinks()
                 }
             }
             .navigationViewStyle(StackNavigationViewStyle())
         }
     }
-    
+
     private func cardFormScreen() -> some View {
         CardFormScreen(
-            paymentData: $paymentData,
-            viewModel: .init(configuration: configuration),
-            onBack: { cancelCheckout() },
+            paymentData: self.$paymentData,
+            viewModel: self.cardFormViewModel,
+            onBack: { self.cancelCheckout() },
             onContinue: {
-                route = .installments
+                self.route = .installments
             }
         )
     }
-    
+
     private func installmentScreen() -> some View {
         InstallmentScreen(
-            paymentData: $paymentData,
+            paymentData: self.$paymentData,
             installments: InstallmentMock.visa,
             onBack: {
-                presentationMode.wrappedValue.dismiss()
+                self.presentationMode.wrappedValue.dismiss()
             },
             onContinue: {
-                route = .reviewAndConfirm
+                self.route = .reviewAndConfirm
             }
         )
         .listItemStyle(.radioButton)
     }
-    
-    @ViewBuilder
+
     private func navigationLinks() -> some View {
         Group {
             NavigationLink(
-                destination: installmentScreen(),
+                destination: self.installmentScreen(),
                 tag: .installments,
-                selection: $route
+                selection: self.$route
             ) {
                 EmptyView()
             }
             .hidden()
-            
         }
     }
-    
+
     private func cancelCheckout() {
-        route = nil
-        onResult(.userCancelled)
-        presentationMode.wrappedValue.dismiss()
+        self.route = nil
+        self.onResult(.userCancelled)
+        self.presentationMode.wrappedValue.dismiss()
     }
-    
+
     private func completeCheckout() {
-        route = nil
-        onResult(.success(paymentData))
+        self.route = nil
+        self.onResult(.success(self.paymentData))
     }
-    
+
     private func fail(_ error: MercadoPagoCheckoutError) {
-        onResult(.error(error))
+        self.onResult(.error(error))
     }
 }

--- a/Sources/MercadoPagoCheckout/Domain/UseCases/FetchBinDataUseCase.swift
+++ b/Sources/MercadoPagoCheckout/Domain/UseCases/FetchBinDataUseCase.swift
@@ -28,16 +28,12 @@ struct FetchBinDataUseCase {
             acceptedPaymentMethodIds: acceptedPaymentMethodIds
         )
 
-        let fetchedIssuer: Issuer? = try await filterIssuer(
-            method,
-            bin: bin
-        )
+        async let issuersTask = self.filterIssuer(method, bin: bin)
+        async let installmentsTask = self.filterInstallmentsRaw(amount: amount, bin: bin)
 
-        let fetchedInstallment: Installment? = try await filterInstallments(
-            amount: amount,
-            bin: bin,
-            issuer: fetchedIssuer
-        )
+        let fetchedIssuer = try await issuersTask
+        let allInstallments = try await installmentsTask
+        let fetchedInstallment = self.pickInstallment(from: allInstallments, issuer: fetchedIssuer)
 
         return CardBinData(
             paymentMethod: method,
@@ -94,24 +90,22 @@ struct FetchBinDataUseCase {
         }
     }
 
-    private func filterInstallments(
-        amount: Double?,
-        bin: String,
-        issuer fetchedIssuer: Issuer? = nil
-    ) async throws -> Installment? {
-        guard let amount else { return nil }
+    private func filterInstallmentsRaw(amount: Double?, bin: String) async throws -> [Installment] {
+        guard let amount else { return [] }
         do {
-            let installments = try await service.installments(amount: amount, bin: bin)
-            if let fetchedIssuer {
-                return installments.first(where: { $0.issuer.id == fetchedIssuer.id })
-            } else {
-                return installments.first
-            }
+            return try await self.service.installments(amount: amount, bin: bin)
         } catch let error as APIClientError {
             throw BinFetchError(from: error)
         } catch {
             throw BinFetchError.serviceError
         }
+    }
+
+    private func pickInstallment(from installments: [Installment], issuer: Issuer?) -> Installment? {
+        if let issuer {
+            return installments.first(where: { $0.issuer.id == issuer.id })
+        }
+        return installments.first
     }
 }
 

--- a/Sources/MercadoPagoCheckout/Domain/UseCases/FetchBinDataUseCase.swift
+++ b/Sources/MercadoPagoCheckout/Domain/UseCases/FetchBinDataUseCase.swift
@@ -28,12 +28,12 @@ struct FetchBinDataUseCase {
             acceptedPaymentMethodIds: acceptedPaymentMethodIds
         )
 
-        var fetchedIssuer: Issuer? = try await filterIssuer(
+        let fetchedIssuer: Issuer? = try await filterIssuer(
             method,
             bin: bin
         )
-     
-        var fetchedInstallment: Installment? = try await filterInstallments(
+
+        let fetchedInstallment: Installment? = try await filterInstallments(
             amount: amount,
             bin: bin,
             issuer: fetchedIssuer
@@ -45,16 +45,17 @@ struct FetchBinDataUseCase {
             installment: fetchedInstallment
         )
     }
+
     private func getPaymentMethods(from bin: String) async throws -> [PaymentMethod] {
         do {
-            return try await service.paymentMethod(bin: bin)
+            return try await self.service.paymentMethod(bin: bin)
         } catch let error as APIClientError {
             throw BinFetchError(from: error)
         } catch {
             throw BinFetchError.serviceError
         }
     }
-    
+
     private func filterPaymentMethod(
         _ methods: [PaymentMethod],
         acceptedPaymentTypeIds: [String],
@@ -67,7 +68,7 @@ struct FetchBinDataUseCase {
         }) else {
             if let typeMatchedMethod = methods.first(where: {
                 acceptedPaymentTypeIds.contains($0.paymentTypeId) &&
-                !acceptedPaymentMethodIds.contains($0.id)
+                    !acceptedPaymentMethodIds.contains($0.id)
             }) {
                 throw BinFetchError.paymentMethodNotAllowed(typeMatchedMethod.id)
             } else {
@@ -78,21 +79,21 @@ struct FetchBinDataUseCase {
         }
         return method
     }
-    
+
     private func filterIssuer(
         _ method: PaymentMethod,
         bin: String
     ) async throws -> Issuer? {
-        guard  method.additionalInfoNeeded?.contains("issuer_id") == true else { return nil }
+        guard method.additionalInfoNeeded?.contains("issuer_id") == true else { return nil }
         do {
-            return try await service.issuers(bin: bin, paymentMethodID: method.id).first
+            return try await self.service.issuers(bin: bin, paymentMethodID: method.id).first
         } catch let error as APIClientError {
             throw BinFetchError(from: error)
         } catch {
             throw BinFetchError.serviceError
         }
     }
-    
+
     private func filterInstallments(
         amount: Double?,
         bin: String,
@@ -129,7 +130,7 @@ private extension BinFetchError {
         switch error {
         case .networkError:
             self = .networkError
-        case .apiError(let response) where response.code == "not_found":
+        case let .apiError(response) where response.code == "not_found":
             self = .paymentMethodNotFound
         default:
             self = .serviceError

--- a/Sources/MercadoPagoCheckout/Domain/UseCases/FetchBinDataUseCase.swift
+++ b/Sources/MercadoPagoCheckout/Domain/UseCases/FetchBinDataUseCase.swift
@@ -5,6 +5,7 @@
 //  Created by Danielle Nozaki Ogawa on 26/02/26.
 //
 import CoreMethods
+import MPCore
 
 struct FetchBinDataUseCase {
     private let service: CheckoutServiceProtocol
@@ -19,7 +20,46 @@ struct FetchBinDataUseCase {
         acceptedPaymentTypeIds: [String],
         acceptedPaymentMethodIds: [String]
     ) async throws -> CardBinData {
-        let methods = try await service.paymentMethod(bin: bin)
+        var methods: [PaymentMethod] = try await getPaymentMethods(from: bin)
+
+        let method = try filterPaymentMethod(
+            methods,
+            acceptedPaymentTypeIds: acceptedPaymentTypeIds,
+            acceptedPaymentMethodIds: acceptedPaymentMethodIds
+        )
+
+        var fetchedIssuer: Issuer? = try await filterIssuer(
+            method,
+            bin: bin
+        )
+     
+        var fetchedInstallment: Installment? = try await filterInstallments(
+            amount: amount,
+            bin: bin,
+            issuer: fetchedIssuer
+        )
+
+        return CardBinData(
+            paymentMethod: method,
+            issuer: fetchedIssuer,
+            installment: fetchedInstallment
+        )
+    }
+    private func getPaymentMethods(from bin: String) async throws -> [PaymentMethod] {
+        do {
+            return try await service.paymentMethod(bin: bin)
+        } catch let error as APIClientError {
+            throw BinFetchError(from: error)
+        } catch {
+            throw BinFetchError.serviceError
+        }
+    }
+    
+    private func filterPaymentMethod(
+        _ methods: [PaymentMethod],
+        acceptedPaymentTypeIds: [String],
+        acceptedPaymentMethodIds: [String]
+    ) throws -> PaymentMethod {
         guard let method = methods.first(where: {
             let matchesType = acceptedPaymentTypeIds.contains($0.paymentTypeId)
             let matchesBrand = acceptedPaymentMethodIds.isEmpty || acceptedPaymentMethodIds.contains($0.id)
@@ -36,33 +76,63 @@ struct FetchBinDataUseCase {
                 throw BinFetchError.paymentTypeNotAllowed(detectedCardType)
             }
         }
-
-        var fetchedIssuer: Issuer?
-        if method.additionalInfoNeeded?.contains("issuer_id") == true {
-            fetchedIssuer = try await service.issuers(bin: bin, paymentMethodID: method.id).first
+        return method
+    }
+    
+    private func filterIssuer(
+        _ method: PaymentMethod,
+        bin: String
+    ) async throws -> Issuer? {
+        guard  method.additionalInfoNeeded?.contains("issuer_id") == true else { return nil }
+        do {
+            return try await service.issuers(bin: bin, paymentMethodID: method.id).first
+        } catch let error as APIClientError {
+            throw BinFetchError(from: error)
+        } catch {
+            throw BinFetchError.serviceError
         }
-
-        var fetchedInstallment: Installment?
-        if let amount {
+    }
+    
+    private func filterInstallments(
+        amount: Double?,
+        bin: String,
+        issuer fetchedIssuer: Issuer? = nil
+    ) async throws -> Installment? {
+        guard let amount else { return nil }
+        do {
             let installments = try await service.installments(amount: amount, bin: bin)
             if let fetchedIssuer {
-                fetchedInstallment = installments.first(where: { $0.issuer.id == fetchedIssuer.id })
+                return installments.first(where: { $0.issuer.id == fetchedIssuer.id })
             } else {
-                fetchedInstallment = installments.first
+                return installments.first
             }
+        } catch let error as APIClientError {
+            throw BinFetchError(from: error)
+        } catch {
+            throw BinFetchError.serviceError
         }
-
-        return CardBinData(
-            paymentMethod: method,
-            issuer: fetchedIssuer,
-            installment: fetchedInstallment
-        )
     }
 }
 
 // MARK: - Private
 
 package enum BinFetchError: Error, Equatable {
+    case paymentMethodNotFound
     case paymentMethodNotAllowed(String)
     case paymentTypeNotAllowed(MercadoPagoCheckout.CardType?)
+    case networkError
+    case serviceError
+}
+
+private extension BinFetchError {
+    init(from error: APIClientError) {
+        switch error {
+        case .networkError:
+            self = .networkError
+        case .apiError(let response) where response.code == "not_found":
+            self = .paymentMethodNotFound
+        default:
+            self = .serviceError
+        }
+    }
 }

--- a/Sources/MercadoPagoCheckout/Utils/CardFormFormatting.swift
+++ b/Sources/MercadoPagoCheckout/Utils/CardFormFormatting.swift
@@ -13,8 +13,8 @@ import MPComponents
 /// A formatter that applies a mask pattern to card numbers.
 package struct CardNumberFormatter: TextFormatting {
     private static let maskByLength: [Int: String] = [
-        8:  "#### ####",
-        9:  "#### #####",
+        8: "#### ####",
+        9: "#### #####",
         10: "#### ######",
         11: "#### #### ###",
         12: "#### #### ####",
@@ -33,20 +33,20 @@ package struct CardNumberFormatter: TextFormatting {
 
     /// Creates a card number formatter for the specified max digit count.
     /// The mask is automatically selected based on `maxLength`.
-    /// - Parameter maxLength: Maximum number of digits accepted. Default is 19.
-    package init(maxLength: Int = 19) {
+    /// - Parameter maxLength: Maximum number of digits accepted. Default is 16.
+    package init(maxLength: Int = 16) {
         self.maxLength = maxLength
         self.maskFormat = Self.maskByLength[maxLength] ?? Self.defaultMask
     }
 
     package func formatOnChange(_ text: String) -> String {
         let cleanNumber = String(
-            text.components(separatedBy: CharacterSet.decimalDigits.inverted).joined().prefix(maxLength)
+            text.components(separatedBy: CharacterSet.decimalDigits.inverted).joined().prefix(self.maxLength)
         )
         var result = ""
         var index = cleanNumber.startIndex
 
-        for char in maskFormat where index < cleanNumber.endIndex {
+        for char in self.maskFormat where index < cleanNumber.endIndex {
             if char == "#" {
                 result.append(cleanNumber[index])
                 index = cleanNumber.index(after: index)
@@ -57,9 +57,9 @@ package struct CardNumberFormatter: TextFormatting {
 
         return result
     }
-    
+
     package func formatOnCommit(_ text: String) -> String {
-        formatOnChange(text)
+        self.formatOnChange(text)
     }
 }
 
@@ -67,28 +67,27 @@ package struct CardNumberFormatter: TextFormatting {
 
 /// A formatter that applies MM/YY mask to expiration dates.
 package struct ExpirationDateFormatter: TextFormatting {
-    
     package init() {}
-    
+
     package func formatOnChange(_ text: String) -> String {
         let digits = text.components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
-        
+
         guard !digits.isEmpty else { return "" }
-        
+
         let limited = String(digits.prefix(4))
-        
+
         if limited.count <= 2 {
             return limited
         }
-        
+
         let month = String(limited.prefix(2))
         let year = String(limited.dropFirst(2))
-        
+
         return "\(month)/\(year)"
     }
-    
+
     package func formatOnCommit(_ text: String) -> String {
-        formatOnChange(text)
+        self.formatOnChange(text)
     }
 }
 
@@ -107,16 +106,16 @@ package struct DocumentFormatter: TextFormatting {
     }
 
     package func formatOnChange(_ text: String) -> String {
-        guard !maskFormat.isEmpty else {
-            return String(text.prefix(maxLength))
+        guard !self.maskFormat.isEmpty else {
+            return String(text.prefix(self.maxLength))
         }
         let digits = String(
-            text.components(separatedBy: CharacterSet.decimalDigits.inverted).joined().prefix(maxLength)
+            text.components(separatedBy: CharacterSet.decimalDigits.inverted).joined().prefix(self.maxLength)
         )
         var result = ""
         var index = digits.startIndex
 
-        for char in maskFormat where index < digits.endIndex {
+        for char in self.maskFormat where index < digits.endIndex {
             if char == "#" {
                 result.append(digits[index])
                 index = digits.index(after: index)
@@ -129,7 +128,7 @@ package struct DocumentFormatter: TextFormatting {
     }
 
     package func formatOnCommit(_ text: String) -> String {
-        formatOnChange(text)
+        self.formatOnChange(text)
     }
 }
 
@@ -138,19 +137,19 @@ package struct DocumentFormatter: TextFormatting {
 /// A formatter that limits CVV input to digits only.
 package struct SecurityCodeFormatter: TextFormatting {
     private let maxLength: Int
-    
+
     /// Creates a security code formatter.
     /// - Parameter maxLength: Maximum digits allowed. Default is 4 (for Amex).
     package init(maxLength: Int = 4) {
         self.maxLength = maxLength
     }
-    
+
     package func formatOnChange(_ text: String) -> String {
         let digits = text.components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
-        return String(digits.prefix(maxLength))
+        return String(digits.prefix(self.maxLength))
     }
-    
+
     package func formatOnCommit(_ text: String) -> String {
-        formatOnChange(text)
+        self.formatOnChange(text)
     }
 }

--- a/Sources/MercadoPagoCheckout/Utils/CardFormFormatting.swift
+++ b/Sources/MercadoPagoCheckout/Utils/CardFormFormatting.swift
@@ -12,16 +12,31 @@ import MPComponents
 
 /// A formatter that applies a mask pattern to card numbers.
 package struct CardNumberFormatter: TextFormatting {
+    private static let maskByLength: [Int: String] = [
+        8:  "#### ####",
+        9:  "#### #####",
+        10: "#### ######",
+        11: "#### #### ###",
+        12: "#### #### ####",
+        13: "#### ###### ###",
+        14: "#### ###### ####",
+        15: "#### ###### #####",
+        16: "#### #### #### ####",
+        17: "#### #### #### #####",
+        18: "#### #### #### ######",
+        19: "#### #### #### #### ###"
+    ]
+    private static let defaultMask = "#### #### #### ####"
+
     private let maskFormat: String
     private let maxLength: Int
 
-    /// Creates a card number formatter with the specified mask and max digit count.
-    /// - Parameters:
-    ///   - mask: The mask pattern where '#' represents a digit.
-    ///   - maxLength: Maximum number of digits accepted. Default is 19.
-    package init(mask: String = "#### #### #### ####", maxLength: Int = 19) {
-        self.maskFormat = mask
+    /// Creates a card number formatter for the specified max digit count.
+    /// The mask is automatically selected based on `maxLength`.
+    /// - Parameter maxLength: Maximum number of digits accepted. Default is 19.
+    package init(maxLength: Int = 19) {
         self.maxLength = maxLength
+        self.maskFormat = Self.maskByLength[maxLength] ?? Self.defaultMask
     }
 
     package func formatOnChange(_ text: String) -> String {

--- a/Sources/MercadoPagoCheckout/Utils/RetryUtils.swift
+++ b/Sources/MercadoPagoCheckout/Utils/RetryUtils.swift
@@ -18,6 +18,7 @@ func withRetry<T>(
     isolation _: isolated (any Actor)? = #isolation,
     operation: () async throws -> T
 ) async throws -> T {
+    try Task.checkCancellation()
     var lastError: Error?
     for _ in 0 ..< maxAttempts {
         do {

--- a/Sources/MercadoPagoCheckout/Utils/RetryUtils.swift
+++ b/Sources/MercadoPagoCheckout/Utils/RetryUtils.swift
@@ -1,0 +1,30 @@
+//
+//  RetryUtils.swift
+//  MercadoPagoSDK
+//
+//  Created by SDK on 09/03/26.
+//
+
+import Foundation
+
+/// Executes the given `operation` up to `maxAttempts` times, retrying on any thrown error.
+/// Throws the last error if all attempts fail.
+///
+/// - Parameters:
+///   - maxAttempts: Maximum number of attempts. Defaults to 2.
+///   - operation: The async throwing closure to execute.
+@MainActor
+func withRetry<T>(
+    maxAttempts: Int = 2,
+    operation: () async throws -> T
+) async throws -> T {
+    var lastError: Error?
+    for _ in 0 ..< maxAttempts {
+        do {
+            return try await operation()
+        } catch {
+            lastError = error
+        }
+    }
+    throw lastError ?? CancellationError()
+}

--- a/Sources/MercadoPagoCheckout/Utils/RetryUtils.swift
+++ b/Sources/MercadoPagoCheckout/Utils/RetryUtils.swift
@@ -13,9 +13,9 @@ import Foundation
 /// - Parameters:
 ///   - maxAttempts: Maximum number of attempts. Defaults to 2.
 ///   - operation: The async throwing closure to execute.
-@MainActor
 func withRetry<T>(
     maxAttempts: Int = 2,
+    isolation _: isolated (any Actor)? = #isolation,
     operation: () async throws -> T
 ) async throws -> T {
     var lastError: Error?

--- a/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
+++ b/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
@@ -86,6 +86,10 @@ package struct CardNumberRule: CardFormRuleType {
                 return MPStrings.CardForm.CardNumber.errorInvalid
             }
             return MPStrings.CardForm.CardNumber.errorTypeNotAllowed(cardType: cardTypeDisplayName(cardType))
+        case .paymentMethodNotFound:
+            return MPStrings.CardForm.CardNumber.errorInvalid
+        case .networkError, .serviceError:
+            return nil
         }
     }
 

--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -17,6 +17,8 @@ struct CardFormScreen: View {
     
     // MARK: States View
     @State private var cardForm = CardFormData()
+    @State private var isSnackbarPresented = false
+    @State private var footerHeight: CGFloat = 0
     @Binding private var paymentData: MPPaymentData
 
     // MARK: Enviroments
@@ -40,6 +42,7 @@ struct CardFormScreen: View {
             case .loading:
                 MPProgressIndicator()
                     .size(.xlarge)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .ready:
                 MPHeader(
                     title: MPStrings.CardForm.title,
@@ -52,6 +55,11 @@ struct CardFormScreen: View {
                             action: { onContinue() }
                         )
                         .disabled(!cardForm.isFormValid)
+                        .background(
+                            GeometryReader { geo in
+                                Color.clear.onAppear { footerHeight = geo.size.height }
+                            }
+                        )
                     },
                     content: {
                         VStack(spacing: theme.spacings.xsmall) {
@@ -107,9 +115,15 @@ struct CardFormScreen: View {
                         .padding(.horizontal, theme.spacings.micro)
                     }
                 )
-                .background(theme.colors.background.primary)
+                .messageSnackbar(
+                    isPresented: $isSnackbarPresented,
+                    text: MPStrings.Errors.generic,
+                    state: .negative,
+                    bottomPadding: footerHeight
+                )
             }
         }
+        .background(theme.colors.background.primary.edgesIgnoringSafeArea(.all))
         .mpTask {
             await viewModel.loadIdentificationTypes()
         }
@@ -132,6 +146,9 @@ struct CardFormScreen: View {
         }
         .mpOnChange(of: viewModel.fetchBinError) { error in
             cardForm.setCardNumberExternalError(error)
+        }
+        .mpOnChange(of: viewModel.snackbarError) { error in
+            if error != nil { isSnackbarPresented = true }
         }
     }
         

--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -119,14 +119,14 @@ struct CardFormScreen: View {
                         .padding(.horizontal, self.theme.spacings.micro)
                     }
                 )
-                .messageSnackbar(
-                    isPresented: self.$isSnackbarPresented,
-                    text: MPStrings.Errors.generic,
-                    state: .negative,
-                    bottomPadding: self.footerHeight
-                )
             }
         }
+        .messageSnackbar(
+            isPresented: self.$isSnackbarPresented,
+            text: MPStrings.Errors.generic,
+            state: .negative,
+            bottomPadding: self.footerHeight
+        )
         .background(self.theme.colors.background.primary.edgesIgnoringSafeArea(.all))
         .mpTask {
             await self.viewModel.loadIdentificationTypes()

--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -4,24 +4,25 @@
 //
 //  Created by Guilherme Prata Costa on 14/11/25.
 //
-import SwiftUI
-import MPComponents
 import CoreMethods
+import MPComponents
+import SwiftUI
 
 struct CardFormScreen: View {
-    
     private let onBack: () -> Void
     private let onContinue: () -> Void
-    
+
     @ObservedObject private var viewModel: CardFormViewModel
-    
+
     // MARK: States View
+
     @State private var cardForm = CardFormData()
     @State private var isSnackbarPresented = false
     @State private var footerHeight: CGFloat = 0
     @Binding private var paymentData: MPPaymentData
 
     // MARK: Enviroments
+
     @Environment(\.checkoutTheme) var theme: MPTheme
 
     init(
@@ -38,7 +39,7 @@ struct CardFormScreen: View {
 
     var body: some View {
         Group {
-            switch viewModel.screenState {
+            switch self.viewModel.screenState {
             case .loading:
                 MPProgressIndicator()
                     .size(.xlarge)
@@ -46,182 +47,185 @@ struct CardFormScreen: View {
             case .ready:
                 MPHeader(
                     title: MPStrings.CardForm.title,
-                    onBack: { onBack() },
+                    onBack: { self.onBack() },
                     footer: {
                         MPFooter(
                             label: MPStrings.Common.total,
-                            amount: MPStrings.formatPrice(paymentData.transactionAmount),
+                            amount: MPStrings.formatPrice(self.paymentData.transactionAmount),
                             buttonLabel: MPStrings.CardForm.button,
-                            action: { onContinue() }
+                            action: { self.onContinue() }
                         )
-                        .disabled(!cardForm.isFormValid)
+                        .disabled(!self.cardForm.isFormValid)
                         .background(
                             GeometryReader { geo in
-                                Color.clear.onAppear { footerHeight = geo.size.height }
+                                Color.clear.onAppear { self.footerHeight = geo.size.height }
                             }
                         )
                     },
                     content: {
-                        VStack(spacing: theme.spacings.xsmall) {
+                        VStack(spacing: self.theme.spacings.xsmall) {
                             MPTextField(
-                                text: $cardForm.cardNumber,
+                                text: self.$cardForm.cardNumber,
                                 label: MPStrings.CardForm.CardNumber.label,
                                 placeholder: MPStrings.CardForm.CardNumber.placeholder,
-                                errorMessage: cardForm.$cardNumber,
-                                liveErrorMessage: cardForm.cardNumberLiveErrors,
+                                errorMessage: self.cardForm.$cardNumber,
+                                liveErrorMessage: self.cardForm.cardNumberLiveErrors,
                                 keyboard: .numberPad,
-                                formatter: viewModel.cardNumberFormatter,
+                                onEditingChanged: { isEditing in
+                                    if !isEditing { self.viewModel.retryBinFetch() }
+                                },
+                                formatter: self.viewModel.cardNumberFormatter
                             )
 
                             MPTextField(
-                                text: $cardForm.cardHolder,
+                                text: self.$cardForm.cardHolder,
                                 label: MPStrings.CardForm.CardHolder.label,
                                 placeholder: MPStrings.CardForm.CardHolder.placeholder,
                                 helperText: MPStrings.CardForm.CardHolder.helperText,
-                                errorMessage: cardForm.$cardHolder,
+                                errorMessage: self.cardForm.$cardHolder
                             )
 
                             MPTextField(
-                                text: $cardForm.expirationDate,
+                                text: self.$cardForm.expirationDate,
                                 label: MPStrings.CardForm.Expiration.label,
                                 placeholder: MPStrings.CardForm.Expiration.placeholder,
-                                errorMessage: cardForm.$expirationDate,
+                                errorMessage: self.cardForm.$expirationDate,
                                 keyboard: .numberPad,
-                                formatter: viewModel.expirationDateFormatter,
+                                formatter: self.viewModel.expirationDateFormatter
                             )
 
                             MPTextField(
-                                text: $cardForm.securityCode,
+                                text: self.$cardForm.securityCode,
                                 label: MPStrings.CardForm.CVV.label,
-                                placeholder: viewModel.cvvPlaceholder,
-                                errorMessage: cardForm.$securityCode,
+                                placeholder: self.viewModel.cvvPlaceholder,
+                                errorMessage: self.cardForm.$securityCode,
                                 keyboard: .numberPad,
-                                formatter: viewModel.securityCodeFormatter,
+                                formatter: self.viewModel.securityCodeFormatter,
                                 popoverText: MPStrings.CardForm.CVV.tooltipStaticDefault
                             )
 
                             MPTextField(
-                                text: $cardForm.documentHolder,
+                                text: self.$cardForm.documentHolder,
                                 label: MPStrings.CardForm.Document.label,
-                                placeholder: viewModel.selectTypeDocument?.getPlaceholder(),
-                                errorMessage: cardForm.$documentHolder,
-                                keyboard: viewModel.selectTypeDocument?.getKeyboardType() ?? .default,
-                                formatter: viewModel.documentFormatter,
+                                placeholder: self.viewModel.selectTypeDocument?.getPlaceholder(),
+                                errorMessage: self.cardForm.$documentHolder,
+                                keyboard: self.viewModel.selectTypeDocument?.getKeyboardType() ?? .default,
+                                formatter: self.viewModel.documentFormatter,
                                 prefix: {
-                                    dropdownDocument()
-                                },
+                                    self.dropdownDocument()
+                                }
                             )
                         }
-                        .padding(.horizontal, theme.spacings.micro)
+                        .padding(.horizontal, self.theme.spacings.micro)
                     }
                 )
                 .messageSnackbar(
-                    isPresented: $isSnackbarPresented,
+                    isPresented: self.$isSnackbarPresented,
                     text: MPStrings.Errors.generic,
                     state: .negative,
-                    bottomPadding: footerHeight
+                    bottomPadding: self.footerHeight
                 )
             }
         }
-        .background(theme.colors.background.primary.edgesIgnoringSafeArea(.all))
+        .background(self.theme.colors.background.primary.edgesIgnoringSafeArea(.all))
         .mpTask {
-            await viewModel.loadIdentificationTypes()
+            await self.viewModel.loadIdentificationTypes()
         }
-        .mpOnChange(of: cardForm.cardNumber) { newValue in
-            viewModel.onCardNumberChange(newValue)
-            
+        .mpOnChange(of: self.cardForm.cardNumber) { newValue in
+            self.viewModel.onCardNumberChange(newValue)
         }
-        .mpOnChange(of: viewModel.binData) { binData in
-            if let cardInfo = binData?.paymentMethod.card {
-                cardForm.setCardNumberLength(cardInfo.length.min, cardInfo.length.max)
-                cardForm.setSecurityCodeLength(cardInfo.securityCode.length)
-            } else {
-                cardForm.setCardNumberLength()
-            }
+        .mpOnChange(of: self.viewModel.binData) { binData in
+            self.updateCardNumberLength(binData: binData)
         }
-        .mpOnChange(of: viewModel.selectTypeDocument) { identificationType in
-            if let identificationType {
-                cardForm.setDocumentLength(identificationType.minLenght, identificationType.maxLenght)
-            }
+        .mpOnChange(of: self.viewModel.selectTypeDocument) { identificationType in
+            self.updateIdentificationTypes(identificationType)
         }
-        .mpOnChange(of: viewModel.fetchBinError) { error in
-            cardForm.setCardNumberExternalError(error)
+        .mpOnChange(of: self.viewModel.binFetchError) { error in
+            self.cardForm.setCardNumberExternalError(error)
         }
-        .mpOnChange(of: viewModel.snackbarError) { error in
-            if error != nil { isSnackbarPresented = true }
+        .mpOnChange(of: self.viewModel.showSnackbar) { show in
+            if show { self.isSnackbarPresented = true }
         }
     }
-        
-    @ViewBuilder
+
     private func dropdownDocument() -> some View {
         HStack(spacing: 0) {
             if #available(iOS 14.0, *) {
-                documentPickerMenu()
+                self.documentPickerMenu()
             } else {
-                documentPickerFallback()
+                self.documentPickerFallback()
             }
 
             Rectangle()
-                .fill(theme.textFields.standard.idle.borderColor)
-                .frame(width: theme.borderWidth.small)
+                .fill(self.theme.textFields.standard.idle.borderColor)
+                .frame(width: self.theme.borderWidth.small)
         }
     }
 
     @available(iOS 14.0, *)
-    @ViewBuilder
     private func documentPickerMenu() -> some View {
         Menu {
             Picker(
-                selection: $viewModel.selectTypeDocument,
+                selection: self.$viewModel.selectTypeDocument,
                 label: EmptyView()
             ) {
-                ForEach(viewModel.identificationTypes, id: \.id) { type in
+                ForEach(self.viewModel.identificationTypes, id: \.id) { type in
                     Text(type.name).tag(Optional(type))
                 }
             }
         } label: {
-            documentLabel()
+            self.documentLabel()
         }
-        .accessibility(label: Text(verbatim: viewModel.selectTypeDocument?.name ?? String()))
+        .accessibility(label: Text(verbatim: self.viewModel.selectTypeDocument?.name ?? String()))
     }
 
-    @ViewBuilder
     private func documentPickerFallback() -> some View {
         Picker(
-            selection: $viewModel.selectTypeDocument,
-            label: documentLabel()
+            selection: self.$viewModel.selectTypeDocument,
+            label: self.documentLabel()
         ) {
-            ForEach(viewModel.identificationTypes, id: \.id) { type in
+            ForEach(self.viewModel.identificationTypes, id: \.id) { type in
                 Text(type.name).tag(Optional(type))
             }
         }
         .fixedSize(horizontal: true, vertical: false)
-        .accentColor(theme.textFields.standard.idle.textColor)
-        .accessibility(label: Text(verbatim: viewModel.selectTypeDocument?.name ?? String()))
+        .accentColor(self.theme.textFields.standard.idle.textColor)
+        .accessibility(label: Text(verbatim: self.viewModel.selectTypeDocument?.name ?? String()))
     }
 
-    @ViewBuilder
     private func documentLabel() -> some View {
         HStack {
-            Text(viewModel.selectTypeDocument?.name ?? String())
+            Text(self.viewModel.selectTypeDocument?.name ?? String())
                 .textStyle(.bodyMedium(colorType: .secondary))
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
 
             Image(systemName: "chevron.down")
                 .renderingMode(.template)
-                .foregroundColor(theme.textFields.standard.idle.borderColor)
-                .padding(.horizontal, theme.spacings.xmicro)
+                .foregroundColor(self.theme.textFields.standard.idle.borderColor)
+                .padding(.horizontal, self.theme.spacings.xmicro)
         }
-        .padding(.leading, theme.spacings.micro)
+        .padding(.leading, self.theme.spacings.micro)
         .animation(nil)
+    }
+
+    private func updateCardNumberLength(binData: CardBinData?) {
+        if let cardInfo = binData?.paymentMethod.card {
+            self.cardForm.setCardNumberLength(cardInfo.length.min, cardInfo.length.max)
+            self.cardForm.setSecurityCodeLength(cardInfo.securityCode.length)
+        } else {
+            self.cardForm.setCardNumberLength()
+        }
+    }
+
+    private func updateIdentificationTypes(_ identificationType: IdentificationType?) {
+        guard let identificationType else { return }
+        self.cardForm.setDocumentLength(identificationType.minLenght, identificationType.maxLenght)
     }
 }
 
 struct CardForm_Previews: PreviewProvider {
-    
     static var previews: some View {
-        
         ThemeProvider(
             light: MPLightTheme(),
             dark: MPLightTheme()
@@ -236,6 +240,5 @@ struct CardForm_Previews: PreviewProvider {
                 )
             )
         }
-
     }
 }

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -49,6 +49,10 @@ final class CardFormViewModel: ObservableObject {
             : MPStrings.CardForm.CVV.placeholderDefault
     }
 
+    private var isRetriableBinError: Bool {
+        self.binFetchError == .networkError || self.binFetchError == .serviceError
+    }
+
     // MARK: - Constants
 
     private static let amexSecurityCodeLength = 4
@@ -122,17 +126,14 @@ final class CardFormViewModel: ObservableObject {
     }
 
     func retryBinFetch() {
-        guard self.binData == nil, let lastFetchedBIN,
-              binFetchError == .networkError || binFetchError == .serviceError else { return }
+        guard self.binData == nil, let lastFetchedBIN, isRetriableBinError else { return }
         self.binFetchError = nil
         self.showSnackbar = false
         self.paymentMethodTask?.cancel()
         self.paymentMethodTask = Task { [weak self] in
             await self?.fetchBinData(bin: lastFetchedBIN)
             guard let self, !Task.isCancelled else { return }
-            if self.binFetchError == .networkError || self.binFetchError == .serviceError {
-                self.showSnackbar = true
-            }
+            if self.isRetriableBinError { self.showSnackbar = true }
         }
     }
 

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -41,6 +41,7 @@ final class CardFormViewModel: ObservableObject {
     }
 
     @Published private(set) var fetchBinError: BinFetchError?
+    @Published private(set) var snackbarError: BinFetchError?
 
     var cvvPlaceholder: String {
         self.binData?.paymentMethod.card?.securityCode.length == Self.amexSecurityCodeLength
@@ -111,6 +112,7 @@ final class CardFormViewModel: ObservableObject {
         self.paymentMethodTask?.cancel()
         self.binData = nil
         self.fetchBinError = nil
+        self.snackbarError = nil
 
         guard let bin else { return }
 
@@ -135,7 +137,12 @@ final class CardFormViewModel: ObservableObject {
         } catch let error as BinFetchError {
             guard !Task.isCancelled else { return }
             binData = nil
-            self.fetchBinError = error
+            switch error {
+            case .networkError, .serviceError:
+                self.snackbarError = error
+            default:
+                self.fetchBinError = error
+            }
         } catch {
             guard !Task.isCancelled else { return }
             self.binData = nil

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -40,8 +40,8 @@ final class CardFormViewModel: ObservableObject {
         didSet { self.updateFormatters(for: self.binData) }
     }
 
-    @Published private(set) var fetchBinError: BinFetchError?
-    @Published private(set) var snackbarError: BinFetchError?
+    @Published private(set) var binFetchError: BinFetchError?
+    @Published private(set) var showSnackbar = false
 
     var cvvPlaceholder: String {
         self.binData?.paymentMethod.card?.securityCode.length == Self.amexSecurityCodeLength
@@ -111,13 +111,27 @@ final class CardFormViewModel: ObservableObject {
 
         self.paymentMethodTask?.cancel()
         self.binData = nil
-        self.fetchBinError = nil
-        self.snackbarError = nil
+        self.binFetchError = nil
 
         guard let bin else { return }
 
         self.paymentMethodTask = Task { [weak self] in
             await self?.fetchBinData(bin: bin)
+        }
+    }
+
+    func retryBinFetch() {
+        guard self.binData == nil, let lastFetchedBIN,
+              binFetchError == .networkError || binFetchError == .serviceError else { return }
+        self.binFetchError = nil
+        self.showSnackbar = false
+        self.paymentMethodTask?.cancel()
+        self.paymentMethodTask = Task { [weak self] in
+            await self?.fetchBinData(bin: lastFetchedBIN)
+            guard let self, !Task.isCancelled else { return }
+            if self.binFetchError == .networkError || self.binFetchError == .serviceError {
+                self.showSnackbar = true
+            }
         }
     }
 
@@ -137,12 +151,7 @@ final class CardFormViewModel: ObservableObject {
         } catch let error as BinFetchError {
             guard !Task.isCancelled else { return }
             binData = nil
-            switch error {
-            case .networkError, .serviceError:
-                self.snackbarError = error
-            default:
-                self.fetchBinError = error
-            }
+            self.binFetchError = error
         } catch {
             guard !Task.isCancelled else { return }
             self.binData = nil

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -72,12 +72,13 @@ final class CardFormViewModel: ObservableObject {
 
     func loadIdentificationTypes() async {
         do {
-            let types = try await service.identificationTypes()
+            let types = try await withRetry { try await self.service.identificationTypes() }
             self.identificationTypes = types
             self.selectTypeDocument = types.first
             self.screenState = .ready
         } catch {
             self.screenState = .ready
+            self.showSnackbar = true
         }
     }
 

--- a/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
+++ b/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
@@ -11,55 +11,57 @@ struct CardFormData {
         RequiredRule(MPStrings.CardForm.CardNumber.errorEmpty),
         CardNumberRule()
     )
-    var cardNumber: String = ""
-    
+    var cardNumber = ""
+
     @CardFormValidate(
         RequiredRule(MPStrings.CardForm.CardHolder.errorEmpty),
         CardHolderRule()
     )
-    var cardHolder: String = ""
-    
+    var cardHolder = ""
+
     @CardFormValidate(
         RequiredRule(MPStrings.CardForm.Expiration.errorEmpty),
         ExpirationDateRule()
     )
-    var expirationDate: String = ""
-    
+    var expirationDate = ""
+
     @CardFormValidate(
         RequiredRule(MPStrings.CardForm.CVV.errorEmpty),
         SecurityCodeRule()
     )
-    var securityCode: String = ""
-    
+    var securityCode = ""
+
     @CardFormValidate(
         RequiredRule(MPStrings.CardForm.Document.errorEmpty),
         DocumentRule()
     )
-    var documentHolder: String = ""
-    
+    var documentHolder = ""
+
     mutating func setSecurityCodeLength(_ length: Int) {
         _securityCode.update(.securityCodeLength(length))
     }
-    
+
     mutating func setDocumentLength(_ min: Int, _ max: Int) {
         _documentHolder.update(.documentLength(min: min, max: max))
     }
-    
-    mutating func setCardNumberLength(_ minLength: Int = 13, _ maxLength: Int = 19) {
+
+    mutating func setCardNumberLength(_ minLength: Int = 13, _ maxLength: Int = 16) {
         _cardNumber.update(.cardNumberRange(min: minLength, max: maxLength))
     }
-    
+
     mutating func setCardNumberExternalError(_ error: BinFetchError?) {
         _cardNumber.update(.cardNumberExternalError(error))
     }
-    
-    var cardNumberLiveErrors: [String] { _cardNumber.liveErrorMessages }
+
+    var cardNumberLiveErrors: [String] {
+        _cardNumber.liveErrorMessages
+    }
 
     var isFormValid: Bool {
         return _cardNumber.errorMessages.isEmpty
-        && _cardHolder.errorMessages.isEmpty
-        && _expirationDate.errorMessages.isEmpty
-        && _securityCode.errorMessages.isEmpty
-        && _documentHolder.errorMessages.isEmpty
+            && _cardHolder.errorMessages.isEmpty
+            && _expirationDate.errorMessages.isEmpty
+            && _securityCode.errorMessages.isEmpty
+            && _documentHolder.errorMessages.isEmpty
     }
 }

--- a/Tests/MercadoPagoCheckoutTests/Formatting/CardFormFormattingTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Formatting/CardFormFormattingTests.swift
@@ -1,0 +1,106 @@
+//
+//  CardFormFormattingTests.swift
+//  MercadoPagoSDK
+//
+//  Created by SDK on 09/03/26.
+//
+
+@testable import MercadoPagoCheckout
+import XCTest
+
+final class CardFormFormattingTests: XCTestCase {
+    // MARK: - CardNumberFormatter (default maxLength = 16)
+
+    func test_cardNumberFormatter_default_shouldLimitTo16Digits() {
+        // Arrange
+        let formatter = CardNumberFormatter()
+
+        // Act — 19 digits provided, only 16 should be accepted
+        let result = formatter.formatOnChange("1234567890123456789")
+
+        // Assert
+        let digits = result.filter(\.isNumber)
+        XCTAssertEqual(digits.count, 16)
+    }
+
+    func test_cardNumberFormatter_default_shouldApply16DigitMask() {
+        // Arrange
+        let formatter = CardNumberFormatter()
+
+        // Act
+        let result = formatter.formatOnChange("1234567890123456")
+
+        // Assert — "#### #### #### ####" pattern
+        XCTAssertEqual(result, "1234 5678 9012 3456")
+    }
+
+    func test_cardNumberFormatter_default_whenInputAlreadyFormatted_shouldPreserveOutput() {
+        // Arrange — simulates user pasting a formatted card number
+        let formatter = CardNumberFormatter()
+
+        // Act
+        let result = formatter.formatOnChange("1234 5678 9012 3456")
+
+        // Assert
+        XCTAssertEqual(result, "1234 5678 9012 3456")
+    }
+
+    func test_cardNumberFormatter_default_whenPartialInput_shouldFormatWithoutTrailingSpace() {
+        // Arrange
+        let formatter = CardNumberFormatter()
+
+        // Act — 5 digits
+        let result = formatter.formatOnChange("12345")
+
+        // Assert
+        XCTAssertEqual(result, "1234 5")
+    }
+
+    func test_cardNumberFormatter_default_whenEmpty_shouldReturnEmpty() {
+        // Arrange
+        let formatter = CardNumberFormatter()
+
+        // Act
+        let result = formatter.formatOnChange("")
+
+        // Assert
+        XCTAssertEqual(result, "")
+    }
+
+    // MARK: - CardNumberFormatter (maxLength = 19 — e.g. Maestro)
+
+    func test_cardNumberFormatter_whenMaxLength19_shouldLimitTo19Digits() {
+        // Arrange
+        let formatter = CardNumberFormatter(maxLength: 19)
+
+        // Act — 20 digits provided, only 19 should be accepted
+        let result = formatter.formatOnChange("12345678901234567890")
+
+        // Assert
+        let digits = result.filter(\.isNumber)
+        XCTAssertEqual(digits.count, 19)
+    }
+
+    func test_cardNumberFormatter_whenMaxLength19_shouldApply19DigitMask() {
+        // Arrange
+        let formatter = CardNumberFormatter(maxLength: 19)
+
+        // Act
+        let result = formatter.formatOnChange("1234567890123456789")
+
+        // Assert — "#### #### #### #### ###" pattern
+        XCTAssertEqual(result, "1234 5678 9012 3456 789")
+    }
+
+    func test_cardNumberFormatter_whenMaxLength19_shouldNotLimitAt16() {
+        // Arrange
+        let formatter = CardNumberFormatter(maxLength: 19)
+
+        // Act — 17 digits: should not be cut at 16
+        let result = formatter.formatOnChange("12345678901234567")
+
+        // Assert
+        let digits = result.filter(\.isNumber)
+        XCTAssertEqual(digits.count, 17)
+    }
+}

--- a/Tests/MercadoPagoCheckoutTests/Mocks/MockCheckoutService.swift
+++ b/Tests/MercadoPagoCheckoutTests/Mocks/MockCheckoutService.swift
@@ -5,16 +5,15 @@
 //  Created by Guilherme Prata Costa on 25/02/26.
 //
 
-@testable import MercadoPagoCheckout
 @testable import CoreMethods
+@testable import MercadoPagoCheckout
 
 final actor MockCheckoutService: CheckoutServiceProtocol {
-
     enum MockError: Error {
         case resultNotSet
     }
 
-    private var identificationTypesResult: Result<[IdentificationType], Error>?
+    private var identificationTypesResults: [Result<[IdentificationType], Error>] = []
     private var paymentMethodResult: Result<[PaymentMethod], Error>?
     private var issuersResult: Result<[Issuer], Error>?
     private var installmentsResult: Result<[Installment], Error>?
@@ -22,60 +21,67 @@ final actor MockCheckoutService: CheckoutServiceProtocol {
     private var createCardTokenResult: Result<CardToken, Error>?
 
     func setIdentificationTypesResult(_ result: Result<[IdentificationType], Error>) {
-        identificationTypesResult = result
+        self.identificationTypesResults = [result]
+    }
+
+    func setSequentialIdentificationTypesResults(_ results: Result<[IdentificationType], Error>...) {
+        self.identificationTypesResults = Array(results)
     }
 
     func setPaymentMethodResult(_ result: Result<[PaymentMethod], Error>) {
-        paymentMethodResult = result
+        self.paymentMethodResult = result
     }
 
     func setIssuersResult(_ result: Result<[Issuer], Error>) {
-        issuersResult = result
+        self.issuersResult = result
     }
 
     func setInstallmentsResult(_ result: Result<[Installment], Error>) {
-        installmentsResult = result
+        self.installmentsResult = result
     }
 
     func setFetchBinDataResult(_ result: Result<CardBinData, Error>) {
-        fetchBinDataResult = result
+        self.fetchBinDataResult = result
     }
 
     func setCreateCardTokenResult(_ result: Result<CardToken, Error>) {
-        createCardTokenResult = result
+        self.createCardTokenResult = result
     }
 
     func identificationTypes() async throws -> [IdentificationType] {
-        guard let result = identificationTypesResult else { throw MockError.resultNotSet }
+        guard !self.identificationTypesResults.isEmpty else { throw MockError.resultNotSet }
+        let result = self.identificationTypesResults.count > 1
+            ? self.identificationTypesResults.removeFirst()
+            : self.identificationTypesResults[0]
         return try result.get()
     }
 
-    func paymentMethod(bin: String) async throws -> [PaymentMethod] {
+    func paymentMethod(bin _: String) async throws -> [PaymentMethod] {
         guard let result = paymentMethodResult else { throw MockError.resultNotSet }
         return try result.get()
     }
 
-    func issuers(bin: String, paymentMethodID: String) async throws -> [Issuer] {
+    func issuers(bin _: String, paymentMethodID _: String) async throws -> [Issuer] {
         guard let result = issuersResult else { throw MockError.resultNotSet }
         return try result.get()
     }
 
-    func installments(amount: Double, bin: String) async throws -> [Installment] {
+    func installments(amount _: Double, bin _: String) async throws -> [Installment] {
         guard let result = installmentsResult else { throw MockError.resultNotSet }
         return try result.get()
     }
 
     func fetchBinData(
-        bin: String,
-        amount: Double?,
-        acceptedPaymentTypeIds: [String],
-        acceptedPaymentMethodIds: [String]
+        bin _: String,
+        amount _: Double?,
+        acceptedPaymentTypeIds _: [String],
+        acceptedPaymentMethodIds _: [String]
     ) async throws -> CardBinData {
         guard let result = fetchBinDataResult else { throw MockError.resultNotSet }
         return try result.get()
     }
 
-    func createCardToken(cardParams: CardParams) async throws -> CardToken {
+    func createCardToken(cardParams _: CardParams) async throws -> CardToken {
         guard let result = createCardTokenResult else { throw MockError.resultNotSet }
         return try result.get()
     }

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
@@ -204,6 +204,38 @@ final class CardFormViewModelTests: XCTestCase {
         XCTAssertEqual(sut.viewModel.selectTypeDocument, defaultDocument)
     }
 
+    func test_loadIdentificationTypes_whenFirstAttemptFails_andRetrySucceeds_shouldSetTypes() async {
+        // Arrange — first call fails, second (retry) succeeds
+        let sut = self.makeSUT()
+        await sut.service.setSequentialIdentificationTypesResults(
+            .failure(MockCheckoutService.MockError.resultNotSet),
+            .success([IdentificationTypeStub.cpf])
+        )
+
+        // Act
+        await sut.viewModel.loadIdentificationTypes()
+
+        // Assert
+        XCTAssertEqual(sut.viewModel.screenState, .ready)
+        XCTAssertEqual(sut.viewModel.selectTypeDocument, IdentificationTypeStub.cpf)
+    }
+
+    func test_loadIdentificationTypes_whenBothAttemptsFail_shouldSetReadyStateWithoutTypes() async {
+        // Arrange — both attempts fail
+        let sut = self.makeSUT()
+        await sut.service.setSequentialIdentificationTypesResults(
+            .failure(MockCheckoutService.MockError.resultNotSet),
+            .failure(MockCheckoutService.MockError.resultNotSet)
+        )
+
+        // Act
+        await sut.viewModel.loadIdentificationTypes()
+
+        // Assert
+        XCTAssertEqual(sut.viewModel.screenState, .ready)
+        XCTAssertTrue(sut.viewModel.identificationTypes.isEmpty)
+    }
+
     // MARK: - onCardNumberChange
 
     func test_onCardNumberChange_whenDigitsLessThan8_shouldNotFetchBinData() {

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
@@ -5,14 +5,13 @@
 //  Created by Guilherme Prata Costa on 25/02/26.
 //
 
-import XCTest
 import Combine
-@testable import MercadoPagoCheckout
 @testable import CoreMethods
+@testable import MercadoPagoCheckout
+import XCTest
 
 @MainActor
 final class CardFormViewModelTests: XCTestCase {
-
     // MARK: - Types
 
     typealias SUT = (
@@ -27,7 +26,7 @@ final class CardFormViewModelTests: XCTestCase {
     // MARK: - Lifecycle
 
     override func tearDown() {
-        cancellables.removeAll()
+        self.cancellables.removeAll()
         super.tearDown()
     }
 
@@ -110,7 +109,7 @@ final class CardFormViewModelTests: XCTestCase {
             .dropFirst()
             .first()
             .sink { _ in exp.fulfill() }
-            .store(in: &cancellables)
+            .store(in: &self.cancellables)
         await fulfillment(of: [exp], timeout: timeout)
     }
 
@@ -118,7 +117,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_init_screenStateShouldBeLoading() {
         // Arrange / Act
-        let sut = makeSUT()
+        let sut = self.makeSUT()
 
         // Assert
         XCTAssertEqual(sut.viewModel.screenState, .loading)
@@ -126,25 +125,25 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_init_binDataShouldBeNil() {
         // Arrange / Act
-        let sut = makeSUT()
+        let sut = self.makeSUT()
 
         // Assert
         XCTAssertNil(sut.viewModel.binData)
     }
 
-    func test_init_fetchBinErrorShouldBeNil() {
+    func test_init_binFetchErrorShouldBeNil() {
         // Arrange / Act
-        let sut = makeSUT()
+        let sut = self.makeSUT()
 
         // Assert
-        XCTAssertNil(sut.viewModel.fetchBinError)
+        XCTAssertNil(sut.viewModel.binFetchError)
     }
 
     // MARK: - loadIdentificationTypes
 
     func test_loadIdentificationTypes_whenSuccess_shouldSetReadyState() async {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setIdentificationTypesResult(.success([IdentificationTypeStub.cpf]))
 
         // Act
@@ -156,7 +155,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_loadIdentificationTypes_whenSuccess_withTypes_shouldUpdateSelectTypeDocument() async {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setIdentificationTypesResult(.success([IdentificationTypeStub.cpf, IdentificationTypeStub.cnpj]))
 
         // Act
@@ -168,7 +167,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_loadIdentificationTypes_whenSuccess_withEmptyTypes_shouldKeepDefaultDocument() async {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         let defaultDocument = sut.viewModel.selectTypeDocument
         await sut.service.setIdentificationTypesResult(.success([]))
 
@@ -182,7 +181,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_loadIdentificationTypes_whenError_shouldSetReadyState() async {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setIdentificationTypesResult(.failure(MockCheckoutService.MockError.resultNotSet))
 
         // Act
@@ -194,7 +193,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_loadIdentificationTypes_whenError_shouldKeepDefaultDocument() async {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         let defaultDocument = sut.viewModel.selectTypeDocument
         await sut.service.setIdentificationTypesResult(.failure(MockCheckoutService.MockError.resultNotSet))
 
@@ -209,66 +208,66 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_onCardNumberChange_whenDigitsLessThan8_shouldNotFetchBinData() {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
 
         // Act — synchronous: no task created for < 8 digits
         sut.viewModel.onCardNumberChange("1234567")
 
         // Assert
         XCTAssertNil(sut.viewModel.binData)
-        XCTAssertNil(sut.viewModel.fetchBinError)
+        XCTAssertNil(sut.viewModel.binFetchError)
     }
 
     func test_onCardNumberChange_whenDigitsReach8_withSuccess_shouldSetBinData() async {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
 
         // Act
         sut.viewModel.onCardNumberChange("12345678")
-        await waitForChange(sut.viewModel.$binData)
+        await self.waitForChange(sut.viewModel.$binData)
 
         // Assert
         XCTAssertEqual(sut.viewModel.binData, CardBinDataStub.visa)
-        XCTAssertNil(sut.viewModel.fetchBinError)
+        XCTAssertNil(sut.viewModel.binFetchError)
     }
 
     func test_onCardNumberChange_whenDigitsReach8_withError_shouldSetApiError() async {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setFetchBinDataResult(.failure(BinFetchError.paymentMethodNotAllowed("visa")))
 
         // Act
         sut.viewModel.onCardNumberChange("12345678")
-        await waitForChange(sut.viewModel.$fetchBinError)
+        await self.waitForChange(sut.viewModel.$binFetchError)
 
         // Assert
-        XCTAssertNotNil(sut.viewModel.fetchBinError)
+        XCTAssertNotNil(sut.viewModel.binFetchError)
         XCTAssertNil(sut.viewModel.binData)
     }
 
     func test_onCardNumberChange_whenClearedBelow8Digits_shouldClearBinDataAndError() async {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
         sut.viewModel.onCardNumberChange("12345678")
-        await waitForChange(sut.viewModel.$binData)
+        await self.waitForChange(sut.viewModel.$binData)
 
         // Act — clearing to below 8 digits is synchronous
         sut.viewModel.onCardNumberChange("123")
 
         // Assert
         XCTAssertNil(sut.viewModel.binData)
-        XCTAssertNil(sut.viewModel.fetchBinError)
+        XCTAssertNil(sut.viewModel.binFetchError)
     }
 
     func test_onCardNumberChange_whenSameBINCalledTwice_shouldNotRefetch() async {
         // Arrange — first call fails
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setFetchBinDataResult(.failure(BinFetchError.paymentMethodNotAllowed("visa")))
         sut.viewModel.onCardNumberChange("12345678")
-        await waitForChange(sut.viewModel.$fetchBinError)
-        XCTAssertNotNil(sut.viewModel.fetchBinError)
+        await self.waitForChange(sut.viewModel.$binFetchError)
+        XCTAssertNotNil(sut.viewModel.binFetchError)
 
         // Change result to success, but call with same BIN
         await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
@@ -277,37 +276,173 @@ final class CardFormViewModelTests: XCTestCase {
         sut.viewModel.onCardNumberChange("12345678")
 
         // Assert — state unchanged
-        XCTAssertNotNil(sut.viewModel.fetchBinError)
+        XCTAssertNotNil(sut.viewModel.binFetchError)
         XCTAssertNil(sut.viewModel.binData)
     }
 
     func test_onCardNumberChange_whenDifferentBINAfterError_shouldRefetchAndClearError() async {
         // Arrange — first BIN fails
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setFetchBinDataResult(.failure(BinFetchError.paymentMethodNotAllowed("visa")))
         sut.viewModel.onCardNumberChange("12345678")
-        await waitForChange(sut.viewModel.$fetchBinError)
+        await self.waitForChange(sut.viewModel.$binFetchError)
 
         // Act — different BIN with success
         await sut.service.setFetchBinDataResult(.success(CardBinDataStub.master))
         sut.viewModel.onCardNumberChange("87654321")
-        await waitForChange(sut.viewModel.$binData)
+        await self.waitForChange(sut.viewModel.$binData)
 
         // Assert
-        XCTAssertNil(sut.viewModel.fetchBinError)
+        XCTAssertNil(sut.viewModel.binFetchError)
         XCTAssertEqual(sut.viewModel.binData, CardBinDataStub.master)
     }
 
     func test_onCardNumberChange_whenFormattedCardNumber_shouldExtractBINCorrectly() async {
         // Arrange — formatted number "1234 5678 9012 3456"
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
 
         // Act
         sut.viewModel.onCardNumberChange("1234 5678 9012 3456")
-        await waitForChange(sut.viewModel.$binData)
+        await self.waitForChange(sut.viewModel.$binData)
 
         // Assert — BIN extracted from digits only (12345678)
         XCTAssertEqual(sut.viewModel.binData, CardBinDataStub.visa)
+    }
+
+    // MARK: - retryBinFetch
+
+    func test_init_showSnackbarShouldBeFalse() {
+        // Arrange / Act
+        let sut = self.makeSUT()
+
+        // Assert
+        XCTAssertFalse(sut.viewModel.showSnackbar)
+    }
+
+    func test_retryBinFetch_whenNoPreviousError_shouldNotShowSnackbar() {
+        // Arrange — no BIN fetch has occurred
+        let sut = self.makeSUT()
+
+        // Act — guard: binFetchError == nil → retryBinFetch does nothing
+        sut.viewModel.retryBinFetch()
+
+        // Assert
+        XCTAssertFalse(sut.viewModel.showSnackbar)
+    }
+
+    func test_retryBinFetch_whenBinDataIsPresent_shouldNotRetry() async {
+        // Arrange — successful fetch means binData != nil
+        let sut = self.makeSUT()
+        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binData)
+        XCTAssertNotNil(sut.viewModel.binData)
+
+        // Act — guard: binData != nil → retryBinFetch does nothing
+        sut.viewModel.retryBinFetch()
+
+        // Assert
+        XCTAssertFalse(sut.viewModel.showSnackbar)
+    }
+
+    func test_retryBinFetch_whenValidationError_shouldNotRetry() async {
+        // Arrange — paymentMethodNotAllowed is not a retriable error
+        let sut = self.makeSUT()
+        await sut.service.setFetchBinDataResult(.failure(BinFetchError.paymentMethodNotAllowed("visa")))
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binFetchError)
+        XCTAssertEqual(sut.viewModel.binFetchError, .paymentMethodNotAllowed("visa"))
+
+        // Act — guard: binFetchError is not .networkError/.serviceError → does nothing
+        sut.viewModel.retryBinFetch()
+
+        // Assert
+        XCTAssertFalse(sut.viewModel.showSnackbar)
+    }
+
+    func test_retryBinFetch_whenNetworkError_andRetryFails_shouldShowSnackbar() async {
+        // Arrange — initial fetch fails with networkError
+        let sut = self.makeSUT()
+        await sut.service.setFetchBinDataResult(.failure(BinFetchError.networkError))
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binFetchError)
+        XCTAssertEqual(sut.viewModel.binFetchError, .networkError)
+
+        // Act — retry also fails
+        await sut.service.setFetchBinDataResult(.failure(BinFetchError.networkError))
+        sut.viewModel.retryBinFetch()
+        await self.waitForChange(sut.viewModel.$showSnackbar)
+
+        // Assert
+        XCTAssertTrue(sut.viewModel.showSnackbar)
+    }
+
+    func test_retryBinFetch_whenServiceError_andRetryFails_shouldShowSnackbar() async {
+        // Arrange — initial fetch fails with serviceError
+        let sut = self.makeSUT()
+        await sut.service.setFetchBinDataResult(.failure(BinFetchError.serviceError))
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binFetchError)
+        XCTAssertEqual(sut.viewModel.binFetchError, .serviceError)
+
+        // Act — retry also fails
+        await sut.service.setFetchBinDataResult(.failure(BinFetchError.serviceError))
+        sut.viewModel.retryBinFetch()
+        await self.waitForChange(sut.viewModel.$showSnackbar)
+
+        // Assert
+        XCTAssertTrue(sut.viewModel.showSnackbar)
+    }
+
+    func test_retryBinFetch_whenNetworkError_andRetrySucceeds_shouldNotShowSnackbar() async {
+        // Arrange — initial fetch fails with networkError
+        let sut = self.makeSUT()
+        await sut.service.setFetchBinDataResult(.failure(BinFetchError.networkError))
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binFetchError)
+
+        // Act — retry succeeds
+        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
+        sut.viewModel.retryBinFetch()
+        await self.waitForChange(sut.viewModel.$binData)
+
+        // Assert
+        XCTAssertFalse(sut.viewModel.showSnackbar)
+        XCTAssertNotNil(sut.viewModel.binData)
+    }
+
+    func test_retryBinFetch_whenCalledTwice_withNetworkError_shouldShowSnackbarBothTimes() async {
+        // Arrange — initial fetch fails
+        let sut = self.makeSUT()
+        await sut.service.setFetchBinDataResult(.failure(BinFetchError.networkError))
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binFetchError)
+
+        // First retry fails → showSnackbar becomes true
+        await sut.service.setFetchBinDataResult(.failure(BinFetchError.networkError))
+        sut.viewModel.retryBinFetch()
+        await self.waitForChange(sut.viewModel.$showSnackbar)
+        XCTAssertTrue(sut.viewModel.showSnackbar)
+
+        // Second retry: observe showSnackbar going false (reset) then true (failure)
+        let exp = expectation(description: "showSnackbar toggles false→true on second retry")
+        var capturedValues: [Bool] = []
+        sut.viewModel.$showSnackbar
+            .dropFirst() // skip current true
+            .prefix(2) // capture: false (reset), true (failure)
+            .collect()
+            .sink { values in
+                capturedValues = values
+                exp.fulfill()
+            }
+            .store(in: &self.cancellables)
+
+        await sut.service.setFetchBinDataResult(.failure(BinFetchError.networkError))
+        sut.viewModel.retryBinFetch()
+        await fulfillment(of: [exp], timeout: 1.0)
+
+        // Assert — snackbar was reset then re-triggered
+        XCTAssertEqual(capturedValues, [false, true])
     }
 }


### PR DESCRIPTION
# Pull Request
  This PR adds request error handling and retry logic to the Card Form checkout flow.                                                                                                   
## Ticket or Issue link
https://mercadolibre.atlassian.net/browse/CHOBK-3673

## Description
 Error Handling — FetchBinDataUseCase                                                                                                                                                  
  - Added network-aware error mapping: APIClientError is now mapped to BinFetchError (.networkError, .serviceError, .paymentMethodNotFound)
  - Extracted internal steps into private helpers (getPaymentMethods, filterPaymentMethod, filterIssuer, filterInstallments), each wrapping errors into the appropriate BinFetchError   
  case                                                                                                                                                                               
  - Added MPCore as a dependency of MercadoPagoCheckout to access APIClientError                                                                                                        
                                                                                                   
  Retry Logic — CardFormViewModel + RetryUtils                                                                                                                                          
  - Added withRetry utility that re-executes an async operation up to N times before propagating the error                                                                              
  - loadIdentificationTypes now uses withRetry (2 attempts) before falling back to showing a snackbar                                                                                   
  - Added retryBinFetch(): triggered when the user finishes editing the card number field; retries only for retriable errors (.networkError, .serviceError) and silently skips for      
  validation errors (.paymentMethodNotAllowed, .paymentTypeNotAllowed)                                                                                                                  
                                                                                                                                                                                        
  Snackbar Feedback — CardFormScreen + MPMessage+ViewModifier                                                                                                                           
  - Added showSnackbar state to CardFormViewModel; shown when identification types or BIN fetch fail after retries                                                                      
  - Integrated snackbar into CardFormScreen with bottomPadding to avoid overlapping the footer                                                                                          
  - Added bottomPadding parameter to .messageSnackbar() modifier in MPComponents                                                                                                        
  - Footer height is measured via GeometryReader and passed to the snackbar as bottom offset                                                                                            
                                                                                                                                                                                        
  Card Number Formatter                                                                                                                                                                 
  - CardNumberFormatter.init now accepts only maxLength (instead of explicit mask + maxLength); the correct mask is selected automatically from a static lookup table covering lengths  
  8–19                                                                                                                                                                                  
  - Updated setCardNumberLength default max to 16 (was 19)                                         
                                                                                                                                                                                        
  CardFormBrick                                                                                                                                                                         
  - CardFormViewModel is now stored as view state in CardFormBrick instead of being re-created on every render cycle
                                                                                                                                                                                        
  CardFormRules                                                                                    
  - Added handling for the new BinFetchError cases in the card number validation rule            
  
Tests
                                                                                                                                                                                        
  - CardFormFormattingTests: covers CardNumberFormatter mask selection and digit limits for various maxLength values                                                                    
  - CardFormViewModelTests: added coverage for showSnackbar, retryBinFetch (no-op guards, network/service error retry, snackbar toggle), formatted card number BIN extraction, and retry
   success/failure scenarios                                                                                                                                                            
  - MockCheckoutService: added setSequentialIdentificationTypesResults to support deterministic multi-attempt retry tests
## Checklist
- [] I have tested my changes creating a local version (More info in README file).
- [] I have added tests that prove my solution is effective and works
- [] New and existing unit tests pass locally with my changes.
- [] Verify that you are merged with the latest in develop.
- [] I have run `swiftlint` and fixed any possible issues of my code.
- [] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [] I have tested the accessibility of the changes and added them to the screenshots.
- [] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<!---
Provide videos or screenshots. You can change their size in the src
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>
-->

https://github.com/user-attachments/assets/0863cd66-a63a-4a99-951b-298bbb42c82c

