### PR TITLE
[CHOBK-3736] (Feature): Error callback and cancelled form state

### DIFF
--- a/Example/Sources/MainListView.swift
+++ b/Example/Sources/MainListView.swift
@@ -15,6 +15,13 @@ struct MainListView: View {
     @State private var showDebug = false
     @State private var showBuilderShow = false
     @State private var showBuilderPresent = false
+    @State private var alertItem: AlertItem?
+
+    struct AlertItem: Identifiable {
+        let id = UUID()
+        let title: String
+        let message: String
+    }
 
     var body: some View {
         NavigationView {
@@ -32,14 +39,17 @@ struct MainListView: View {
                     Button("show(onResult:) - SwiftUI") {
                         self.showBuilderShow = true
                     }
+                    .accessibilityIdentifier("show(onResult:) - SwiftUI")
 
                     Button("present(from:onResult:)") {
                         self.presentCheckout()
                     }
+                    .accessibilityIdentifier("present(from:onResult:)")
 
                     Button("push(to:onResult:)") {
                         self.showBuilderPresent = true
                     }
+                    .accessibilityIdentifier("push(to:onResult:)")
                 }
 
                 Section("Settings") {
@@ -69,6 +79,9 @@ struct MainListView: View {
         .sheet(isPresented: self.$showDebug) {
             DebugView()
         }
+        .alert(item: self.$alertItem) { item in
+            Alert(title: Text(item.title), message: Text(item.message))
+        }
     }
 
     private func buildCheckout() -> MercadoPagoCheckout {
@@ -84,13 +97,24 @@ struct MainListView: View {
     }
 
     private func handleResult(_ result: MercadoPagoCheckoutResult) {
-        switch result {
-        case let .success(paymentData):
-            print(paymentData)
-        case let .error(error):
-            print(error)
-        case let .userCancelled(context):
-            print("User cancelled with \(context.fields.count) field error(s)\n details: \(context.fields)")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            switch result {
+            case let .success(paymentData):
+                self.alertItem = AlertItem(
+                    title: "Pagamento cadastrado",
+                    message: "Método: \(paymentData.paymentMethodId)\type: \(paymentData.paymentTypeId)"
+                )
+            case let .error(error):
+                self.alertItem = AlertItem(
+                    title: "Erro",
+                    message: error.localizedDescription
+                )
+            case .userCancelled:
+                self.alertItem = AlertItem(
+                    title: "Cancelado",
+                    message: "O usuário cancelou o formulário."
+                )
+            }
         }
     }
 

--- a/Example/Sources/MainListView.swift
+++ b/Example/Sources/MainListView.swift
@@ -97,12 +97,13 @@ struct MainListView: View {
     }
 
     private func handleResult(_ result: MercadoPagoCheckoutResult) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(0.6))
             switch result {
             case let .success(paymentData):
                 self.alertItem = AlertItem(
                     title: "Pagamento cadastrado",
-                    message: "Método: \(paymentData.paymentMethodId)\type: \(paymentData.paymentTypeId)"
+                    message: "Método: \(paymentData.paymentMethodId)\nToken: \(paymentData.token)"
                 )
             case let .error(error):
                 self.alertItem = AlertItem(

--- a/Example/Sources/MainListView.swift
+++ b/Example/Sources/MainListView.swift
@@ -102,18 +102,18 @@ struct MainListView: View {
             switch result {
             case let .success(paymentData):
                 self.alertItem = AlertItem(
-                    title: "Pagamento cadastrado",
-                    message: "Método: \(paymentData.paymentMethodId)\nToken: \(paymentData.token)"
+                    title: "Sucess",
+                    message: "Method: \(paymentData.paymentMethodId)\nToken: \(paymentData.token)"
                 )
             case let .error(error):
                 self.alertItem = AlertItem(
-                    title: "Erro",
+                    title: "Error",
                     message: error.localizedDescription
                 )
             case .userCancelled:
                 self.alertItem = AlertItem(
-                    title: "Cancelado",
-                    message: "O usuário cancelou o formulário."
+                    title: "Cancelled",
+                    message: "User has cancelled."
                 )
             }
         }

--- a/Example/Sources/MainListView.swift
+++ b/Example/Sources/MainListView.swift
@@ -90,7 +90,7 @@ struct MainListView: View {
         case let .error(error):
             print(error)
         case let .userCancelled(context):
-            print("User cancelled with \(context.fieldErrors.count) field error(s)\n details: \(context.fieldErrors)")
+            print("User cancelled with \(context.fields.count) field error(s)\n details: \(context.fields)")
         }
     }
 

--- a/Example/Sources/MainListView.swift
+++ b/Example/Sources/MainListView.swift
@@ -87,10 +87,10 @@ struct MainListView: View {
         switch result {
         case let .success(paymentData):
             print(paymentData)
-        case .error:
-            print("Error")
-        case .userCancelled:
-            print("User cancelled")
+        case let .error(error):
+            print(error)
+        case let .userCancelled(context):
+            print("User cancelled with \(context.fieldErrors.count) field error(s)\n details: \(context.fieldErrors)")
         }
     }
 

--- a/Sources/MPComponents/BaseElements/Footer/MPFixedFooterButtonData.swift
+++ b/Sources/MPComponents/BaseElements/Footer/MPFixedFooterButtonData.swift
@@ -18,9 +18,9 @@ package struct MPFixedFooterButtonData {
     /// Visual variant of the button. Defaults to `.loud`.
     var style: MPButtonStyle.Variant = .loud
     /// Closure invoked when the button is tapped.
-    var onClick: () -> Void
+    var onClick: () async -> Void
 
-    package init(text: String, style: MPButtonStyle.Variant = .loud, onClick: @escaping () -> Void) {
+    package init(text: String, style: MPButtonStyle.Variant = .loud, onClick: @escaping () async -> Void) {
         self.text = text
         self.style = style
         self.onClick = onClick

--- a/Sources/MPComponents/BaseElements/Footer/MPFooter.swift
+++ b/Sources/MPComponents/BaseElements/Footer/MPFooter.swift
@@ -35,6 +35,10 @@ package struct MPFooter: View {
     @Environment(\.mpFooterStyle) private var style: any MPFooterStyle
     @Environment(\.checkoutTheme) var theme: MPTheme
 
+    // MARK: - Tasks
+
+    @State private var submitTask: Task<Void, Never>?
+
     // MARK: - Initialization
 
     /// Creates a new footer with the specified configuration.
@@ -122,11 +126,16 @@ package struct MPFooter: View {
     private var button: some View {
         if let buttonData {
             Button {
-                buttonData.onClick()
+                Task {
+                    await buttonData.onClick()
+                }
             } label: {
                 Text(buttonData.text)
             }
             .mpButtonStyle(variant: buttonData.style)
+            .onDisappear {
+                self.submitTask?.cancel()
+            }
         }
     }
 

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -41,35 +41,18 @@ struct CardFormBrick: View {
     }
 
     var body: some View {
-        if let error = configurationError {
-            Color.clear.onAppear {
-                self.onResult(.error(error))
-                self.presentationMode.wrappedValue.dismiss()
-            }
-        } else {
-            ThemeProvider(
-                light: self.themeLight,
-                dark: self.themeDark
-            ) {
-                NavigationView {
-                    ZStack {
-                        self.cardFormScreen()
-                        self.navigationLinks()
-                    }
+        ThemeProvider(
+            light: self.themeLight,
+            dark: self.themeDark
+        ) {
+            NavigationView {
+                ZStack {
+                    self.cardFormScreen()
+                    self.navigationLinks()
                 }
-                .navigationViewStyle(StackNavigationViewStyle())
             }
+            .navigationViewStyle(StackNavigationViewStyle())
         }
-    }
-
-    private var configurationError: MercadoPagoCheckoutError? {
-        guard !self.configuration.paymentMethod.acceptedPaymentTypeIds.isEmpty else {
-            return MercadoPagoCheckoutError(
-                code: .invalidConfiguration,
-                _localizedDescription: "No payment types configured. Provide at least one card type in CheckoutConfiguration.paymentMethod.", location: .cardForm
-            )
-        }
-        return nil
     }
 
     private func cardFormScreen() -> some View {

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -20,6 +20,7 @@ struct CardFormBrick: View {
     private let themeDark: MPTheme
     private let themeLight: MPTheme
     private let transactionAmount: Double?
+    private let configuration: MercadoPagoCheckout.CheckoutConfiguration
 
     private let onResult: (MercadoPagoCheckoutResult) -> Void
 
@@ -34,30 +35,48 @@ struct CardFormBrick: View {
         self.themeDark = appearance.dark
         self.themeLight = appearance.light
         self.transactionAmount = configuration.type.configuration.amount
+        self.configuration = configuration
         self._paymentData = State(initialValue: MPPaymentData(transactionAmount: self.transactionAmount))
         self._cardFormViewModel = State(initialValue: CardFormViewModel(configuration: configuration))
     }
 
     var body: some View {
-        ThemeProvider(
-            light: self.themeLight,
-            dark: self.themeDark
-        ) {
-            NavigationView {
-                ZStack {
-                    self.cardFormScreen()
-                    self.navigationLinks()
-                }
+        if let error = configurationError {
+            Color.clear.onAppear {
+                self.onResult(.error(error))
+                self.presentationMode.wrappedValue.dismiss()
             }
-            .navigationViewStyle(StackNavigationViewStyle())
+        } else {
+            ThemeProvider(
+                light: self.themeLight,
+                dark: self.themeDark
+            ) {
+                NavigationView {
+                    ZStack {
+                        self.cardFormScreen()
+                        self.navigationLinks()
+                    }
+                }
+                .navigationViewStyle(StackNavigationViewStyle())
+            }
         }
+    }
+
+    private var configurationError: MercadoPagoCheckoutError? {
+        guard !self.configuration.paymentMethod.acceptedPaymentTypeIds.isEmpty else {
+            return MercadoPagoCheckoutError(
+                code: .invalidConfiguration,
+                _localizedDescription: "No payment types configured. Provide at least one card type in CheckoutConfiguration.paymentMethod.", location: .cardForm
+            )
+        }
+        return nil
     }
 
     private func cardFormScreen() -> some View {
         CardFormScreen(
             transactionAmount: self.transactionAmount,
             viewModel: self.cardFormViewModel,
-            onBack: { self.cancelCheckout() },
+            onBack: { context in self.cancelCheckout(context: context) },
             onSuccess: { paymentData in
                 self.paymentData = paymentData
                 self.completeCheckout()
@@ -95,9 +114,9 @@ struct CardFormBrick: View {
         }
     }
 
-    private func cancelCheckout() {
+    private func cancelCheckout(context: MPCancelledFormContext) {
         self.route = nil
-        self.onResult(.userCancelled)
+        self.onResult(.userCancelled(context))
         self.presentationMode.wrappedValue.dismiss()
     }
 
@@ -108,6 +127,8 @@ struct CardFormBrick: View {
     }
 
     private func fail(_ error: MercadoPagoCheckoutError) {
+        self.route = nil
         self.onResult(.error(error))
+        self.presentationMode.wrappedValue.dismiss()
     }
 }

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -113,5 +113,10 @@ struct CardFormBrick: View {
         self.route = nil
         self.onResult(.error(error))
         self.presentationMode.wrappedValue.dismiss()
+        SnackbarWindowPresenter.show(
+            message: MPStrings.Errors.generic,
+            lightTheme: self.themeLight,
+            darkTheme: self.themeDark
+        )
     }
 }

--- a/Sources/MercadoPagoCheckout/Data/CheckoutService.swift
+++ b/Sources/MercadoPagoCheckout/Data/CheckoutService.swift
@@ -20,7 +20,7 @@ struct CheckoutService: CheckoutServiceProtocol {
         } catch let error as APIClientError {
             throw MercadoPagoCheckoutError(from: error, location: .identification)
         } catch {
-            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .identification)
+            throw MercadoPagoCheckoutError(code: .unknown, localizedDescription: error.localizedDescription, location: .identification)
         }
     }
 
@@ -30,7 +30,7 @@ struct CheckoutService: CheckoutServiceProtocol {
         } catch let error as APIClientError {
             throw MercadoPagoCheckoutError(from: error, location: .paymentMethods)
         } catch {
-            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .paymentMethods)
+            throw MercadoPagoCheckoutError(code: .unknown, localizedDescription: error.localizedDescription, location: .paymentMethods)
         }
     }
 
@@ -40,7 +40,7 @@ struct CheckoutService: CheckoutServiceProtocol {
         } catch let error as APIClientError {
             throw MercadoPagoCheckoutError(from: error, location: .paymentMethods)
         } catch {
-            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .paymentMethods)
+            throw MercadoPagoCheckoutError(code: .unknown, localizedDescription: error.localizedDescription, location: .paymentMethods)
         }
     }
 
@@ -50,7 +50,7 @@ struct CheckoutService: CheckoutServiceProtocol {
         } catch let error as APIClientError {
             throw MercadoPagoCheckoutError(from: error, location: .installments)
         } catch {
-            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .installments)
+            throw MercadoPagoCheckoutError(code: .unknown, localizedDescription: error.localizedDescription, location: .installments)
         }
     }
 
@@ -60,7 +60,7 @@ struct CheckoutService: CheckoutServiceProtocol {
         } catch let error as APIClientError {
             throw MercadoPagoCheckoutError(from: error, location: .tokenization)
         } catch {
-            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .tokenization)
+            throw MercadoPagoCheckoutError(code: .unknown, localizedDescription: error.localizedDescription, location: .tokenization)
         }
     }
 

--- a/Sources/MercadoPagoCheckout/Data/CheckoutService.swift
+++ b/Sources/MercadoPagoCheckout/Data/CheckoutService.swift
@@ -24,16 +24,34 @@ struct CheckoutService: CheckoutServiceProtocol {
         }
     }
 
-    func paymentMethod(bin: String) async throws -> [PaymentMethod] {
-        try await self.coreMethods.paymentMethods(bin: bin)
+    func paymentMethod(bin: String) async throws(MercadoPagoCheckoutError) -> [PaymentMethod] {
+        do {
+            return try await self.coreMethods.paymentMethods(bin: bin)
+        } catch let error as APIClientError {
+            throw MercadoPagoCheckoutError(from: error, location: .paymentMethods)
+        } catch {
+            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .paymentMethods)
+        }
     }
 
-    func issuers(bin: String, paymentMethodID: String) async throws -> [Issuer] {
-        try await self.coreMethods.issuers(bin: bin, paymentMethodID: paymentMethodID)
+    func issuers(bin: String, paymentMethodID: String) async throws(MercadoPagoCheckoutError) -> [Issuer] {
+        do {
+            return try await self.coreMethods.issuers(bin: bin, paymentMethodID: paymentMethodID)
+        } catch let error as APIClientError {
+            throw MercadoPagoCheckoutError(from: error, location: .paymentMethods)
+        } catch {
+            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .paymentMethods)
+        }
     }
 
-    func installments(amount: Double, bin: String) async throws -> [Installment] {
-        try await self.coreMethods.installments(amount: amount, bin: bin)
+    func installments(amount: Double, bin: String) async throws(MercadoPagoCheckoutError) -> [Installment] {
+        do {
+            return try await self.coreMethods.installments(amount: amount, bin: bin)
+        } catch let error as APIClientError {
+            throw MercadoPagoCheckoutError(from: error, location: .installments)
+        } catch {
+            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .installments)
+        }
     }
 
     func createCardToken(cardParams: CardParams) async throws(MercadoPagoCheckoutError) -> CardToken {

--- a/Sources/MercadoPagoCheckout/Data/CheckoutService.swift
+++ b/Sources/MercadoPagoCheckout/Data/CheckoutService.swift
@@ -5,6 +5,7 @@
 //  Created by Danielle Nozaki Ogawa on 23/02/26.
 //
 import CoreMethods
+import MPCore
 
 struct CheckoutService: CheckoutServiceProtocol {
     private let coreMethods: CoreMethods
@@ -13,24 +14,36 @@ struct CheckoutService: CheckoutServiceProtocol {
         self.coreMethods = coreMethods
     }
 
-    func identificationTypes() async throws -> [IdentificationType] {
-        try await coreMethods.identificationTypes()
+    func identificationTypes() async throws(MercadoPagoCheckoutError) -> [IdentificationType] {
+        do {
+            return try await self.coreMethods.identificationTypes()
+        } catch let error as APIClientError {
+            throw MercadoPagoCheckoutError(from: error, location: .identification)
+        } catch {
+            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .identification)
+        }
     }
 
     func paymentMethod(bin: String) async throws -> [PaymentMethod] {
-        try await coreMethods.paymentMethods(bin: bin)
+        try await self.coreMethods.paymentMethods(bin: bin)
     }
 
     func issuers(bin: String, paymentMethodID: String) async throws -> [Issuer] {
-        try await coreMethods.issuers(bin: bin, paymentMethodID: paymentMethodID)
+        try await self.coreMethods.issuers(bin: bin, paymentMethodID: paymentMethodID)
     }
 
     func installments(amount: Double, bin: String) async throws -> [Installment] {
-        try await coreMethods.installments(amount: amount, bin: bin)
+        try await self.coreMethods.installments(amount: amount, bin: bin)
     }
 
-    func createCardToken(cardParams: CardParams) async throws -> CardToken {
-        try await coreMethods.createToken(cardParams)
+    func createCardToken(cardParams: CardParams) async throws(MercadoPagoCheckoutError) -> CardToken {
+        do {
+            return try await self.coreMethods.createToken(cardParams)
+        } catch let error as APIClientError {
+            throw MercadoPagoCheckoutError(from: error, location: .tokenization)
+        } catch {
+            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .tokenization)
+        }
     }
 
     func fetchBinData(

--- a/Sources/MercadoPagoCheckout/Domain/CardAcceptanceError.swift
+++ b/Sources/MercadoPagoCheckout/Domain/CardAcceptanceError.swift
@@ -1,0 +1,12 @@
+//
+//  CardAcceptanceError.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 13/03/26.
+//
+
+package enum CardAcceptanceError: Error, Equatable {
+    case paymentMethodNotFound
+    case paymentMethodNotAllowed(String)
+    case paymentTypeNotAllowed(MercadoPagoCheckout.CardType?)
+}

--- a/Sources/MercadoPagoCheckout/Domain/CardAcceptanceError.swift
+++ b/Sources/MercadoPagoCheckout/Domain/CardAcceptanceError.swift
@@ -6,7 +6,6 @@
 //
 
 package enum CardAcceptanceError: Error, Equatable {
-    case paymentMethodNotFound
     case paymentMethodNotAllowed(String)
     case paymentTypeNotAllowed(MercadoPagoCheckout.CardType?)
 }

--- a/Sources/MercadoPagoCheckout/Domain/CardAcceptanceError.swift
+++ b/Sources/MercadoPagoCheckout/Domain/CardAcceptanceError.swift
@@ -2,8 +2,6 @@
 //  CardAcceptanceError.swift
 //  MercadoPagoSDK
 //
-//  Created by Guilherme Prata Costa on 13/03/26.
-//
 
 package enum CardAcceptanceError: Error, Equatable {
     case paymentMethodNotAllowed(String)

--- a/Sources/MercadoPagoCheckout/Domain/CheckoutServiceProtocol.swift
+++ b/Sources/MercadoPagoCheckout/Domain/CheckoutServiceProtocol.swift
@@ -8,9 +8,9 @@ import CoreMethods
 
 protocol CheckoutServiceProtocol: Sendable {
     func identificationTypes() async throws(MercadoPagoCheckoutError) -> [IdentificationType]
-    func paymentMethod(bin: String) async throws -> [PaymentMethod]
-    func issuers(bin: String, paymentMethodID: String) async throws -> [Issuer]
-    func installments(amount: Double, bin: String) async throws -> [Installment]
+    func paymentMethod(bin: String) async throws(MercadoPagoCheckoutError) -> [PaymentMethod]
+    func issuers(bin: String, paymentMethodID: String) async throws(MercadoPagoCheckoutError) -> [Issuer]
+    func installments(amount: Double, bin: String) async throws(MercadoPagoCheckoutError) -> [Installment]
     func createCardToken(cardParams: CardParams) async throws(MercadoPagoCheckoutError) -> CardToken
     func fetchBinData(
         bin: String,

--- a/Sources/MercadoPagoCheckout/Domain/CheckoutServiceProtocol.swift
+++ b/Sources/MercadoPagoCheckout/Domain/CheckoutServiceProtocol.swift
@@ -7,11 +7,11 @@
 import CoreMethods
 
 protocol CheckoutServiceProtocol: Sendable {
-    func identificationTypes() async throws -> [IdentificationType]
+    func identificationTypes() async throws(MercadoPagoCheckoutError) -> [IdentificationType]
     func paymentMethod(bin: String) async throws -> [PaymentMethod]
     func issuers(bin: String, paymentMethodID: String) async throws -> [Issuer]
     func installments(amount: Double, bin: String) async throws -> [Installment]
-    func createCardToken(cardParams: CardParams) async throws -> CardToken
+    func createCardToken(cardParams: CardParams) async throws(MercadoPagoCheckoutError) -> CardToken
     func fetchBinData(
         bin: String,
         amount: Double?,

--- a/Sources/MercadoPagoCheckout/Domain/UseCases/FetchBinDataUseCase.swift
+++ b/Sources/MercadoPagoCheckout/Domain/UseCases/FetchBinDataUseCase.swift
@@ -5,7 +5,6 @@
 //  Created by Danielle Nozaki Ogawa on 26/02/26.
 //
 import CoreMethods
-import MPCore
 
 struct FetchBinDataUseCase {
     private let service: CheckoutServiceProtocol
@@ -43,13 +42,7 @@ struct FetchBinDataUseCase {
     }
 
     private func getPaymentMethods(from bin: String) async throws -> [PaymentMethod] {
-        do {
-            return try await self.service.paymentMethod(bin: bin)
-        } catch let error as APIClientError {
-            throw BinFetchError(from: error)
-        } catch {
-            throw BinFetchError.serviceError
-        }
+        try await self.service.paymentMethod(bin: bin)
     }
 
     private func filterPaymentMethod(
@@ -66,11 +59,11 @@ struct FetchBinDataUseCase {
                 acceptedPaymentTypeIds.contains($0.paymentTypeId) &&
                     !acceptedPaymentMethodIds.contains($0.id)
             }) {
-                throw BinFetchError.paymentMethodNotAllowed(typeMatchedMethod.id)
+                throw CardAcceptanceError.paymentMethodNotAllowed(typeMatchedMethod.id)
             } else {
                 let detectedMethod = methods.first(where: { !acceptedPaymentTypeIds.contains($0.paymentTypeId) })
                 let detectedCardType = MercadoPagoCheckout.CardType(paymentTypeId: detectedMethod?.paymentTypeId)
-                throw BinFetchError.paymentTypeNotAllowed(detectedCardType)
+                throw CardAcceptanceError.paymentTypeNotAllowed(detectedCardType)
             }
         }
         return method
@@ -81,24 +74,12 @@ struct FetchBinDataUseCase {
         bin: String
     ) async throws -> Issuer? {
         guard method.additionalInfoNeeded?.contains("issuer_id") == true else { return nil }
-        do {
-            return try await self.service.issuers(bin: bin, paymentMethodID: method.id).first
-        } catch let error as APIClientError {
-            throw BinFetchError(from: error)
-        } catch {
-            throw BinFetchError.serviceError
-        }
+        return try await self.service.issuers(bin: bin, paymentMethodID: method.id).first
     }
 
     private func filterInstallmentsRaw(amount: Double?, bin: String) async throws -> [Installment] {
         guard let amount else { return [] }
-        do {
-            return try await self.service.installments(amount: amount, bin: bin)
-        } catch let error as APIClientError {
-            throw BinFetchError(from: error)
-        } catch {
-            throw BinFetchError.serviceError
-        }
+        return try await self.service.installments(amount: amount, bin: bin)
     }
 
     private func pickInstallment(from installments: [Installment], issuer: Issuer?) -> Installment? {
@@ -106,28 +87,5 @@ struct FetchBinDataUseCase {
             return installments.first(where: { $0.issuer.id == issuer.id })
         }
         return installments.first
-    }
-}
-
-// MARK: - Private
-
-package enum BinFetchError: Error, Equatable {
-    case paymentMethodNotFound
-    case paymentMethodNotAllowed(String)
-    case paymentTypeNotAllowed(MercadoPagoCheckout.CardType?)
-    case networkError
-    case serviceError
-}
-
-private extension BinFetchError {
-    init(from error: APIClientError) {
-        switch error {
-        case .networkError:
-            self = .networkError
-        case let .apiError(response) where response.code == "not_found":
-            self = .paymentMethodNotFound
-        default:
-            self = .serviceError
-        }
     }
 }

--- a/Sources/MercadoPagoCheckout/Model/Internal/MercadoPagoCheckoutError+Network.swift
+++ b/Sources/MercadoPagoCheckout/Model/Internal/MercadoPagoCheckoutError+Network.swift
@@ -21,71 +21,71 @@ extension MercadoPagoCheckoutError {
                  .networkConnectionLost:
                 self.init(
                     code: .networkConnectionFailed,
-                    _localizedDescription: "No internet connection.",
+                    localizedDescription: "No internet connection.",
                     location: location
                 )
             case .timedOut:
                 self.init(
                     code: .networkTimeout,
-                    _localizedDescription: "The request timed out.",
+                    localizedDescription: "The request timed out.",
                     location: location
                 )
             default:
                 self.init(
                     code: .unknown,
-                    _localizedDescription: underlying.localizedDescription,
+                    localizedDescription: underlying.localizedDescription,
                     location: location
                 )
             }
         case let .apiError(error):
             self.init(
                 code: .serviceError,
-                _localizedDescription: "An error occurred. Check the error_code for more details.",
-                _userInfo: ["error_code": error.code],
+                localizedDescription: "An error occurred. Check the error_code for more details.",
+                userInfo: ["error_code": error.code],
                 location: location
             )
         case let .statusCode(status):
             self.init(
                 code: .serviceError,
-                _localizedDescription: "An error occurred. Check the status_code for more details.",
-                _userInfo: ["status_code": status],
+                localizedDescription: "An error occurred. Check the status_code for more details.",
+                userInfo: ["status_code": status],
                 location: location
             )
         case .invalidURL:
             self.init(
                 code: .unknown,
-                _localizedDescription: "Invalid URL.",
+                localizedDescription: "Invalid URL.",
                 location: location
             )
         case let .invalidResponse(data):
             self.init(
                 code: .unknown,
-                _localizedDescription: "invalid_response",
-                _userInfo: ["data": data],
+                localizedDescription: "invalid_response",
+                userInfo: ["data": data],
                 location: location
             )
         case let .decodingFailed(error):
             self.init(
                 code: .unknown,
-                _localizedDescription: error.localizedDescription,
+                localizedDescription: error.localizedDescription,
                 location: location
             )
         case let .requestFailed(error):
             self.init(
                 code: .unknown,
-                _localizedDescription: error.localizedDescription,
+                localizedDescription: error.localizedDescription,
                 location: location
             )
         case let .notExpectedHttpResponseCode(code: status):
             self.init(
                 code: .unknown,
-                _localizedDescription: "Not expected HTTP response code: \(status)",
+                localizedDescription: "Not expected HTTP response code: \(status)",
                 location: location
             )
         case .urlRequestIsEmpty:
             self.init(
                 code: .unknown,
-                _localizedDescription: "URL request is empty",
+                localizedDescription: "URL request is empty",
                 location: location
             )
         }

--- a/Sources/MercadoPagoCheckout/Model/Internal/MercadoPagoCheckoutError+Network.swift
+++ b/Sources/MercadoPagoCheckout/Model/Internal/MercadoPagoCheckoutError+Network.swift
@@ -1,0 +1,93 @@
+//
+//  MercadoPagoCheckoutError+Network.swift
+//  MercadoPagoSDK
+//
+import Foundation
+import MPCore
+
+extension MercadoPagoCheckoutError {
+    init(from error: APIClientError, location: LocationDescription) {
+        switch error {
+        case let .networkError(underlying):
+            let urlError = underlying as? URLError
+            switch urlError?.code {
+            case .notConnectedToInternet,
+                 .cannotFindHost,
+                 .cannotConnectToHost,
+                 .dnsLookupFailed,
+                 .internationalRoamingOff,
+                 .dataNotAllowed,
+                 .callIsActive,
+                 .networkConnectionLost:
+                self.init(
+                    code: .noConnection,
+                    _localizedDescription: "No internet connection.",
+                    location: location
+                )
+            case .timedOut:
+                self.init(
+                    code: .timeout,
+                    _localizedDescription: "The request timed out.",
+                    location: location
+                )
+            default:
+                self.init(
+                    code: .noConnection,
+                    _localizedDescription: "No internet connection.",
+                    location: location
+                )
+            }
+        case let .apiError(error):
+            self.init(
+                code: .serviceError,
+                _localizedDescription: "An error occurred. Check the error_code for more details.",
+                _userInfo: ["error_code": error.code],
+                location: location
+            )
+        case let .statusCode(status):
+            self.init(
+                code: .serviceError,
+                _localizedDescription: "An error occurred. Check the status_code for more details.",
+                _userInfo: ["status_code": status],
+                location: location
+            )
+        case .invalidURL:
+            self.init(
+                code: .unknown,
+                _localizedDescription: "Invalid URL.",
+                location: location
+            )
+        case let .invalidResponse(data):
+            self.init(
+                code: .unknown,
+                _localizedDescription: "invalid_response",
+                _userInfo: ["data": data],
+                location: location
+            )
+        case let .decodingFailed(error):
+            self.init(
+                code: .unknown,
+                _localizedDescription: error.localizedDescription,
+                location: location
+            )
+        case let .requestFailed(error):
+            self.init(
+                code: .unknown,
+                _localizedDescription: error.localizedDescription,
+                location: location
+            )
+        case let .notExpectedHttpResponseCode(code: status):
+            self.init(
+                code: .unknown,
+                _localizedDescription: "Not expected HTTP response code: \(status)",
+                location: location
+            )
+        case .urlRequestIsEmpty:
+            self.init(
+                code: .unknown,
+                _localizedDescription: "URL request is empty",
+                location: location
+            )
+        }
+    }
+}

--- a/Sources/MercadoPagoCheckout/Model/Internal/MercadoPagoCheckoutError+Network.swift
+++ b/Sources/MercadoPagoCheckout/Model/Internal/MercadoPagoCheckoutError+Network.swift
@@ -20,20 +20,20 @@ extension MercadoPagoCheckoutError {
                  .callIsActive,
                  .networkConnectionLost:
                 self.init(
-                    code: .noConnection,
+                    code: .networkConnectionFailed,
                     _localizedDescription: "No internet connection.",
                     location: location
                 )
             case .timedOut:
                 self.init(
-                    code: .timeout,
+                    code: .networkTimeout,
                     _localizedDescription: "The request timed out.",
                     location: location
                 )
             default:
                 self.init(
-                    code: .noConnection,
-                    _localizedDescription: "No internet connection.",
+                    code: .unknown,
+                    _localizedDescription: underlying.localizedDescription,
                     location: location
                 )
             }

--- a/Sources/MercadoPagoCheckout/Model/Public/MPCancelledFormContext.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/MPCancelledFormContext.swift
@@ -1,0 +1,56 @@
+//
+//  MPCancelledFormContext.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 13/03/26.
+//
+
+/// Contains information about the state of form fields when the user cancelled the checkout.
+public struct MPCancelledFormContext: Sendable, Equatable {
+    /// The list of fields that had errors at the time of cancellation.
+    public let fieldErrors: [FieldError]
+
+    public init(fieldErrors: [FieldError]) {
+        self.fieldErrors = fieldErrors
+    }
+}
+
+extension MPCancelledFormContext {
+    /// Represents an error in a specific field.
+    public struct FieldError: Sendable, Equatable {
+        /// The field that had an error.
+        public let field: Field
+        /// The reason for the error.
+        public let reason: Reason
+
+        public init(field: Field, reason: Reason) {
+            self.field = field
+            self.reason = reason
+        }
+    }
+}
+
+extension MPCancelledFormContext.FieldError {
+    /// The form field identifiers.
+    public enum Field: Sendable, Equatable {
+        case cardNumber
+        case cardHolder
+        case expirationDate
+        case securityCode
+        case document
+    }
+
+    /// The reason a field had an error.
+    public enum Reason: Sendable, Equatable {
+        /// The field was left empty.
+        case empty
+        /// The field was partially filled.
+        case incomplete
+        /// The field contained an invalid value.
+        case invalid
+        /// The card brand is not accepted.
+        case cardBrandNotAccepted(brand: String)
+        /// The card type is not accepted.
+        case cardTypeNotAccepted(cardType: MercadoPagoCheckout.CardType?)
+    }
+}

--- a/Sources/MercadoPagoCheckout/Model/Public/MPCancelledFormContext.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/MPCancelledFormContext.swift
@@ -2,35 +2,33 @@
 //  MPCancelledFormContext.swift
 //  MercadoPagoSDK
 //
-//  Created by Guilherme Prata Costa on 13/03/26.
-//
 
-/// Contains information about the state of form fields when the user cancelled the checkout.
+/// Contains the state of all form fields at the time the user cancelled the checkout.
 public struct MPCancelledFormContext: Sendable, Equatable {
-    /// The list of fields that had errors at the time of cancellation.
-    public let fieldErrors: [FieldError]
+    /// The state of each field at the time of cancellation.
+    public let fields: [FieldState]
 
-    public init(fieldErrors: [FieldError]) {
-        self.fieldErrors = fieldErrors
+    public init(fields: [FieldState]) {
+        self.fields = fields
     }
 }
 
 extension MPCancelledFormContext {
-    /// Represents an error in a specific field.
-    public struct FieldError: Sendable, Equatable {
-        /// The field that had an error.
+    /// The state of a specific form field at cancellation time.
+    public struct FieldState: Sendable, Equatable {
+        /// The form field.
         public let field: Field
-        /// The reason for the error.
-        public let reason: Reason
+        /// The state of the field.
+        public let state: State
 
-        public init(field: Field, reason: Reason) {
+        public init(field: Field, state: State) {
             self.field = field
-            self.reason = reason
+            self.state = state
         }
     }
 }
 
-extension MPCancelledFormContext.FieldError {
+extension MPCancelledFormContext.FieldState {
     /// The form field identifiers.
     public enum Field: Sendable, Equatable {
         case cardNumber
@@ -40,17 +38,19 @@ extension MPCancelledFormContext.FieldError {
         case document
     }
 
-    /// The reason a field had an error.
-    public enum Reason: Sendable, Equatable {
+    /// The state of a field at cancellation time.
+    public enum State: Sendable, Equatable {
+        /// The field was filled with a valid value.
+        case valid
         /// The field was left empty.
         case empty
         /// The field was partially filled.
         case incomplete
         /// The field contained an invalid value.
         case invalid
-        /// The card brand is not accepted.
+        /// The card brand is not accepted by the seller.
         case cardBrandNotAccepted(brand: String)
-        /// The card type is not accepted.
+        /// The card type is not accepted by the seller.
         case cardTypeNotAccepted(cardType: MercadoPagoCheckout.CardType?)
     }
 }

--- a/Sources/MercadoPagoCheckout/Model/Public/MercadoPagoCheckoutError+Error.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/MercadoPagoCheckoutError+Error.swift
@@ -1,5 +1,5 @@
 //
-//  MercadoPagoCheckoutError+Erros.swift
+//  MercadoPagoCheckoutError+Error.swift
 //  MercadoPagoSDK
 //
 //  Created by Danielle Nozaki Ogawa on 12/03/26.
@@ -29,6 +29,6 @@ extension MercadoPagoCheckoutError {
 
 extension MercadoPagoCheckoutError: Equatable {
     public static func == (lhs: MercadoPagoCheckoutError, rhs: MercadoPagoCheckoutError) -> Bool {
-        lhs.code == rhs.code
+        lhs.code == rhs.code && lhs.locationDescription == rhs.locationDescription
     }
 }

--- a/Sources/MercadoPagoCheckout/Model/Public/MercadoPagoCheckoutError+Erros.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/MercadoPagoCheckoutError+Erros.swift
@@ -6,12 +6,12 @@
 //
 
 extension MercadoPagoCheckoutError {
-    public static var noConnection: Code {
-        .noConnection
+    public static var networkConnectionFailed: Code {
+        .networkConnectionFailed
     }
 
-    public static var timeout: Code {
-        .timeout
+    public static var networkTimeout: Code {
+        .networkTimeout
     }
 
     public static var service: Code {

--- a/Sources/MercadoPagoCheckout/Model/Public/MercadoPagoCheckoutError+Erros.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/MercadoPagoCheckoutError+Erros.swift
@@ -1,0 +1,34 @@
+//
+//  MercadoPagoCheckoutError+Erros.swift
+//  MercadoPagoSDK
+//
+//  Created by Danielle Nozaki Ogawa on 12/03/26.
+//
+
+extension MercadoPagoCheckoutError {
+    public static var noConnection: Code {
+        .noConnection
+    }
+
+    public static var timeout: Code {
+        .timeout
+    }
+
+    public static var service: Code {
+        .serviceError
+    }
+
+    public static var invalidConfiguration: Code {
+        .invalidConfiguration
+    }
+
+    public static var unknown: Code {
+        .unknown
+    }
+}
+
+extension MercadoPagoCheckoutError: Equatable {
+    public static func == (lhs: MercadoPagoCheckoutError, rhs: MercadoPagoCheckoutError) -> Bool {
+        lhs.code == rhs.code
+    }
+}

--- a/Sources/MercadoPagoCheckout/Model/Public/MercadoPagoCheckoutError.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/MercadoPagoCheckoutError.swift
@@ -34,10 +34,10 @@ public struct MercadoPagoCheckoutError: Error, LocalizedError, CustomDebugString
     private let _userInfo: [String: Any]
     private let _location: LocationDescription
 
-    init(code: Code, _localizedDescription: String, _userInfo: [String: Any] = [:], location: LocationDescription) {
+    init(code: Code, localizedDescription: String, userInfo: [String: Any] = [:], location: LocationDescription) {
         self.code = code
-        self._localizedDescription = _localizedDescription
-        self._userInfo = _userInfo
+        self._localizedDescription = localizedDescription
+        self._userInfo = userInfo
         self._location = location
     }
 
@@ -50,6 +50,7 @@ public struct MercadoPagoCheckoutError: Error, LocalizedError, CustomDebugString
     }
 
     public var debugDescription: String {
+        // swiftlint:disable:next line_length
         "\(#file):\(#line): MercadoPagoCheckoutError(code: \(self.code.rawValue), location: \(self._location.rawValue), description: \(self._localizedDescription))"
     }
 

--- a/Sources/MercadoPagoCheckout/Model/Public/MercadoPagoCheckoutError.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/MercadoPagoCheckoutError.swift
@@ -22,7 +22,6 @@ public struct MercadoPagoCheckoutError: Error, LocalizedError, CustomDebugString
     }
 
     public enum LocationDescription: String, CaseIterable, Equatable {
-        case cardForm
         case tokenization
         case identification
         case paymentMethods

--- a/Sources/MercadoPagoCheckout/Model/Public/MercadoPagoCheckoutError.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/MercadoPagoCheckoutError.swift
@@ -7,7 +7,59 @@
 import Foundation
 
 @frozen
-public enum MercadoPagoCheckoutError: Error, Equatable {
-    case serviceError(String)
-    case message(String)
+public struct MercadoPagoCheckoutError: Error, LocalizedError, CustomDebugStringConvertible, CustomNSError {
+    public struct Code: RawRepresentable, Equatable, Hashable, Sendable {
+        public let rawValue: Int
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+
+        public static let networkConnectionFailed = Code(rawValue: -1009)
+        public static let networkTimeout = Code(rawValue: -1001)
+        public static let serviceError = Code(rawValue: 2000)
+        public static let unknown = Code(rawValue: 999)
+        public static let invalidConfiguration = Code(rawValue: 10010)
+    }
+
+    public enum LocationDescription: String, CaseIterable, Equatable {
+        case cardForm
+        case tokenization
+        case identification
+        case paymentMethods
+        case installments
+        case issuer
+    }
+
+    public let code: Code
+    private let _localizedDescription: String
+    private let _userInfo: [String: Any]
+    private let _location: LocationDescription
+
+    init(code: Code, _localizedDescription: String, _userInfo: [String: Any] = [:], location: LocationDescription) {
+        self.code = code
+        self._localizedDescription = _localizedDescription
+        self._userInfo = _userInfo
+        self._location = location
+    }
+
+    public var errorDescription: String? {
+        self._localizedDescription
+    }
+
+    public var locationDescription: String {
+        self._location.rawValue
+    }
+
+    public var debugDescription: String {
+        "\(#file):\(#line): MercadoPagoCheckoutError(code: \(self.code.rawValue), location: \(self._location.rawValue), description: \(self._localizedDescription))"
+    }
+
+    public static let errorDomain = "MercadoPagoSDK"
+    public var errorCode: Int {
+        self.code.rawValue
+    }
+
+    public var errorUserInfo: [String: Any] {
+        self._userInfo
+    }
 }

--- a/Sources/MercadoPagoCheckout/Model/Public/MercadoPagoCheckoutResult.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/MercadoPagoCheckoutResult.swift
@@ -10,5 +10,5 @@ import Foundation
 public enum MercadoPagoCheckoutResult: Equatable, Sendable {
     case success(MPPaymentData)
     case error(MercadoPagoCheckoutError)
-    case userCancelled
+    case userCancelled(MPCancelledFormContext)
 }

--- a/Sources/MercadoPagoCheckout/Utils/CardFormFormatting.swift
+++ b/Sources/MercadoPagoCheckout/Utils/CardFormFormatting.swift
@@ -33,7 +33,7 @@ package struct CardNumberFormatter: TextFormatting {
 
     /// Creates a card number formatter for the specified max digit count.
     /// The mask is automatically selected based on `maxLength`.
-    /// - Parameter maxLength: Maximum number of digits accepted. Default is 16.
+    /// - Parameter maxLength: Maximum number of digits accepted. Default is 19.
     package init(maxLength: Int = 19) {
         self.maxLength = maxLength
         self.maskFormat = Self.maskByLength[maxLength] ?? Self.defaultMask

--- a/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
+++ b/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
@@ -10,7 +10,7 @@ import MPComponents
 
 package enum CardValidationRequirement {
     case cardNumberRange(min: Int, max: Int)
-    case cardNumberExternalError(BinFetchError?)
+    case cardNumberExternalError(CardAcceptanceError?)
     case securityCodeLength(Int)
     case documentLength(min: Int, max: Int)
 }
@@ -46,7 +46,7 @@ package struct RequiredRule: CardFormRuleType {
 
 package struct CardNumberRule: CardFormRuleType {
     private var min = 13, max = 19
-    private var externalError: BinFetchError?
+    private var externalError: CardAcceptanceError?
 
     package mutating func apply(_ requirement: CardValidationRequirement) {
         if case let .cardNumberRange(newMin, newMax) = requirement {
@@ -81,7 +81,7 @@ package struct CardNumberRule: CardFormRuleType {
         return digits.dropFirst().allSatisfy { $0 == first }
     }
 
-    private func validateExternalError(_ error: BinFetchError) -> String? {
+    private func validateExternalError(_ error: CardAcceptanceError) -> String? {
         switch error {
         case let .paymentMethodNotAllowed(method):
             return MPStrings.CardForm.CardNumber.errorSellerExclusion(brand: method)
@@ -92,8 +92,6 @@ package struct CardNumberRule: CardFormRuleType {
             return MPStrings.CardForm.CardNumber.errorTypeNotAllowed(cardType: self.cardTypeDisplayName(cardType))
         case .paymentMethodNotFound:
             return MPStrings.CardForm.CardNumber.errorInvalid
-        case .networkError, .serviceError:
-            return nil
         }
     }
 

--- a/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
+++ b/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
@@ -90,8 +90,6 @@ package struct CardNumberRule: CardFormRuleType {
                 return MPStrings.CardForm.CardNumber.errorInvalid
             }
             return MPStrings.CardForm.CardNumber.errorTypeNotAllowed(cardType: self.cardTypeDisplayName(cardType))
-        case .paymentMethodNotFound:
-            return MPStrings.CardForm.CardNumber.errorInvalid
         }
     }
 

--- a/Sources/MercadoPagoCheckout/Utils/SnackbarWindowPresenter.swift
+++ b/Sources/MercadoPagoCheckout/Utils/SnackbarWindowPresenter.swift
@@ -1,0 +1,108 @@
+//
+//  SnackbarWindowPresenter.swift
+//  MercadoPagoSDK
+//
+import MPComponents
+import SwiftUI
+import UIKit
+
+@MainActor
+enum SnackbarWindowPresenter {
+    private static var overlayWindow: UIWindow?
+    private static var cleanupTask: DispatchWorkItem?
+
+    static func show(
+        message: String,
+        state: MPMessageState = .negative,
+        lightTheme: MPTheme,
+        darkTheme: MPTheme
+    ) {
+        // Waits for the brick's modal dismiss animation to complete (~0.35s default)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.present(message: message, state: state, lightTheme: lightTheme, darkTheme: darkTheme)
+        }
+    }
+
+    private static func present(
+        message: String,
+        state: MPMessageState,
+        lightTheme: MPTheme,
+        darkTheme: MPTheme
+    ) {
+        guard let windowScene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first(where: { $0.activationState == .foregroundActive }) else { return }
+
+        let window = PassthroughWindow(windowScene: windowScene)
+        window.windowLevel = .alert + 1
+        window.backgroundColor = .clear
+        self.overlayWindow = window
+
+        let view = SnackbarOverlayView(
+            message: message,
+            state: state,
+            lightTheme: lightTheme,
+            darkTheme: darkTheme,
+            onDismiss: { self.dismiss() }
+        )
+
+        let hostingController = UIHostingController(rootView: view)
+        hostingController.view.backgroundColor = .clear
+        window.rootViewController = hostingController
+        window.makeKeyAndVisible()
+
+        // Safety cleanup after snackbar duration + buffer
+        let cleanup = DispatchWorkItem { self.dismiss() }
+        self.cleanupTask = cleanup
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4, execute: cleanup)
+    }
+
+    private static func dismiss() {
+        self.cleanupTask?.cancel()
+        self.cleanupTask = nil
+        // Waits for the snackbar fade-out animation (0.25s)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            self.overlayWindow?.isHidden = true
+            self.overlayWindow = nil
+        }
+    }
+}
+
+// MARK: - PassthroughWindow
+
+private final class PassthroughWindow: UIWindow {
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard let hitView = super.hitTest(point, with: event) else { return nil }
+        // If only the transparent background was hit, pass touch through to the seller's app
+        // If a snackbar subview was hit, consume the touch
+        return hitView === rootViewController?.view ? nil : hitView
+    }
+}
+
+// MARK: - SnackbarOverlayView
+
+private struct SnackbarOverlayView: View {
+    let message: String
+    let state: MPMessageState
+    let lightTheme: MPTheme
+    let darkTheme: MPTheme
+    let onDismiss: () -> Void
+
+    @State private var isPresented = true
+
+    var body: some View {
+        ThemeProvider(light: self.lightTheme, dark: self.darkTheme) {
+            Color.clear
+                .allowsHitTesting(false)
+                .messageSnackbar(
+                    isPresented: self.$isPresented,
+                    text: self.message,
+                    state: self.state,
+                    duration: .short
+                )
+        }
+        .mpOnChange(of: self.isPresented) { presented in
+            if !presented { self.onDismiss() }
+        }
+    }
+}

--- a/Sources/MercadoPagoCheckout/Utils/SnackbarWindowPresenter.swift
+++ b/Sources/MercadoPagoCheckout/Utils/SnackbarWindowPresenter.swift
@@ -18,7 +18,8 @@ enum SnackbarWindowPresenter {
         darkTheme: MPTheme
     ) {
         // Waits for the brick's modal dismiss animation to complete (~0.35s default)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+        Task { @MainActor in
+            try await Task.sleep(nanoseconds: 350_000_000)
             self.present(message: message, state: state, lightTheme: lightTheme, darkTheme: darkTheme)
         }
     }

--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -21,6 +21,7 @@ struct CardFormScreen: View {
     @State private var cardForm = CardFormData()
     @State private var isSnackbarPresented = false
     @State private var footerHeight: CGFloat = 0
+    @State private var submitTask: Task<Void, Never>?
 
     // MARK: Enviroments
 
@@ -58,8 +59,9 @@ struct CardFormScreen: View {
                             buttonData: .init(
                                 text: MPStrings.CardForm.button,
                                 onClick: {
-                                    Task {
-                                        try await self.viewModel.submitCardData(
+                                    self.submitTask?.cancel()
+                                    self.submitTask = Task {
+                                        await self.viewModel.submitCardData(
                                             cardForm: self.cardForm,
                                             transactionAmount: self.transactionAmount
                                         ) {
@@ -170,6 +172,9 @@ struct CardFormScreen: View {
         }
         .mpOnChange(of: self.viewModel.showSnackbar) { show in
             if show { self.isSnackbarPresented = true }
+        }
+        .onDisappear {
+            self.submitTask?.cancel()
         }
     }
 

--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -21,7 +21,6 @@ struct CardFormScreen: View {
     @State private var cardForm = CardFormData()
     @State private var isSnackbarPresented = false
     @State private var footerHeight: CGFloat = 0
-    @State private var submitTask: Task<Void, Never>?
 
     // MARK: Enviroments
 
@@ -59,17 +58,12 @@ struct CardFormScreen: View {
                             buttonData: .init(
                                 text: MPStrings.CardForm.button,
                                 onClick: {
-                                    self.submitTask?.cancel()
-                                    self.submitTask = Task {
-                                        await self.viewModel.submitCardData(
-                                            cardForm: self.cardForm,
-                                            transactionAmount: self.transactionAmount
-                                        ) {
-                                            self.onSuccess($0)
-                                        } onFailure: {
-                                            self.onFailure($0)
-                                        }
-                                    }
+                                    await self.viewModel.submitCardData(
+                                        cardForm: self.cardForm,
+                                        transactionAmount: self.transactionAmount,
+                                        onSuccess: { self.onSuccess($0) },
+                                        onFailure: { self.onFailure($0) }
+                                    )
                                 }
                             )
                         )
@@ -172,9 +166,6 @@ struct CardFormScreen: View {
         }
         .mpOnChange(of: self.viewModel.showSnackbar) { show in
             if show { self.isSnackbarPresented = true }
-        }
-        .onDisappear {
-            self.submitTask?.cancel()
         }
     }
 

--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -165,7 +165,7 @@ struct CardFormScreen: View {
         .mpOnChange(of: self.viewModel.selectTypeDocument) { identificationType in
             self.updateIdentificationTypes(identificationType)
         }
-        .mpOnChange(of: self.viewModel.binFetchError) { error in
+        .mpOnChange(of: self.viewModel.cardAcceptanceError) { error in
             self.cardForm.setCardNumberExternalError(error)
         }
         .mpOnChange(of: self.viewModel.showSnackbar) { show in

--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -155,7 +155,7 @@ struct CardFormScreen: View {
             } catch let error as MercadoPagoCheckoutError {
                 self.onFailure(error)
             } catch {
-                self.onFailure(MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .identification))
+                self.onFailure(MercadoPagoCheckoutError(code: .unknown, localizedDescription: error.localizedDescription, location: .identification))
             }
         }
         .mpOnChange(of: self.cardForm.cardNumber) { newValue in

--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -9,7 +9,7 @@ import MPComponents
 import SwiftUI
 
 struct CardFormScreen: View {
-    private let onBack: () -> Void
+    private let onBack: (MPCancelledFormContext) -> Void
     private let onSuccess: (MPPaymentData) -> Void
     private let onFailure: (MercadoPagoCheckoutError) -> Void
     private let transactionAmount: Double?
@@ -29,7 +29,7 @@ struct CardFormScreen: View {
     init(
         transactionAmount: Double?,
         viewModel: CardFormViewModel,
-        onBack: @escaping () -> Void = {},
+        onBack: @escaping (MPCancelledFormContext) -> Void = { _ in },
         onSuccess: @escaping (MPPaymentData) -> Void = { _ in },
         onFailure: @escaping (MercadoPagoCheckoutError) -> Void = { _ in }
     ) {
@@ -50,7 +50,7 @@ struct CardFormScreen: View {
             case .ready:
                 MPHeader(
                     title: MPStrings.CardForm.title,
-                    onBack: { self.onBack() },
+                    onBack: { self.onBack(self.cardForm.cancelledFormContext) },
                     footer: {
                         MPFooter(
                             title: MPStrings.Common.total,
@@ -59,16 +59,13 @@ struct CardFormScreen: View {
                                 text: MPStrings.CardForm.button,
                                 onClick: {
                                     Task {
-                                        do {
-                                            let paymentData = try await self.viewModel.submitPaymentData(
-                                                self.transactionAmount,
-                                                cardFormData: self.cardForm
-                                            )
-                                            self.onSuccess(paymentData)
-                                        } catch let error as MercadoPagoCheckoutError {
-                                            self.onFailure(error)
-                                        } catch {
-                                            self.onFailure(.serviceError(error.localizedDescription))
+                                        try await self.viewModel.submitCardData(
+                                            cardForm: self.cardForm,
+                                            transactionAmount: self.transactionAmount
+                                        ) {
+                                            self.onSuccess($0)
+                                        } onFailure: {
+                                            self.onFailure($0)
                                         }
                                     }
                                 }
@@ -151,7 +148,13 @@ struct CardFormScreen: View {
         )
         .background(self.theme.colors.background.primary.edgesIgnoringSafeArea(.all))
         .mpTask {
-            await self.viewModel.loadIdentificationTypes()
+            do {
+                try await self.viewModel.loadIdentificationTypes()
+            } catch let error as MercadoPagoCheckoutError {
+                self.onFailure(error)
+            } catch {
+                self.onFailure(MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .identification))
+            }
         }
         .mpOnChange(of: self.cardForm.cardNumber) { newValue in
             self.viewModel.onCardNumberChange(newValue)

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -89,16 +89,18 @@ final class CardFormViewModel: ObservableObject {
 
     // MARK: - Identification Types
 
-    func loadIdentificationTypes() async {
+    func loadIdentificationTypes() async throws {
+        let types: [IdentificationType]
         do {
-            let types = try await withRetry { try await self.service.identificationTypes() }
-            self.identificationTypes = types
-            self.selectTypeDocument = types.first
-            self.screenState = .ready
+            types = try await withRetry { try await self.service.identificationTypes() }
+        } catch let error as APIClientError {
+            throw MercadoPagoCheckoutError(from: error, location: .identification)
         } catch {
-            self.screenState = .ready
-            self.showSnackbar = true
+            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .identification)
         }
+        self.identificationTypes = types
+        self.selectTypeDocument = types.first
+        self.screenState = .ready
     }
 
     // MARK: - Formatter Updates
@@ -135,7 +137,17 @@ final class CardFormViewModel: ObservableObject {
 
     private func createCardToken(cardForm: CardFormData) async throws -> CardToken {
         let params = self.buildCardParams(from: cardForm)
-        return try await self.service.createCardToken(cardParams: params)
+        do {
+            return try await self.service.createCardToken(cardParams: params)
+        } catch let error as APIClientError {
+            throw MercadoPagoCheckoutError(from: error, location: .tokenization)
+        } catch {
+            throw MercadoPagoCheckoutError(
+                code: .unknown,
+                _localizedDescription: "Card tokenization failed. \(error.localizedDescription)",
+                location: .tokenization
+            )
+        }
     }
 
     private func buildCardParams(from cardForm: CardFormData) -> CardParams {
@@ -215,10 +227,7 @@ final class CardFormViewModel: ObservableObject {
 
     // MARK: - Payment Data
 
-    func submitPaymentData(_ amount: Double?, cardFormData: CardFormData) async throws -> MPPaymentData {
-        self.isTokenizing = true
-        let cardToken = try await self.createCardToken(cardForm: cardFormData)
-
+    private func createPaymentData(_ amount: Double?, cardToken: CardToken, cardFormData: CardFormData) throws -> MPPaymentData {
         var payer: MPPaymentData.Payer? {
             guard let selectTypeDocument else { return nil }
             return .init(
@@ -241,5 +250,28 @@ final class CardFormViewModel: ObservableObject {
             issuerId: self.binData?.issuer?.id,
             payer: payer
         )
+    }
+
+    func submitCardData(cardForm: CardFormData, transactionAmount: Double?, onSuccess: (MPPaymentData) -> Void, onFailure: (MercadoPagoCheckoutError) -> Void) async {
+        do {
+            self.isTokenizing = true
+            let cardToken = try await self.createCardToken(cardForm: cardForm)
+            let paymentData = try self.createPaymentData(
+                transactionAmount,
+                cardToken: cardToken,
+                cardFormData: cardForm
+            )
+            onSuccess(paymentData)
+        } catch let error as MercadoPagoCheckoutError {
+            onFailure(error)
+        } catch {
+            onFailure(
+                MercadoPagoCheckoutError(
+                    code: .unknown,
+                    _localizedDescription: "Unknown error ocurred while submitting card token. Error: \(error.localizedDescription)",
+                    location: .tokenization
+                )
+            )
+        }
     }
 }

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -90,14 +90,7 @@ final class CardFormViewModel: ObservableObject {
     // MARK: - Identification Types
 
     func loadIdentificationTypes() async throws {
-        let types: [IdentificationType]
-        do {
-            types = try await withRetry { try await self.service.identificationTypes() }
-        } catch let error as APIClientError {
-            throw MercadoPagoCheckoutError(from: error, location: .identification)
-        } catch {
-            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .identification)
-        }
+        let types = try await withRetry { try await self.service.identificationTypes() }
         self.identificationTypes = types
         self.selectTypeDocument = types.first
         self.screenState = .ready
@@ -135,19 +128,9 @@ final class CardFormViewModel: ObservableObject {
 
     // MARK: - Card Token
 
-    private func createCardToken(cardForm: CardFormData) async throws -> CardToken {
+    private func createCardToken(cardForm: CardFormData) async throws(MercadoPagoCheckoutError) -> CardToken {
         let params = self.buildCardParams(from: cardForm)
-        do {
-            return try await self.service.createCardToken(cardParams: params)
-        } catch let error as APIClientError {
-            throw MercadoPagoCheckoutError(from: error, location: .tokenization)
-        } catch {
-            throw MercadoPagoCheckoutError(
-                code: .unknown,
-                _localizedDescription: "Card tokenization failed. \(error.localizedDescription)",
-                location: .tokenization
-            )
-        }
+        return try await self.service.createCardToken(cardParams: params)
     }
 
     private func buildCardParams(from cardForm: CardFormData) -> CardParams {
@@ -227,7 +210,11 @@ final class CardFormViewModel: ObservableObject {
 
     // MARK: - Payment Data
 
-    private func createPaymentData(_ amount: Double?, cardToken: CardToken, cardFormData: CardFormData) throws -> MPPaymentData {
+    private func createPaymentData(
+        _ amount: Double?,
+        cardToken: CardToken,
+        cardFormData: CardFormData
+    ) throws(MercadoPagoCheckoutError) -> MPPaymentData {
         var payer: MPPaymentData.Payer? {
             guard let selectTypeDocument else { return nil }
             return .init(
@@ -237,8 +224,11 @@ final class CardFormViewModel: ObservableObject {
         }
 
         guard let binData else {
-            // TODO: - Map correct error
-            throw NSError()
+            throw MercadoPagoCheckoutError(
+                code: .unknown,
+                _localizedDescription: "Couldn't create payment data: bin data is missing",
+                location: .paymentMethods
+            )
         }
 
         return .init(
@@ -252,26 +242,20 @@ final class CardFormViewModel: ObservableObject {
         )
     }
 
-    func submitCardData(cardForm: CardFormData, transactionAmount: Double?, onSuccess: (MPPaymentData) -> Void, onFailure: (MercadoPagoCheckoutError) -> Void) async {
+    func submitCardData(
+        cardForm: CardFormData,
+        transactionAmount: Double?,
+        onSuccess: (MPPaymentData) -> Void,
+        onFailure: (MercadoPagoCheckoutError) -> Void
+    ) async {
+        self.isTokenizing = true
+        defer { self.isTokenizing = false }
         do {
-            self.isTokenizing = true
             let cardToken = try await self.createCardToken(cardForm: cardForm)
-            let paymentData = try self.createPaymentData(
-                transactionAmount,
-                cardToken: cardToken,
-                cardFormData: cardForm
-            )
+            let paymentData = try self.createPaymentData(transactionAmount, cardToken: cardToken, cardFormData: cardForm)
             onSuccess(paymentData)
-        } catch let error as MercadoPagoCheckoutError {
-            onFailure(error)
         } catch {
-            onFailure(
-                MercadoPagoCheckoutError(
-                    code: .unknown,
-                    _localizedDescription: "Unknown error ocurred while submitting card token. Error: \(error.localizedDescription)",
-                    location: .tokenization
-                )
-            )
+            onFailure(error)
         }
     }
 }

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -66,10 +66,9 @@ final class CardFormViewModel: ObservableObject {
     }
 
     private var isRetriableBinError: Bool {
-        guard let error = binNetworkError else { return false }
-        return error.code == .networkConnectionFailed
-            || error.code == .networkTimeout
-            || error.code == .serviceError
+        return self.binNetworkError?.code == .networkConnectionFailed
+            || self.binNetworkError?.code == .networkTimeout
+            || self.binNetworkError?.code == .serviceError
     }
 
     // MARK: - Constants
@@ -229,7 +228,7 @@ final class CardFormViewModel: ObservableObject {
             guard let selectTypeDocument else { return nil }
             return .init(
                 type: selectTypeDocument.type,
-                number: cardFormData.documentHolder
+                number: cardFormData.documentHolder.filter(\.isNumber)
             )
         }
 

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -235,7 +235,7 @@ final class CardFormViewModel: ObservableObject {
         guard let binData else {
             throw MercadoPagoCheckoutError(
                 code: .unknown,
-                _localizedDescription: "Couldn't create payment data: bin data is missing",
+                localizedDescription: "Couldn't create payment data: bin data is missing",
                 location: .paymentMethods
             )
         }

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -40,7 +40,8 @@ final class CardFormViewModel: ObservableObject {
         didSet { self.updateFormatters(for: self.binData) }
     }
 
-    @Published private(set) var binFetchError: BinFetchError?
+    @Published private(set) var cardAcceptanceError: CardAcceptanceError?
+    @Published private(set) var binNetworkError: MercadoPagoCheckoutError?
     @Published private(set) var showSnackbar = false
     @Published private(set) var isTokenizing = false
 
@@ -65,7 +66,10 @@ final class CardFormViewModel: ObservableObject {
     }
 
     private var isRetriableBinError: Bool {
-        self.binFetchError == .networkError || self.binFetchError == .serviceError
+        guard let error = binNetworkError else { return false }
+        return error.code == .networkConnectionFailed
+            || error.code == .networkTimeout
+            || error.code == .serviceError
     }
 
     // MARK: - Constants
@@ -164,7 +168,8 @@ final class CardFormViewModel: ObservableObject {
 
         self.paymentMethodTask?.cancel()
         self.binData = nil
-        self.binFetchError = nil
+        self.cardAcceptanceError = nil
+        self.binNetworkError = nil
 
         guard let bin else { return }
 
@@ -175,7 +180,8 @@ final class CardFormViewModel: ObservableObject {
 
     func retryBinFetch() {
         guard self.binData == nil, let lastFetchedBIN, isRetriableBinError else { return }
-        self.binFetchError = nil
+        self.cardAcceptanceError = nil
+        self.binNetworkError = nil
         self.showSnackbar = false
         self.paymentMethodTask?.cancel()
         self.paymentMethodTask = Task { [weak self] in
@@ -198,10 +204,14 @@ final class CardFormViewModel: ObservableObject {
             )
             guard !Task.isCancelled else { return }
             self.binData = data
-        } catch let error as BinFetchError {
+        } catch let error as CardAcceptanceError {
             guard !Task.isCancelled else { return }
-            binData = nil
-            self.binFetchError = error
+            self.binData = nil
+            self.cardAcceptanceError = error
+        } catch let error as MercadoPagoCheckoutError {
+            guard !Task.isCancelled else { return }
+            self.binData = nil
+            self.binNetworkError = error
         } catch {
             guard !Task.isCancelled else { return }
             self.binData = nil

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -264,6 +264,7 @@ final class CardFormViewModel: ObservableObject {
             let paymentData = try self.createPaymentData(transactionAmount, cardToken: cardToken, cardFormData: cardForm)
             onSuccess(paymentData)
         } catch {
+            guard !Task.isCancelled else { return }
             onFailure(error)
         }
     }

--- a/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
+++ b/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
@@ -75,17 +75,17 @@ struct CardFormData {
     // MARK: - Cancelled Form Context
 
     var cancelledFormContext: MPCancelledFormContext {
-        var errors: [MPCancelledFormContext.FieldError] = []
-        if let reason = cardNumberReason() { errors.append(.init(field: .cardNumber, reason: reason)) }
-        if let reason = cardHolderReason() { errors.append(.init(field: .cardHolder, reason: reason)) }
-        if let reason = expirationDateReason() { errors.append(.init(field: .expirationDate, reason: reason)) }
-        if let reason = securityCodeReason() { errors.append(.init(field: .securityCode, reason: reason)) }
-        if let reason = documentHolderReason() { errors.append(.init(field: .document, reason: reason)) }
-        return MPCancelledFormContext(fieldErrors: errors)
+        MPCancelledFormContext(fields: [
+            .init(field: .cardNumber, state: cardNumberState()),
+            .init(field: .cardHolder, state: cardHolderState()),
+            .init(field: .expirationDate, state: expirationDateState()),
+            .init(field: .securityCode, state: securityCodeState()),
+            .init(field: .document, state: documentHolderState())
+        ])
     }
 
-    private func cardNumberReason() -> MPCancelledFormContext.FieldError.Reason? {
-        guard !_cardNumber.errorMessages.isEmpty else { return nil }
+    private func cardNumberState() -> MPCancelledFormContext.FieldState.State {
+        guard !_cardNumber.errorMessages.isEmpty else { return .valid }
         let digits = self.cardNumber.filter(\.isNumber)
         if digits.isEmpty { return .empty }
         if let acceptanceError = cardAcceptanceError {
@@ -97,28 +97,28 @@ struct CardFormData {
         return _cardNumber.errorMessages.contains(MPStrings.CardForm.CardNumber.errorIncomplete) ? .incomplete : .invalid
     }
 
-    private func cardHolderReason() -> MPCancelledFormContext.FieldError.Reason? {
-        guard !_cardHolder.errorMessages.isEmpty else { return nil }
+    private func cardHolderState() -> MPCancelledFormContext.FieldState.State {
+        guard !_cardHolder.errorMessages.isEmpty else { return .valid }
         if self.cardHolder.trimmingCharacters(in: .whitespaces).isEmpty { return .empty }
         if _cardHolder.errorMessages.contains(MPStrings.CardForm.CardHolder.errorIncomplete) { return .incomplete }
         return .invalid
     }
 
-    private func expirationDateReason() -> MPCancelledFormContext.FieldError.Reason? {
-        guard !_expirationDate.errorMessages.isEmpty else { return nil }
+    private func expirationDateState() -> MPCancelledFormContext.FieldState.State {
+        guard !_expirationDate.errorMessages.isEmpty else { return .valid }
         if self.expirationDate.filter(\.isNumber).isEmpty { return .empty }
         if _expirationDate.errorMessages.contains(MPStrings.CardForm.Expiration.errorIncomplete) { return .incomplete }
         return .invalid
     }
 
-    private func securityCodeReason() -> MPCancelledFormContext.FieldError.Reason? {
-        guard !_securityCode.errorMessages.isEmpty else { return nil }
+    private func securityCodeState() -> MPCancelledFormContext.FieldState.State {
+        guard !_securityCode.errorMessages.isEmpty else { return .valid }
         if self.securityCode.filter(\.isNumber).isEmpty { return .empty }
         return .incomplete
     }
 
-    private func documentHolderReason() -> MPCancelledFormContext.FieldError.Reason? {
-        guard !_documentHolder.errorMessages.isEmpty else { return nil }
+    private func documentHolderState() -> MPCancelledFormContext.FieldState.State {
+        guard !_documentHolder.errorMessages.isEmpty else { return .valid }
         if self.documentHolder.filter(\.isNumber).isEmpty { return .empty }
         if _documentHolder.errorMessages.contains(MPStrings.CardForm.Document.errorIncomplete) { return .incomplete }
         return .invalid

--- a/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
+++ b/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
@@ -37,7 +37,7 @@ struct CardFormData {
     )
     var documentHolder = ""
 
-    private var currentBinFetchError: BinFetchError?
+    private var cardAcceptanceError: CardAcceptanceError?
 
     mutating func setSecurityCodeLength(_ length: Int) {
         _securityCode.update(.securityCodeLength(length))
@@ -55,8 +55,8 @@ struct CardFormData {
         self.securityCode = ""
     }
 
-    mutating func setCardNumberExternalError(_ error: BinFetchError?) {
-        self.currentBinFetchError = error
+    mutating func setCardNumberExternalError(_ error: CardAcceptanceError?) {
+        self.cardAcceptanceError = error
         _cardNumber.update(.cardNumberExternalError(error))
     }
 
@@ -88,12 +88,11 @@ struct CardFormData {
         guard !_cardNumber.errorMessages.isEmpty else { return nil }
         let digits = self.cardNumber.filter(\.isNumber)
         if digits.isEmpty { return .empty }
-        if let binError = currentBinFetchError {
-            switch binError {
+        if let acceptanceError = cardAcceptanceError {
+            switch acceptanceError {
             case let .paymentMethodNotAllowed(brand): return .cardBrandNotAccepted(brand: brand)
             case let .paymentTypeNotAllowed(cardType): return .cardTypeNotAccepted(cardType: cardType)
             case .paymentMethodNotFound: return .invalid
-            case .networkError, .serviceError: break
             }
         }
         return _cardNumber.errorMessages.contains(MPStrings.CardForm.CardNumber.errorIncomplete) ? .incomplete : .invalid

--- a/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
+++ b/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
@@ -92,7 +92,6 @@ struct CardFormData {
             switch acceptanceError {
             case let .paymentMethodNotAllowed(brand): return .cardBrandNotAccepted(brand: brand)
             case let .paymentTypeNotAllowed(cardType): return .cardTypeNotAccepted(cardType: cardType)
-            case .paymentMethodNotFound: return .invalid
             }
         }
         return _cardNumber.errorMessages.contains(MPStrings.CardForm.CardNumber.errorIncomplete) ? .incomplete : .invalid

--- a/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
+++ b/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
@@ -37,6 +37,8 @@ struct CardFormData {
     )
     var documentHolder = ""
 
+    private var currentBinFetchError: BinFetchError?
+
     mutating func setSecurityCodeLength(_ length: Int) {
         _securityCode.update(.securityCodeLength(length))
     }
@@ -54,6 +56,7 @@ struct CardFormData {
     }
 
     mutating func setCardNumberExternalError(_ error: BinFetchError?) {
+        self.currentBinFetchError = error
         _cardNumber.update(.cardNumberExternalError(error))
     }
 
@@ -67,5 +70,59 @@ struct CardFormData {
             && _expirationDate.errorMessages.isEmpty
             && (isSecurityCodeMandatory ? _securityCode.errorMessages.isEmpty : true)
             && _documentHolder.errorMessages.isEmpty
+    }
+
+    // MARK: - Cancelled Form Context
+
+    var cancelledFormContext: MPCancelledFormContext {
+        var errors: [MPCancelledFormContext.FieldError] = []
+        if let reason = cardNumberReason() { errors.append(.init(field: .cardNumber, reason: reason)) }
+        if let reason = cardHolderReason() { errors.append(.init(field: .cardHolder, reason: reason)) }
+        if let reason = expirationDateReason() { errors.append(.init(field: .expirationDate, reason: reason)) }
+        if let reason = securityCodeReason() { errors.append(.init(field: .securityCode, reason: reason)) }
+        if let reason = documentHolderReason() { errors.append(.init(field: .document, reason: reason)) }
+        return MPCancelledFormContext(fieldErrors: errors)
+    }
+
+    private func cardNumberReason() -> MPCancelledFormContext.FieldError.Reason? {
+        guard !_cardNumber.errorMessages.isEmpty else { return nil }
+        let digits = self.cardNumber.filter(\.isNumber)
+        if digits.isEmpty { return .empty }
+        if let binError = currentBinFetchError {
+            switch binError {
+            case let .paymentMethodNotAllowed(brand): return .cardBrandNotAccepted(brand: brand)
+            case let .paymentTypeNotAllowed(cardType): return .cardTypeNotAccepted(cardType: cardType)
+            case .paymentMethodNotFound: return .invalid
+            case .networkError, .serviceError: break
+            }
+        }
+        return _cardNumber.errorMessages.contains(MPStrings.CardForm.CardNumber.errorIncomplete) ? .incomplete : .invalid
+    }
+
+    private func cardHolderReason() -> MPCancelledFormContext.FieldError.Reason? {
+        guard !_cardHolder.errorMessages.isEmpty else { return nil }
+        if self.cardHolder.trimmingCharacters(in: .whitespaces).isEmpty { return .empty }
+        if _cardHolder.errorMessages.contains(MPStrings.CardForm.CardHolder.errorIncomplete) { return .incomplete }
+        return .invalid
+    }
+
+    private func expirationDateReason() -> MPCancelledFormContext.FieldError.Reason? {
+        guard !_expirationDate.errorMessages.isEmpty else { return nil }
+        if self.expirationDate.filter(\.isNumber).isEmpty { return .empty }
+        if _expirationDate.errorMessages.contains(MPStrings.CardForm.Expiration.errorIncomplete) { return .incomplete }
+        return .invalid
+    }
+
+    private func securityCodeReason() -> MPCancelledFormContext.FieldError.Reason? {
+        guard !_securityCode.errorMessages.isEmpty else { return nil }
+        if self.securityCode.filter(\.isNumber).isEmpty { return .empty }
+        return .incomplete
+    }
+
+    private func documentHolderReason() -> MPCancelledFormContext.FieldError.Reason? {
+        guard !_documentHolder.errorMessages.isEmpty else { return nil }
+        if self.documentHolder.filter(\.isNumber).isEmpty { return .empty }
+        if _documentHolder.errorMessages.contains(MPStrings.CardForm.Document.errorIncomplete) { return .incomplete }
+        return .invalid
     }
 }

--- a/Tests/MercadoPagoCheckoutTests/Formatting/CardFormFormattingTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Formatting/CardFormFormattingTests.swift
@@ -11,16 +11,16 @@ import XCTest
 final class CardFormFormattingTests: XCTestCase {
     // MARK: - CardNumberFormatter (default maxLength = 16)
 
-    func test_cardNumberFormatter_default_shouldLimitTo16Digits() {
+    func test_cardNumberFormatter_default_shouldLimitTo19Digits() {
         // Arrange
         let formatter = CardNumberFormatter()
 
-        // Act — 19 digits provided, only 16 should be accepted
-        let result = formatter.formatOnChange("1234567890123456789")
+        // Act — 22 digits provided, only 19 should be accepted
+        let result = formatter.formatOnChange("1234567890123456789012")
 
         // Assert
         let digits = result.filter(\.isNumber)
-        XCTAssertEqual(digits.count, 16)
+        XCTAssertEqual(digits.count, 19)
     }
 
     func test_cardNumberFormatter_default_shouldApply16DigitMask() {

--- a/Tests/MercadoPagoCheckoutTests/Mocks/MockCheckoutService.swift
+++ b/Tests/MercadoPagoCheckoutTests/Mocks/MockCheckoutService.swift
@@ -51,7 +51,7 @@ final actor MockCheckoutService: CheckoutServiceProtocol {
 
     func identificationTypes() async throws(MercadoPagoCheckoutError) -> [IdentificationType] {
         guard !self.identificationTypesResults.isEmpty else {
-            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: "resultNotSet", location: .identification)
+            throw MercadoPagoCheckoutError(code: .unknown, localizedDescription: "resultNotSet", location: .identification)
         }
         let result = self.identificationTypesResults.count > 1
             ? self.identificationTypesResults.removeFirst()
@@ -61,46 +61,46 @@ final actor MockCheckoutService: CheckoutServiceProtocol {
         } catch let error as MercadoPagoCheckoutError {
             throw error
         } catch {
-            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .identification)
+            throw MercadoPagoCheckoutError(code: .unknown, localizedDescription: error.localizedDescription, location: .identification)
         }
     }
 
     func paymentMethod(bin _: String) async throws(MercadoPagoCheckoutError) -> [PaymentMethod] {
         guard let result = paymentMethodResult else {
-            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: "resultNotSet", location: .paymentMethods)
+            throw MercadoPagoCheckoutError(code: .unknown, localizedDescription: "resultNotSet", location: .paymentMethods)
         }
         do {
             return try result.get()
         } catch let error as MercadoPagoCheckoutError {
             throw error
         } catch {
-            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .paymentMethods)
+            throw MercadoPagoCheckoutError(code: .unknown, localizedDescription: error.localizedDescription, location: .paymentMethods)
         }
     }
 
     func issuers(bin _: String, paymentMethodID _: String) async throws(MercadoPagoCheckoutError) -> [Issuer] {
         guard let result = issuersResult else {
-            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: "resultNotSet", location: .paymentMethods)
+            throw MercadoPagoCheckoutError(code: .unknown, localizedDescription: "resultNotSet", location: .paymentMethods)
         }
         do {
             return try result.get()
         } catch let error as MercadoPagoCheckoutError {
             throw error
         } catch {
-            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .paymentMethods)
+            throw MercadoPagoCheckoutError(code: .unknown, localizedDescription: error.localizedDescription, location: .paymentMethods)
         }
     }
 
     func installments(amount _: Double, bin _: String) async throws(MercadoPagoCheckoutError) -> [Installment] {
         guard let result = installmentsResult else {
-            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: "resultNotSet", location: .installments)
+            throw MercadoPagoCheckoutError(code: .unknown, localizedDescription: "resultNotSet", location: .installments)
         }
         do {
             return try result.get()
         } catch let error as MercadoPagoCheckoutError {
             throw error
         } catch {
-            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .installments)
+            throw MercadoPagoCheckoutError(code: .unknown, localizedDescription: error.localizedDescription, location: .installments)
         }
     }
 
@@ -117,14 +117,14 @@ final actor MockCheckoutService: CheckoutServiceProtocol {
     func createCardToken(cardParams: CardParams) async throws(MercadoPagoCheckoutError) -> CardToken {
         self.capturedCardParams = cardParams
         guard let result = createCardTokenResult else {
-            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: "resultNotSet", location: .tokenization)
+            throw MercadoPagoCheckoutError(code: .unknown, localizedDescription: "resultNotSet", location: .tokenization)
         }
         do {
             return try result.get()
         } catch let error as MercadoPagoCheckoutError {
             throw error
         } catch {
-            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .tokenization)
+            throw MercadoPagoCheckoutError(code: .unknown, localizedDescription: error.localizedDescription, location: .tokenization)
         }
     }
 }

--- a/Tests/MercadoPagoCheckoutTests/Mocks/MockCheckoutService.swift
+++ b/Tests/MercadoPagoCheckoutTests/Mocks/MockCheckoutService.swift
@@ -49,27 +49,59 @@ final actor MockCheckoutService: CheckoutServiceProtocol {
         self.createCardTokenResult = result
     }
 
-    func identificationTypes() async throws -> [IdentificationType] {
-        guard !self.identificationTypesResults.isEmpty else { throw MockError.resultNotSet }
+    func identificationTypes() async throws(MercadoPagoCheckoutError) -> [IdentificationType] {
+        guard !self.identificationTypesResults.isEmpty else {
+            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: "resultNotSet", location: .identification)
+        }
         let result = self.identificationTypesResults.count > 1
             ? self.identificationTypesResults.removeFirst()
             : self.identificationTypesResults[0]
-        return try result.get()
+        do {
+            return try result.get()
+        } catch let error as MercadoPagoCheckoutError {
+            throw error
+        } catch {
+            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .identification)
+        }
     }
 
-    func paymentMethod(bin _: String) async throws -> [PaymentMethod] {
-        guard let result = paymentMethodResult else { throw MockError.resultNotSet }
-        return try result.get()
+    func paymentMethod(bin _: String) async throws(MercadoPagoCheckoutError) -> [PaymentMethod] {
+        guard let result = paymentMethodResult else {
+            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: "resultNotSet", location: .paymentMethods)
+        }
+        do {
+            return try result.get()
+        } catch let error as MercadoPagoCheckoutError {
+            throw error
+        } catch {
+            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .paymentMethods)
+        }
     }
 
-    func issuers(bin _: String, paymentMethodID _: String) async throws -> [Issuer] {
-        guard let result = issuersResult else { throw MockError.resultNotSet }
-        return try result.get()
+    func issuers(bin _: String, paymentMethodID _: String) async throws(MercadoPagoCheckoutError) -> [Issuer] {
+        guard let result = issuersResult else {
+            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: "resultNotSet", location: .paymentMethods)
+        }
+        do {
+            return try result.get()
+        } catch let error as MercadoPagoCheckoutError {
+            throw error
+        } catch {
+            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .paymentMethods)
+        }
     }
 
-    func installments(amount _: Double, bin _: String) async throws -> [Installment] {
-        guard let result = installmentsResult else { throw MockError.resultNotSet }
-        return try result.get()
+    func installments(amount _: Double, bin _: String) async throws(MercadoPagoCheckoutError) -> [Installment] {
+        guard let result = installmentsResult else {
+            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: "resultNotSet", location: .installments)
+        }
+        do {
+            return try result.get()
+        } catch let error as MercadoPagoCheckoutError {
+            throw error
+        } catch {
+            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .installments)
+        }
     }
 
     func fetchBinData(
@@ -82,9 +114,17 @@ final actor MockCheckoutService: CheckoutServiceProtocol {
         return try result.get()
     }
 
-    func createCardToken(cardParams: CardParams) async throws -> CardToken {
+    func createCardToken(cardParams: CardParams) async throws(MercadoPagoCheckoutError) -> CardToken {
         self.capturedCardParams = cardParams
-        guard let result = createCardTokenResult else { throw MockError.resultNotSet }
-        return try result.get()
+        guard let result = createCardTokenResult else {
+            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: "resultNotSet", location: .tokenization)
+        }
+        do {
+            return try result.get()
+        } catch let error as MercadoPagoCheckoutError {
+            throw error
+        } catch {
+            throw MercadoPagoCheckoutError(code: .unknown, _localizedDescription: error.localizedDescription, location: .tokenization)
+        }
     }
 }

--- a/Tests/MercadoPagoCheckoutTests/UseCases/FetchBinDataUseCaseTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/UseCases/FetchBinDataUseCaseTests.swift
@@ -5,12 +5,11 @@
 //  Created by Danielle Nozaki Ogawa on 26/02/26.
 //
 
-import XCTest
-@testable import MercadoPagoCheckout
 @testable import CoreMethods
+@testable import MercadoPagoCheckout
+import XCTest
 
 final class FetchBinDataUseCaseTests: XCTestCase {
-
     // MARK: - Types
 
     typealias SUT = (
@@ -107,49 +106,49 @@ final class FetchBinDataUseCaseTests: XCTestCase {
 
     func test_execute_whenPaymentMethodsIsEmpty_shouldThrow() async {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.success([]))
 
         // Act / Assert
-        await XCTAssertThrowsErrorAsync(try await execute(sut.useCase))
+        await XCTAssertThrowsErrorAsync(try await self.execute(sut.useCase))
     }
 
     func test_execute_whenNoMatchingPaymentType_shouldThrow() async {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.success([PaymentMethodStub.debitVisa]))
 
         // Act / Assert
         await XCTAssertThrowsErrorAsync(
-            try await execute(sut.useCase, acceptedPaymentTypeIds: ["credit_card"])
+            try await self.execute(sut.useCase, acceptedPaymentTypeIds: ["credit_card"])
         )
     }
 
     func test_execute_whenNoMatchingPaymentMethodId_shouldThrow() async {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.success([PaymentMethodStub.visa]))
 
         // Act / Assert
         await XCTAssertThrowsErrorAsync(
-            try await execute(sut.useCase, acceptedPaymentMethodIds: ["master"])
+            try await self.execute(sut.useCase, acceptedPaymentMethodIds: ["master"])
         )
     }
 
     func test_execute_whenPaymentMethodFails_shouldPropagateError() async {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.failure(MockCheckoutService.MockError.resultNotSet))
 
         // Act / Assert
-        await XCTAssertThrowsErrorAsync(try await execute(sut.useCase))
+        await XCTAssertThrowsErrorAsync(try await self.execute(sut.useCase))
     }
 
     // MARK: - Payment Method Filtering
 
     func test_execute_whenEmptyAcceptedMethodIds_shouldMatchAnyBrand() async throws {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.success([PaymentMethodStub.visa]))
 
         // Act
@@ -161,7 +160,7 @@ final class FetchBinDataUseCaseTests: XCTestCase {
 
     func test_execute_whenAcceptedMethodIdsMatches_shouldReturnMatchingMethod() async throws {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.success([PaymentMethodStub.visa, PaymentMethodStub.master]))
 
         // Act
@@ -175,7 +174,7 @@ final class FetchBinDataUseCaseTests: XCTestCase {
 
     func test_execute_whenAdditionalInfoNeededHasNoIssuerId_shouldNotFetchIssuer() async throws {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.success([PaymentMethodStub.visa]))
 
         // Act
@@ -187,7 +186,7 @@ final class FetchBinDataUseCaseTests: XCTestCase {
 
     func test_execute_whenAdditionalInfoNeededHasIssuerId_shouldFetchIssuer() async throws {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.success([PaymentMethodStub.visaWithIssuer]))
         await sut.service.setIssuersResult(.success([IssuerStub.santander]))
 
@@ -200,7 +199,7 @@ final class FetchBinDataUseCaseTests: XCTestCase {
 
     func test_execute_whenIssuersReturnsEmpty_shouldHaveNilIssuer() async throws {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.success([PaymentMethodStub.visaWithIssuer]))
         await sut.service.setIssuersResult(.success([]))
 
@@ -213,19 +212,19 @@ final class FetchBinDataUseCaseTests: XCTestCase {
 
     func test_execute_whenIssuersFails_shouldPropagateError() async {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.success([PaymentMethodStub.visaWithIssuer]))
         await sut.service.setIssuersResult(.failure(MockCheckoutService.MockError.resultNotSet))
 
         // Act / Assert
-        await XCTAssertThrowsErrorAsync(try await execute(sut.useCase))
+        await XCTAssertThrowsErrorAsync(try await self.execute(sut.useCase))
     }
 
     // MARK: - Installments Fetching
 
     func test_execute_whenAmountIsNil_shouldNotFetchInstallments() async throws {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.success([PaymentMethodStub.visa]))
 
         // Act
@@ -237,7 +236,7 @@ final class FetchBinDataUseCaseTests: XCTestCase {
 
     func test_execute_whenAmountProvided_shouldFetchInstallments() async throws {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.success([PaymentMethodStub.visa]))
         await sut.service.setInstallmentsResult(.success([InstallmentStub.withSantander]))
 
@@ -250,7 +249,7 @@ final class FetchBinDataUseCaseTests: XCTestCase {
 
     func test_execute_whenAmountProvidedAndNoIssuer_shouldReturnFirstInstallment() async throws {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.success([PaymentMethodStub.visa]))
         await sut.service.setInstallmentsResult(.success([InstallmentStub.withSantander, InstallmentStub.withBradesco]))
 
@@ -263,7 +262,7 @@ final class FetchBinDataUseCaseTests: XCTestCase {
 
     func test_execute_whenAmountProvidedWithIssuer_shouldMatchInstallmentByIssuer() async throws {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.success([PaymentMethodStub.visaWithIssuer]))
         await sut.service.setIssuersResult(.success([IssuerStub.bradesco]))
         await sut.service.setInstallmentsResult(.success([InstallmentStub.withSantander, InstallmentStub.withBradesco]))
@@ -277,7 +276,7 @@ final class FetchBinDataUseCaseTests: XCTestCase {
 
     func test_execute_whenAmountProvidedWithIssuerButNoMatchingInstallment_shouldHaveNilInstallment() async throws {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.success([PaymentMethodStub.visaWithIssuer]))
         await sut.service.setIssuersResult(.success([IssuerStub.santander]))
         await sut.service.setInstallmentsResult(.success([InstallmentStub.withBradesco]))
@@ -291,26 +290,26 @@ final class FetchBinDataUseCaseTests: XCTestCase {
 
     func test_execute_whenInstallmentsFails_shouldPropagateError() async {
         // Arrange
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.success([PaymentMethodStub.visa]))
         await sut.service.setInstallmentsResult(.failure(MockCheckoutService.MockError.resultNotSet))
 
         // Act / Assert
-        await XCTAssertThrowsErrorAsync(try await execute(sut.useCase, amount: 100.0))
+        await XCTAssertThrowsErrorAsync(try await self.execute(sut.useCase, amount: 100.0))
     }
 
-    // MARK: - BinFetchError Detection
+    // MARK: - CardAcceptanceError Detection
 
     func test_execute_whenTypeMatchesButBrandExcluded_shouldThrowPaymentMethodNotAllowed() async {
         // Arrange — visa is credit_card (accepted type) but excluded from accepted brands
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.success([PaymentMethodStub.visa]))
 
         // Act / Assert
         do {
-            _ = try await execute(sut.useCase, acceptedPaymentTypeIds: ["credit_card"], acceptedPaymentMethodIds: ["master"])
+            _ = try await self.execute(sut.useCase, acceptedPaymentTypeIds: ["credit_card"], acceptedPaymentMethodIds: ["master"])
             XCTFail("Expected paymentMethodNotAllowed error")
-        } catch BinFetchError.paymentMethodNotAllowed(let method) {
+        } catch let CardAcceptanceError.paymentMethodNotAllowed(method) {
             XCTAssertEqual(method, PaymentMethodStub.visa.id)
         } catch {
             XCTFail("Unexpected error: \(error)")
@@ -319,14 +318,14 @@ final class FetchBinDataUseCaseTests: XCTestCase {
 
     func test_execute_whenTypeDoesNotMatch_shouldThrowPaymentTypeNotAllowed() async {
         // Arrange — debitVisa is debit_card, only credit_card accepted
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.success([PaymentMethodStub.debitVisa]))
 
         // Act / Assert
         do {
-            _ = try await execute(sut.useCase, acceptedPaymentTypeIds: ["credit_card"], acceptedPaymentMethodIds: [])
+            _ = try await self.execute(sut.useCase, acceptedPaymentTypeIds: ["credit_card"], acceptedPaymentMethodIds: [])
             XCTFail("Expected paymentTypeNotAllowed error")
-        } catch BinFetchError.paymentTypeNotAllowed(let cardType) {
+        } catch let CardAcceptanceError.paymentTypeNotAllowed(cardType) {
             XCTAssertEqual(cardType, .debit)
         } catch {
             XCTFail("Unexpected error: \(error)")
@@ -335,14 +334,14 @@ final class FetchBinDataUseCaseTests: XCTestCase {
 
     func test_execute_whenMultipleMethodsAndBothBrandExcluded_shouldThrowWithFirstDetectedBrand() async {
         // Arrange — visa and master are both credit_card, neither is in accepted brands
-        let sut = makeSUT()
+        let sut = self.makeSUT()
         await sut.service.setPaymentMethodResult(.success([PaymentMethodStub.visa, PaymentMethodStub.master]))
 
         // Act / Assert
         do {
-            _ = try await execute(sut.useCase, acceptedPaymentTypeIds: ["credit_card"], acceptedPaymentMethodIds: ["amex"])
+            _ = try await self.execute(sut.useCase, acceptedPaymentTypeIds: ["credit_card"], acceptedPaymentMethodIds: ["amex"])
             XCTFail("Expected paymentMethodNotAllowed error")
-        } catch BinFetchError.paymentMethodNotAllowed(let method) {
+        } catch let CardAcceptanceError.paymentMethodNotAllowed(method) {
             XCTAssertEqual(method, PaymentMethodStub.visa.id)
         } catch {
             XCTFail("Unexpected error: \(error)")

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
@@ -245,7 +245,7 @@ final class CardFormViewModelTests: XCTestCase {
         let sut = self.makeSUT()
 
         // Assert
-        XCTAssertNil(sut.viewModel.binFetchError)
+        XCTAssertNil(sut.viewModel.cardAcceptanceError)
     }
 
     // MARK: - loadIdentificationTypes
@@ -356,7 +356,7 @@ final class CardFormViewModelTests: XCTestCase {
 
         // Assert
         XCTAssertNil(sut.viewModel.binData)
-        XCTAssertNil(sut.viewModel.binFetchError)
+        XCTAssertNil(sut.viewModel.cardAcceptanceError)
     }
 
     func test_onCardNumberChange_whenDigitsReach8_withSuccess_shouldSetBinData() async {
@@ -370,20 +370,20 @@ final class CardFormViewModelTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(sut.viewModel.binData, CardBinDataStub.visa)
-        XCTAssertNil(sut.viewModel.binFetchError)
+        XCTAssertNil(sut.viewModel.cardAcceptanceError)
     }
 
     func test_onCardNumberChange_whenDigitsReach8_withError_shouldSetApiError() async {
         // Arrange
         let sut = self.makeSUT()
-        await sut.service.setFetchBinDataResult(.failure(BinFetchError.paymentMethodNotAllowed("visa")))
+        await sut.service.setFetchBinDataResult(.failure(CardAcceptanceError.paymentMethodNotAllowed("visa")))
 
         // Act
         sut.viewModel.onCardNumberChange("12345678")
-        await self.waitForChange(sut.viewModel.$binFetchError)
+        await self.waitForChange(sut.viewModel.$cardAcceptanceError)
 
         // Assert
-        XCTAssertNotNil(sut.viewModel.binFetchError)
+        XCTAssertNotNil(sut.viewModel.cardAcceptanceError)
         XCTAssertNil(sut.viewModel.binData)
     }
 
@@ -399,16 +399,16 @@ final class CardFormViewModelTests: XCTestCase {
 
         // Assert
         XCTAssertNil(sut.viewModel.binData)
-        XCTAssertNil(sut.viewModel.binFetchError)
+        XCTAssertNil(sut.viewModel.cardAcceptanceError)
     }
 
     func test_onCardNumberChange_whenSameBINCalledTwice_shouldNotRefetch() async {
         // Arrange — first call fails
         let sut = self.makeSUT()
-        await sut.service.setFetchBinDataResult(.failure(BinFetchError.paymentMethodNotAllowed("visa")))
+        await sut.service.setFetchBinDataResult(.failure(CardAcceptanceError.paymentMethodNotAllowed("visa")))
         sut.viewModel.onCardNumberChange("12345678")
-        await self.waitForChange(sut.viewModel.$binFetchError)
-        XCTAssertNotNil(sut.viewModel.binFetchError)
+        await self.waitForChange(sut.viewModel.$cardAcceptanceError)
+        XCTAssertNotNil(sut.viewModel.cardAcceptanceError)
 
         // Change result to success, but call with same BIN
         await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
@@ -417,16 +417,16 @@ final class CardFormViewModelTests: XCTestCase {
         sut.viewModel.onCardNumberChange("12345678")
 
         // Assert — state unchanged
-        XCTAssertNotNil(sut.viewModel.binFetchError)
+        XCTAssertNotNil(sut.viewModel.cardAcceptanceError)
         XCTAssertNil(sut.viewModel.binData)
     }
 
     func test_onCardNumberChange_whenDifferentBINAfterError_shouldRefetchAndClearError() async {
         // Arrange — first BIN fails
         let sut = self.makeSUT()
-        await sut.service.setFetchBinDataResult(.failure(BinFetchError.paymentMethodNotAllowed("visa")))
+        await sut.service.setFetchBinDataResult(.failure(CardAcceptanceError.paymentMethodNotAllowed("visa")))
         sut.viewModel.onCardNumberChange("12345678")
-        await self.waitForChange(sut.viewModel.$binFetchError)
+        await self.waitForChange(sut.viewModel.$cardAcceptanceError)
 
         // Act — different BIN with success
         await sut.service.setFetchBinDataResult(.success(CardBinDataStub.master))
@@ -434,7 +434,7 @@ final class CardFormViewModelTests: XCTestCase {
         await self.waitForChange(sut.viewModel.$binData)
 
         // Assert
-        XCTAssertNil(sut.viewModel.binFetchError)
+        XCTAssertNil(sut.viewModel.cardAcceptanceError)
         XCTAssertEqual(sut.viewModel.binData, CardBinDataStub.master)
     }
 
@@ -626,10 +626,10 @@ final class CardFormViewModelTests: XCTestCase {
     func test_retryBinFetch_whenValidationError_shouldNotRetry() async {
         // Arrange — paymentMethodNotAllowed is not a retriable error
         let sut = self.makeSUT()
-        await sut.service.setFetchBinDataResult(.failure(BinFetchError.paymentMethodNotAllowed("visa")))
+        await sut.service.setFetchBinDataResult(.failure(CardAcceptanceError.paymentMethodNotAllowed("visa")))
         sut.viewModel.onCardNumberChange("12345678")
-        await self.waitForChange(sut.viewModel.$binFetchError)
-        XCTAssertEqual(sut.viewModel.binFetchError, .paymentMethodNotAllowed("visa"))
+        await self.waitForChange(sut.viewModel.$cardAcceptanceError)
+        XCTAssertEqual(sut.viewModel.cardAcceptanceError, .paymentMethodNotAllowed("visa"))
 
         // Act — guard: binFetchError is not .networkError/.serviceError → does nothing
         sut.viewModel.retryBinFetch()
@@ -641,13 +641,14 @@ final class CardFormViewModelTests: XCTestCase {
     func test_retryBinFetch_whenNetworkError_andRetryFails_shouldShowSnackbar() async {
         // Arrange — initial fetch fails with networkError
         let sut = self.makeSUT()
-        await sut.service.setFetchBinDataResult(.failure(BinFetchError.networkError))
+        let networkError = MercadoPagoCheckoutError(code: .networkConnectionFailed, _localizedDescription: "", location: .paymentMethods)
+        await sut.service.setFetchBinDataResult(.failure(networkError))
         sut.viewModel.onCardNumberChange("12345678")
-        await self.waitForChange(sut.viewModel.$binFetchError)
-        XCTAssertEqual(sut.viewModel.binFetchError, .networkError)
+        await self.waitForChange(sut.viewModel.$binNetworkError)
+        XCTAssertEqual(sut.viewModel.binNetworkError?.code, .networkConnectionFailed)
 
         // Act — retry also fails
-        await sut.service.setFetchBinDataResult(.failure(BinFetchError.networkError))
+        await sut.service.setFetchBinDataResult(.failure(networkError))
         sut.viewModel.retryBinFetch()
         await self.waitForChange(sut.viewModel.$showSnackbar)
 
@@ -658,13 +659,14 @@ final class CardFormViewModelTests: XCTestCase {
     func test_retryBinFetch_whenServiceError_andRetryFails_shouldShowSnackbar() async {
         // Arrange — initial fetch fails with serviceError
         let sut = self.makeSUT()
-        await sut.service.setFetchBinDataResult(.failure(BinFetchError.serviceError))
+        let serviceError = MercadoPagoCheckoutError(code: .serviceError, _localizedDescription: "", location: .paymentMethods)
+        await sut.service.setFetchBinDataResult(.failure(serviceError))
         sut.viewModel.onCardNumberChange("12345678")
-        await self.waitForChange(sut.viewModel.$binFetchError)
-        XCTAssertEqual(sut.viewModel.binFetchError, .serviceError)
+        await self.waitForChange(sut.viewModel.$binNetworkError)
+        XCTAssertEqual(sut.viewModel.binNetworkError?.code, .serviceError)
 
         // Act — retry also fails
-        await sut.service.setFetchBinDataResult(.failure(BinFetchError.serviceError))
+        await sut.service.setFetchBinDataResult(.failure(serviceError))
         sut.viewModel.retryBinFetch()
         await self.waitForChange(sut.viewModel.$showSnackbar)
 
@@ -675,9 +677,10 @@ final class CardFormViewModelTests: XCTestCase {
     func test_retryBinFetch_whenNetworkError_andRetrySucceeds_shouldNotShowSnackbar() async {
         // Arrange — initial fetch fails with networkError
         let sut = self.makeSUT()
-        await sut.service.setFetchBinDataResult(.failure(BinFetchError.networkError))
+        let networkError = MercadoPagoCheckoutError(code: .networkConnectionFailed, _localizedDescription: "", location: .paymentMethods)
+        await sut.service.setFetchBinDataResult(.failure(networkError))
         sut.viewModel.onCardNumberChange("12345678")
-        await self.waitForChange(sut.viewModel.$binFetchError)
+        await self.waitForChange(sut.viewModel.$binNetworkError)
 
         // Act — retry succeeds
         await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
@@ -920,12 +923,13 @@ final class CardFormViewModelTests: XCTestCase {
     func test_retryBinFetch_whenCalledTwice_withNetworkError_shouldShowSnackbarBothTimes() async {
         // Arrange — initial fetch fails
         let sut = self.makeSUT()
-        await sut.service.setFetchBinDataResult(.failure(BinFetchError.networkError))
+        let networkError = MercadoPagoCheckoutError(code: .networkConnectionFailed, _localizedDescription: "", location: .paymentMethods)
+        await sut.service.setFetchBinDataResult(.failure(networkError))
         sut.viewModel.onCardNumberChange("12345678")
-        await self.waitForChange(sut.viewModel.$binFetchError)
+        await self.waitForChange(sut.viewModel.$binNetworkError)
 
         // First retry fails → showSnackbar becomes true
-        await sut.service.setFetchBinDataResult(.failure(BinFetchError.networkError))
+        await sut.service.setFetchBinDataResult(.failure(networkError))
         sut.viewModel.retryBinFetch()
         await self.waitForChange(sut.viewModel.$showSnackbar)
         XCTAssertTrue(sut.viewModel.showSnackbar)
@@ -943,7 +947,7 @@ final class CardFormViewModelTests: XCTestCase {
             }
             .store(in: &self.cancellables)
 
-        await sut.service.setFetchBinDataResult(.failure(BinFetchError.networkError))
+        await sut.service.setFetchBinDataResult(.failure(networkError))
         sut.viewModel.retryBinFetch()
         await fulfillment(of: [exp], timeout: 1.0)
 

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
@@ -628,7 +628,7 @@ final class CardFormViewModelTests: XCTestCase {
     func test_retryBinFetch_whenNetworkError_andRetryFails_shouldShowSnackbar() async {
         // Arrange — initial fetch fails with networkError
         let sut = self.makeSUT()
-        let networkError = MercadoPagoCheckoutError(code: .networkConnectionFailed, _localizedDescription: "", location: .paymentMethods)
+        let networkError = MercadoPagoCheckoutError(code: .networkConnectionFailed, localizedDescription: "", location: .paymentMethods)
         await sut.service.setFetchBinDataResult(.failure(networkError))
         sut.viewModel.onCardNumberChange("12345678")
         await self.waitForChange(sut.viewModel.$binNetworkError)
@@ -646,7 +646,7 @@ final class CardFormViewModelTests: XCTestCase {
     func test_retryBinFetch_whenServiceError_andRetryFails_shouldShowSnackbar() async {
         // Arrange — initial fetch fails with serviceError
         let sut = self.makeSUT()
-        let serviceError = MercadoPagoCheckoutError(code: .serviceError, _localizedDescription: "", location: .paymentMethods)
+        let serviceError = MercadoPagoCheckoutError(code: .serviceError, localizedDescription: "", location: .paymentMethods)
         await sut.service.setFetchBinDataResult(.failure(serviceError))
         sut.viewModel.onCardNumberChange("12345678")
         await self.waitForChange(sut.viewModel.$binNetworkError)
@@ -664,7 +664,7 @@ final class CardFormViewModelTests: XCTestCase {
     func test_retryBinFetch_whenNetworkError_andRetrySucceeds_shouldNotShowSnackbar() async {
         // Arrange — initial fetch fails with networkError
         let sut = self.makeSUT()
-        let networkError = MercadoPagoCheckoutError(code: .networkConnectionFailed, _localizedDescription: "", location: .paymentMethods)
+        let networkError = MercadoPagoCheckoutError(code: .networkConnectionFailed, localizedDescription: "", location: .paymentMethods)
         await sut.service.setFetchBinDataResult(.failure(networkError))
         sut.viewModel.onCardNumberChange("12345678")
         await self.waitForChange(sut.viewModel.$binNetworkError)
@@ -995,7 +995,7 @@ final class CardFormViewModelTests: XCTestCase {
     func test_retryBinFetch_whenCalledTwice_withNetworkError_shouldShowSnackbarBothTimes() async {
         // Arrange — initial fetch fails
         let sut = self.makeSUT()
-        let networkError = MercadoPagoCheckoutError(code: .networkConnectionFailed, _localizedDescription: "", location: .paymentMethods)
+        let networkError = MercadoPagoCheckoutError(code: .networkConnectionFailed, localizedDescription: "", location: .paymentMethods)
         await sut.service.setFetchBinDataResult(.failure(networkError))
         sut.viewModel.onCardNumberChange("12345678")
         await self.waitForChange(sut.viewModel.$binNetworkError)

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
@@ -256,7 +256,7 @@ final class CardFormViewModelTests: XCTestCase {
         await sut.service.setIdentificationTypesResult(.success([IdentificationTypeStub.cpf]))
 
         // Act
-        await sut.viewModel.loadIdentificationTypes()
+        try? await sut.viewModel.loadIdentificationTypes()
 
         // Assert
         XCTAssertEqual(sut.viewModel.screenState, .ready)
@@ -268,7 +268,7 @@ final class CardFormViewModelTests: XCTestCase {
         await sut.service.setIdentificationTypesResult(.success([IdentificationTypeStub.cpf, IdentificationTypeStub.cnpj]))
 
         // Act
-        await sut.viewModel.loadIdentificationTypes()
+        try? await sut.viewModel.loadIdentificationTypes()
 
         // Assert
         XCTAssertEqual(sut.viewModel.selectTypeDocument, IdentificationTypeStub.cpf)
@@ -281,22 +281,10 @@ final class CardFormViewModelTests: XCTestCase {
         await sut.service.setIdentificationTypesResult(.success([]))
 
         // Act
-        await sut.viewModel.loadIdentificationTypes()
+        try? await sut.viewModel.loadIdentificationTypes()
 
         // Assert
         XCTAssertEqual(sut.viewModel.selectTypeDocument, defaultDocument)
-        XCTAssertEqual(sut.viewModel.screenState, .ready)
-    }
-
-    func test_loadIdentificationTypes_whenError_shouldSetReadyState() async {
-        // Arrange
-        let sut = self.makeSUT()
-        await sut.service.setIdentificationTypesResult(.failure(MockCheckoutService.MockError.resultNotSet))
-
-        // Act
-        await sut.viewModel.loadIdentificationTypes()
-
-        // Assert
         XCTAssertEqual(sut.viewModel.screenState, .ready)
     }
 
@@ -307,7 +295,7 @@ final class CardFormViewModelTests: XCTestCase {
         await sut.service.setIdentificationTypesResult(.failure(MockCheckoutService.MockError.resultNotSet))
 
         // Act
-        await sut.viewModel.loadIdentificationTypes()
+        try? await sut.viewModel.loadIdentificationTypes()
 
         // Assert
         XCTAssertEqual(sut.viewModel.selectTypeDocument, defaultDocument)
@@ -322,14 +310,14 @@ final class CardFormViewModelTests: XCTestCase {
         )
 
         // Act
-        await sut.viewModel.loadIdentificationTypes()
+        try? await sut.viewModel.loadIdentificationTypes()
 
         // Assert
         XCTAssertEqual(sut.viewModel.screenState, .ready)
         XCTAssertEqual(sut.viewModel.selectTypeDocument, IdentificationTypeStub.cpf)
     }
 
-    func test_loadIdentificationTypes_whenBothAttemptsFail_shouldSetReadyStateWithoutTypes() async {
+    func test_loadIdentificationTypes_whenBothAttemptsFail_shouldLeaveTypesEmpty() async {
         // Arrange — both attempts fail
         let sut = self.makeSUT()
         await sut.service.setSequentialIdentificationTypesResults(
@@ -338,10 +326,9 @@ final class CardFormViewModelTests: XCTestCase {
         )
 
         // Act
-        await sut.viewModel.loadIdentificationTypes()
+        try? await sut.viewModel.loadIdentificationTypes()
 
         // Assert
-        XCTAssertEqual(sut.viewModel.screenState, .ready)
         XCTAssertTrue(sut.viewModel.identificationTypes.isEmpty)
     }
 
@@ -710,70 +697,125 @@ final class CardFormViewModelTests: XCTestCase {
         XCTAssertEqual(sut.viewModel.footerAmount(), MPAmountData(from: 500.0))
     }
 
-    // MARK: - submitPaymentData
+    // MARK: - submitCardData
 
-    func test_submitPaymentData_whenServiceSucceeds_shouldReturnPaymentDataWithToken() async throws {
+    func test_submitCardData_whenServiceSucceeds_shouldCallOnSuccessWithToken() async {
         // Arrange
         let sut = self.makeSUT()
+        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binData)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
+        var capturedPaymentData: MPPaymentData?
 
         // Act
-        let result = try await sut.viewModel.submitPaymentData(nil, cardFormData: CardFormDataStub.validForm)
+        await sut.viewModel.submitCardData(
+            cardForm: CardFormDataStub.validForm,
+            transactionAmount: nil,
+            onSuccess: { capturedPaymentData = $0 },
+            onFailure: { XCTFail("Expected success, got error: \($0)") }
+        )
 
         // Assert
-        XCTAssertEqual(result.token, CardTokenStub.valid.token)
+        XCTAssertEqual(capturedPaymentData?.token, CardTokenStub.valid.token)
     }
 
-    func test_submitPaymentData_whenServiceFails_shouldThrowError() async {
+    func test_submitCardData_whenServiceFails_shouldCallOnFailure() async {
         // Arrange
         let sut = self.makeSUT()
         await sut.service.setCreateCardTokenResult(.failure(MockCheckoutService.MockError.resultNotSet))
+        var capturedError: MercadoPagoCheckoutError?
 
-        // Act & Assert
-        do {
-            _ = try await sut.viewModel.submitPaymentData(nil, cardFormData: CardFormDataStub.validForm)
-            XCTFail("Expected error to be thrown")
-        } catch {
-            XCTAssertTrue(error is MockCheckoutService.MockError)
-        }
+        // Act
+        await sut.viewModel.submitCardData(
+            cardForm: CardFormDataStub.validForm,
+            transactionAmount: nil,
+            onSuccess: { _ in XCTFail("Expected failure") },
+            onFailure: { capturedError = $0 }
+        )
+
+        // Assert
+        XCTAssertNotNil(capturedError)
     }
 
-    func test_submitPaymentData_shouldSetIsTokenizingTrue() async throws {
+    func test_submitCardData_whenBinDataIsNil_shouldCallOnFailure() async {
+        // Arrange — no bin fetch triggered, binData remains nil
+        let sut = self.makeSUT()
+        await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
+        var capturedError: MercadoPagoCheckoutError?
+
+        // Act
+        await sut.viewModel.submitCardData(
+            cardForm: CardFormDataStub.validForm,
+            transactionAmount: nil,
+            onSuccess: { _ in XCTFail("Expected failure due to missing bin data") },
+            onFailure: { capturedError = $0 }
+        )
+
+        // Assert
+        XCTAssertNotNil(capturedError)
+    }
+
+    func test_submitCardData_shouldResetIsTokenizingAfterCompletion() async {
         // Arrange
         let sut = self.makeSUT()
+        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binData)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
 
         // Act
-        _ = try await sut.viewModel.submitPaymentData(nil, cardFormData: CardFormDataStub.validForm)
+        await sut.viewModel.submitCardData(
+            cardForm: CardFormDataStub.validForm,
+            transactionAmount: nil,
+            onSuccess: { _ in },
+            onFailure: { _ in }
+        )
 
         // Assert
-        XCTAssertTrue(sut.viewModel.isTokenizing)
+        XCTAssertFalse(sut.viewModel.isTokenizing)
     }
 
-    func test_submitPaymentData_shouldStripSpacesFromCardNumber() async throws {
+    func test_submitCardData_shouldStripSpacesFromCardNumber() async {
         // Arrange
         let sut = self.makeSUT()
+        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binData)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
         var cardForm = CardFormDataStub.validForm
         cardForm.cardNumber = "4111 1111 1111 1111"
 
         // Act
-        _ = try await sut.viewModel.submitPaymentData(nil, cardFormData: cardForm)
+        await sut.viewModel.submitCardData(
+            cardForm: cardForm,
+            transactionAmount: nil,
+            onSuccess: { _ in },
+            onFailure: { XCTFail("Expected success, got error: \($0)") }
+        )
 
         // Assert
         let captured = await sut.service.capturedCardParams
         XCTAssertEqual(captured?.cardNumber, "4111111111111111")
     }
 
-    func test_submitPaymentData_shouldPrefixYearWithCurrentCentury() async throws {
+    func test_submitCardData_shouldPrefixYearWithCurrentCentury() async {
         // Arrange
         let sut = self.makeSUT()
+        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binData)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
         var cardForm = CardFormDataStub.validForm
         cardForm.expirationDate = "12/27"
 
         // Act
-        _ = try await sut.viewModel.submitPaymentData(nil, cardFormData: cardForm)
+        await sut.viewModel.submitCardData(
+            cardForm: cardForm,
+            transactionAmount: nil,
+            onSuccess: { _ in },
+            onFailure: { XCTFail("Expected success, got error: \($0)") }
+        )
 
         // Assert
         let captured = await sut.service.capturedCardParams
@@ -782,127 +824,151 @@ final class CardFormViewModelTests: XCTestCase {
         XCTAssertEqual(captured?.expirationMonth, "12")
     }
 
-    func test_submitPaymentData_shouldStripMaskFromDocument() async throws {
+    func test_submitCardData_shouldStripMaskFromDocument() async {
         // Arrange
         let sut = self.makeSUT()
+        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binData)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
         var cardForm = CardFormDataStub.validForm
         cardForm.documentHolder = "123.456.789-09"
 
         // Act
-        _ = try await sut.viewModel.submitPaymentData(nil, cardFormData: cardForm)
+        await sut.viewModel.submitCardData(
+            cardForm: cardForm,
+            transactionAmount: nil,
+            onSuccess: { _ in },
+            onFailure: { XCTFail("Expected success, got error: \($0)") }
+        )
 
         // Assert
         let captured = await sut.service.capturedCardParams
         XCTAssertEqual(captured?.documentNumber, "12345678909")
     }
 
-    func test_submitPaymentData_whenCalledWithDocumentTypeSelected_shouldPassDocumentType() async throws {
+    func test_submitCardData_whenCalledWithDocumentTypeSelected_shouldPassDocumentType() async {
         // Arrange
         let sut = self.makeSUT()
         await sut.service.setIdentificationTypesResult(.success([IdentificationTypeStub.cpf]))
-        await sut.viewModel.loadIdentificationTypes()
-        await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
-
-        // Act
-        _ = try await sut.viewModel.submitPaymentData(nil, cardFormData: CardFormDataStub.validForm)
-
-        // Assert
-        let captured = await sut.service.capturedCardParams
-        XCTAssertEqual(captured?.documentType, IdentificationTypeStub.cpf.id)
-    }
-
-    func test_submitPaymentData_whenDocumentTypeIsNil_shouldReturnOnlyToken() async throws {
-        // Arrange
-        let sut = self.makeSUT()
-        await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
-        // selectTypeDocument starts nil (no identificationTypes loaded)
-
-        // Act
-        let result = try await sut.viewModel.submitPaymentData(nil, cardFormData: CardFormDataStub.validForm)
-
-        // Assert
-        XCTAssertEqual(result.token, CardTokenStub.valid.token)
-        XCTAssertNil(result.transactionAmount)
-        XCTAssertNil(result.paymentMethodId)
-        XCTAssertNil(result.paymentTypeId)
-        XCTAssertNil(result.issuerId)
-        XCTAssertNil(result.payer)
-    }
-
-    func test_submitPaymentData_whenDocumentTypeIsSelected_shouldIncludePayer() async throws {
-        // Arrange
-        let sut = self.makeSUT()
-        await sut.service.setIdentificationTypesResult(.success([IdentificationTypeStub.cpf]))
-        await sut.viewModel.loadIdentificationTypes()
-        await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
-        var cardForm = CardFormDataStub.validForm
-        cardForm.documentHolder = "12345678900"
-
-        // Act
-        let result = try await sut.viewModel.submitPaymentData(200.0, cardFormData: cardForm)
-
-        // Assert
-        XCTAssertEqual(result.payer?.type, IdentificationTypeStub.cpf.type)
-        XCTAssertEqual(result.payer?.number, "12345678900")
-    }
-
-    func test_submitPaymentData_whenDocumentTypeIsSelected_shouldSetTransactionAmountAndInstallment() async throws {
-        // Arrange
-        let sut = self.makeSUT()
-        await sut.service.setIdentificationTypesResult(.success([IdentificationTypeStub.cpf]))
-        await sut.viewModel.loadIdentificationTypes()
-        await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
-
-        // Act
-        let result = try await sut.viewModel.submitPaymentData(350.0, cardFormData: CardFormDataStub.validForm)
-
-        // Assert
-        XCTAssertEqual(result.transactionAmount, 350.0)
-        XCTAssertEqual(result.installment, 1)
-        XCTAssertEqual(result.token, CardTokenStub.valid.token)
-    }
-
-    func test_submitPaymentData_whenBinDataIsAvailable_shouldIncludePaymentMethodAndTypeIds() async throws {
-        // Arrange
-        let sut = self.makeSUT()
-        await sut.service.setIdentificationTypesResult(.success([IdentificationTypeStub.cpf]))
-        await sut.viewModel.loadIdentificationTypes()
+        try? await sut.viewModel.loadIdentificationTypes()
         await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
         sut.viewModel.onCardNumberChange("12345678")
         await self.waitForChange(sut.viewModel.$binData)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
 
         // Act
-        let result = try await sut.viewModel.submitPaymentData(100.0, cardFormData: CardFormDataStub.validForm)
+        await sut.viewModel.submitCardData(
+            cardForm: CardFormDataStub.validForm,
+            transactionAmount: nil,
+            onSuccess: { _ in },
+            onFailure: { XCTFail("Expected success, got error: \($0)") }
+        )
 
         // Assert
-        XCTAssertEqual(result.paymentMethodId, "visa")
-        XCTAssertEqual(result.paymentTypeId, "credit_card")
+        let captured = await sut.service.capturedCardParams
+        XCTAssertEqual(captured?.documentType, IdentificationTypeStub.cpf.id)
     }
 
-    func test_submitPaymentData_whenBinDataIsNil_shouldHaveNilPaymentMethodIds() async throws {
-        // Arrange
+    func test_submitCardData_whenDocumentTypeIsNil_shouldHaveNilPayer() async {
+        // Arrange — no identificationTypes loaded, selectTypeDocument is nil
         let sut = self.makeSUT()
-        await sut.service.setIdentificationTypesResult(.success([IdentificationTypeStub.cpf]))
-        await sut.viewModel.loadIdentificationTypes()
+        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binData)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
-        // No bin fetch triggered — binData remains nil
+        var capturedPaymentData: MPPaymentData?
 
         // Act
-        let result = try await sut.viewModel.submitPaymentData(100.0, cardFormData: CardFormDataStub.validForm)
+        await sut.viewModel.submitCardData(
+            cardForm: CardFormDataStub.validForm,
+            transactionAmount: nil,
+            onSuccess: { capturedPaymentData = $0 },
+            onFailure: { XCTFail("Expected success, got error: \($0)") }
+        )
 
         // Assert
-        XCTAssertNil(result.paymentMethodId)
-        XCTAssertNil(result.paymentTypeId)
-        XCTAssertNil(result.issuerId)
+        XCTAssertNil(capturedPaymentData?.payer)
     }
 
-    func test_submitPaymentData_whenBinDataHasIssuer_shouldIncludeIssuerId() async throws {
+    func test_submitCardData_whenDocumentTypeIsSelected_shouldIncludePayer() async {
         // Arrange
         let sut = self.makeSUT()
         await sut.service.setIdentificationTypesResult(.success([IdentificationTypeStub.cpf]))
-        await sut.viewModel.loadIdentificationTypes()
+        try? await sut.viewModel.loadIdentificationTypes()
+        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binData)
+        await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
+        var cardForm = CardFormDataStub.validForm
+        cardForm.documentHolder = "12345678900"
+        var capturedPaymentData: MPPaymentData?
+
+        // Act
+        await sut.viewModel.submitCardData(
+            cardForm: cardForm,
+            transactionAmount: 200.0,
+            onSuccess: { capturedPaymentData = $0 },
+            onFailure: { XCTFail("Expected success, got error: \($0)") }
+        )
+
+        // Assert
+        XCTAssertEqual(capturedPaymentData?.payer?.type, IdentificationTypeStub.cpf.type)
+        XCTAssertEqual(capturedPaymentData?.payer?.number, "12345678900")
+    }
+
+    func test_submitCardData_whenDocumentTypeIsSelected_shouldSetTransactionAmountAndInstallment() async {
+        // Arrange
+        let sut = self.makeSUT()
+        await sut.service.setIdentificationTypesResult(.success([IdentificationTypeStub.cpf]))
+        try? await sut.viewModel.loadIdentificationTypes()
+        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binData)
+        await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
+        var capturedPaymentData: MPPaymentData?
+
+        // Act
+        await sut.viewModel.submitCardData(
+            cardForm: CardFormDataStub.validForm,
+            transactionAmount: 350.0,
+            onSuccess: { capturedPaymentData = $0 },
+            onFailure: { XCTFail("Expected success, got error: \($0)") }
+        )
+
+        // Assert
+        XCTAssertEqual(capturedPaymentData?.transactionAmount, 350.0)
+        XCTAssertEqual(capturedPaymentData?.installment, 1)
+        XCTAssertEqual(capturedPaymentData?.token, CardTokenStub.valid.token)
+    }
+
+    func test_submitCardData_whenBinDataIsAvailable_shouldIncludePaymentMethodAndTypeIds() async {
+        // Arrange
+        let sut = self.makeSUT()
+        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binData)
+        await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
+        var capturedPaymentData: MPPaymentData?
+
+        // Act
+        await sut.viewModel.submitCardData(
+            cardForm: CardFormDataStub.validForm,
+            transactionAmount: 100.0,
+            onSuccess: { capturedPaymentData = $0 },
+            onFailure: { XCTFail("Expected success, got error: \($0)") }
+        )
+
+        // Assert
+        XCTAssertEqual(capturedPaymentData?.paymentMethodId, "visa")
+        XCTAssertEqual(capturedPaymentData?.paymentTypeId, "credit_card")
+    }
+
+    func test_submitCardData_whenBinDataHasIssuer_shouldIncludeIssuerId() async {
+        // Arrange
+        let sut = self.makeSUT()
+        await sut.service.setIdentificationTypesResult(.success([IdentificationTypeStub.cpf]))
+        try? await sut.viewModel.loadIdentificationTypes()
         let binDataWithIssuer = CardBinData(
             paymentMethod: CardBinDataStub.visa.paymentMethod,
             issuer: IssuerStub.bradesco,
@@ -912,12 +978,18 @@ final class CardFormViewModelTests: XCTestCase {
         sut.viewModel.onCardNumberChange("12345678")
         await self.waitForChange(sut.viewModel.$binData)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
+        var capturedPaymentData: MPPaymentData?
 
         // Act
-        let result = try await sut.viewModel.submitPaymentData(100.0, cardFormData: CardFormDataStub.validForm)
+        await sut.viewModel.submitCardData(
+            cardForm: CardFormDataStub.validForm,
+            transactionAmount: 100.0,
+            onSuccess: { capturedPaymentData = $0 },
+            onFailure: { XCTFail("Expected success, got error: \($0)") }
+        )
 
         // Assert
-        XCTAssertEqual(result.issuerId, IssuerStub.bradesco.id)
+        XCTAssertEqual(capturedPaymentData?.issuerId, IssuerStub.bradesco.id)
     }
 
     func test_retryBinFetch_whenCalledTwice_withNetworkError_shouldShowSnackbarBothTimes() async {


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
https://mercadolibre.atlassian.net/browse/CHOBK-3736
https://mercadolibre.atlassian.net/browse/CHOBK-3738

## Description
- Added `MercadoPagoCheckoutError` public model with code-based error classification and factory methods for network/service errors (`MercadoPagoCheckoutError+Network.swift`, `MercadoPagoCheckoutError+Error.swift`)
- Added `MPCancelledFormContext` public model that captures the state of each form field (valid/empty/incomplete/invalid) at the time of user cancellation
- Updated `MercadoPagoCheckoutResult.userCancelled` to carry `MPCancelledFormContext`, giving integrators visibility into form state on dismiss
- Introduced `CardAcceptanceError` (package-internal) with `paymentMethodNotAllowed` and `paymentTypeNotAllowed` cases, replacing generic errors in BIN validation
- Removed `paymentMethodNotFound` from UI-level validation rules — now handled at the service/domain layer
- `CardFormBrick.fail()` now properly dismisses the checkout view and clears navigation state before calling `onResult(.error(...))`
- Improved `CardFormViewModel` error propagation and refactored `onBack` callback to pass `MPCancelledFormContext`
- Updated tests (`CardFormViewModelTests`, `FetchBinDataUseCaseTests`, `MockCheckoutService`) to cover new error paths, card acceptance errors, and cancelled form context

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [x] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>