### PR TITLE
[CHOBK-3687] (Feature): Card Form initialization domain layer

### DIFF
--- a/Sources/MercadoPagoCheckout/Data/Repositories/LocalCardFormInitializationRepository.swift
+++ b/Sources/MercadoPagoCheckout/Data/Repositories/LocalCardFormInitializationRepository.swift
@@ -1,0 +1,85 @@
+//
+//  LocalCardFormInitializationRepository.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 16/03/26.
+//
+
+import CoreMethods
+import MPFoundation
+
+/// Returns initialization data from local MPStrings and identification types from the service.
+struct LocalCardFormInitializationRepository: CardFormInitializationRepository {
+    private let service: CheckoutServiceProtocol
+
+    init(service: CheckoutServiceProtocol = CheckoutService()) {
+        self.service = service
+    }
+
+    func fetchInitialization() async throws -> CardFormInitializationInput {
+        let identificationTypes = try await service.identificationTypes()
+
+        return CardFormInitializationInput(
+            title: MPStrings.CardForm.title,
+            buttonVariants: .init(
+                save: MPStrings.CardForm.button,
+                pay: ""
+            ),
+            fields: .init(
+                cardNumber: .init(
+                    label: MPStrings.CardForm.CardNumber.label,
+                    placeholder: MPStrings.CardForm.CardNumber.placeholder,
+                    validation: .init(
+                        errorEmpty: MPStrings.CardForm.CardNumber.errorEmpty,
+                        errorIncomplete: MPStrings.CardForm.CardNumber.errorIncomplete,
+                        errorInvalid: MPStrings.CardForm.CardNumber.errorInvalid,
+                        errorSellerExclusion: MPStrings.CardForm.CardNumber.errorSellerExclusion(brand: "%@"),
+                        errorTypeNotAllowed: MPStrings.CardForm.CardNumber.errorTypeNotAllowed(cardType: "%@")
+                    )
+                ),
+                cardHolder: .init(
+                    label: MPStrings.CardForm.CardHolder.label,
+                    placeholder: MPStrings.CardForm.CardHolder.placeholder,
+                    helperText: MPStrings.CardForm.CardHolder.helperText,
+                    validation: .init(
+                        errorEmpty: MPStrings.CardForm.CardHolder.errorEmpty,
+                        errorIncomplete: MPStrings.CardForm.CardHolder.errorIncomplete,
+                        errorInvalidFormat: MPStrings.CardForm.CardHolder.errorInvalidFormat
+                    )
+                ),
+                expiration: .init(
+                    label: MPStrings.CardForm.Expiration.label,
+                    placeholder: MPStrings.CardForm.Expiration.placeholder,
+                    validation: .init(
+                        errorEmpty: MPStrings.CardForm.Expiration.errorEmpty,
+                        errorIncomplete: MPStrings.CardForm.Expiration.errorIncomplete,
+                        errorInvalid: MPStrings.CardForm.Expiration.errorInvalid
+                    )
+                ),
+                cvv: .init(
+                    label: MPStrings.CardForm.CVV.label,
+                    placeholderDefault: MPStrings.CardForm.CVV.placeholderDefault,
+                    placeholderAmex: MPStrings.CardForm.CVV.placeholderAmex,
+                    validation: .init(
+                        errorEmpty: MPStrings.CardForm.CVV.errorEmpty,
+                        errorIncomplete: MPStrings.CardForm.CVV.errorIncomplete
+                    )
+                ),
+                issuer: .init(
+                    label: MPStrings.CardForm.Issuer.label,
+                    placeholder: MPStrings.CardForm.Issuer.placeholder
+                ),
+                document: .init(
+                    label: MPStrings.CardForm.Document.label,
+                    placeholder: MPStrings.CardForm.Document.placeholder,
+                    validation: .init(
+                        errorEmpty: MPStrings.CardForm.Document.errorEmpty,
+                        errorIncomplete: MPStrings.CardForm.Document.errorIncomplete,
+                        errorInvalid: MPStrings.CardForm.Document.errorInvalid
+                    )
+                )
+            ),
+            identificationTypes: identificationTypes
+        )
+    }
+}

--- a/Sources/MercadoPagoCheckout/Domain/Model/CardFormInitializationInput.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Model/CardFormInitializationInput.swift
@@ -1,0 +1,23 @@
+//
+//  CardFormInitializationInput.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 16/03/26.
+//
+
+import CoreMethods
+
+/// Input entity returned by the repository.
+/// Contains all raw data needed for business decisions (e.g. button variants in future).
+/// The UseCase consumes this and produces a `CardFormInitializationOutput` (output entity).
+struct CardFormInitializationInput {
+    let title: String
+    let buttonVariants: ButtonVariants
+    let fields: CardFormTexts.Fields
+    let identificationTypes: [IdentificationType]
+
+    struct ButtonVariants {
+        let save: String
+        let pay: String
+    }
+}

--- a/Sources/MercadoPagoCheckout/Domain/Model/CardFormInitializationOutput.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Model/CardFormInitializationOutput.swift
@@ -1,0 +1,15 @@
+//
+//  CardFormInitializationOutput.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 16/03/26.
+//
+
+import CoreMethods
+
+struct CardFormInitializationOutput {
+    let title: String
+    let button: String
+    let fields: CardFormTexts.Fields
+    let identificationTypes: [IdentificationType]
+}

--- a/Sources/MercadoPagoCheckout/Domain/Model/CardFormTexts.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Model/CardFormTexts.swift
@@ -1,0 +1,85 @@
+//
+//  CardFormTexts.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 16/03/26.
+//
+
+enum CardFormTexts {
+    struct Fields {
+        let cardNumber: CardNumberField
+        let cardHolder: CardHolderField
+        let expiration: ExpirationField
+        let cvv: CVVField
+        let issuer: IssuerField
+        let document: DocumentField
+    }
+
+    struct CardNumberField {
+        let label: String
+        let placeholder: String
+        let validation: Validation
+
+        struct Validation {
+            let errorEmpty: String
+            let errorIncomplete: String
+            let errorInvalid: String
+            let errorSellerExclusion: String
+            let errorTypeNotAllowed: String
+        }
+    }
+
+    struct CardHolderField {
+        let label: String
+        let placeholder: String
+        let helperText: String
+        let validation: Validation
+
+        struct Validation {
+            let errorEmpty: String
+            let errorIncomplete: String
+            let errorInvalidFormat: String
+        }
+    }
+
+    struct ExpirationField {
+        let label: String
+        let placeholder: String
+        let validation: Validation
+
+        struct Validation {
+            let errorEmpty: String
+            let errorIncomplete: String
+            let errorInvalid: String
+        }
+    }
+
+    struct CVVField {
+        let label: String
+        let placeholderDefault: String
+        let placeholderAmex: String
+        let validation: Validation
+
+        struct Validation {
+            let errorEmpty: String
+            let errorIncomplete: String
+        }
+    }
+
+    struct IssuerField {
+        let label: String
+        let placeholder: String
+    }
+
+    struct DocumentField {
+        let label: String
+        let placeholder: String
+        let validation: Validation
+
+        struct Validation {
+            let errorEmpty: String
+            let errorIncomplete: String
+            let errorInvalid: String
+        }
+    }
+}

--- a/Sources/MercadoPagoCheckout/Domain/Repositories/CardFormInitializationRepository.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Repositories/CardFormInitializationRepository.swift
@@ -1,0 +1,12 @@
+//
+//  CardFormInitializationRepository.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 16/03/26.
+//
+
+/// Abstraction for fetching card form initialization data.
+/// Current implementation is local (MPStrings + service). Future: remote endpoint.
+protocol CardFormInitializationRepository: Sendable {
+    func fetchInitialization() async throws -> CardFormInitializationInput
+}

--- a/Sources/MercadoPagoCheckout/Domain/UseCases/InitializeCardFormUseCase.swift
+++ b/Sources/MercadoPagoCheckout/Domain/UseCases/InitializeCardFormUseCase.swift
@@ -1,0 +1,95 @@
+//
+//  InitializeCardFormUseCase.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 16/03/26.
+//
+
+import CoreMethods
+
+/// Orchestrates fetching all initialization data for the CardForm screen.
+/// Applies business rules: resolves button variant and custom texts over defaults.
+struct InitializeCardFormUseCase: Sendable {
+    private let repository: CardFormInitializationRepository
+
+    init(repository: CardFormInitializationRepository = LocalCardFormInitializationRepository()) {
+        self.repository = repository
+    }
+
+    /// Fetches initialization data from the repository,
+    /// then applies business rules (button selection, custom text overrides).
+    func execute(config: MercadoPagoCheckout.CardFormConfiguration) async throws -> CardFormInitializationOutput {
+        let data = try await repository.fetchInitialization()
+        return self.mapToResult(data: data, config: config)
+    }
+
+    // MARK: - Business Rules
+
+    private func mapToResult(
+        data: CardFormInitializationInput,
+        config _: MercadoPagoCheckout.CardFormConfiguration
+    ) -> CardFormInitializationOutput {
+        let custom: CardFormCustomTexts? = nil
+        let fields = data.fields
+
+        return CardFormInitializationOutput(
+            title: custom?.title ?? data.title,
+            button: custom?.button ?? data.buttonVariants.save,
+            fields: .init(
+                cardNumber: .init(
+                    label: custom?.cardNumber?.label ?? fields.cardNumber.label,
+                    placeholder: custom?.cardNumber?.placeholder ?? fields.cardNumber.placeholder,
+                    validation: .init(
+                        errorEmpty: fields.cardNumber.validation.errorEmpty,
+                        errorIncomplete: fields.cardNumber.validation.errorIncomplete,
+                        errorInvalid: fields.cardNumber.validation.errorInvalid,
+                        errorSellerExclusion: fields.cardNumber.validation.errorSellerExclusion,
+                        errorTypeNotAllowed: fields.cardNumber.validation.errorTypeNotAllowed
+                    )
+                ),
+                cardHolder: .init(
+                    label: custom?.cardHolder?.label ?? fields.cardHolder.label,
+                    placeholder: custom?.cardHolder?.placeholder ?? fields.cardHolder.placeholder,
+                    helperText: fields.cardHolder.helperText,
+                    validation: .init(
+                        errorEmpty: fields.cardHolder.validation.errorEmpty,
+                        errorIncomplete: fields.cardHolder.validation.errorIncomplete,
+                        errorInvalidFormat: fields.cardHolder.validation.errorInvalidFormat
+                    )
+                ),
+                expiration: .init(
+                    label: custom?.expiration?.label ?? fields.expiration.label,
+                    placeholder: custom?.expiration?.placeholder ?? fields.expiration.placeholder,
+                    validation: .init(
+                        errorEmpty: fields.expiration.validation.errorEmpty,
+                        errorIncomplete: fields.expiration.validation.errorIncomplete,
+                        errorInvalid: fields.expiration.validation.errorInvalid
+                    )
+                ),
+                cvv: .init(
+                    label: custom?.cvv?.label ?? fields.cvv.label,
+                    placeholderDefault: custom?.cvv?.placeholder ?? fields.cvv.placeholderDefault,
+                    placeholderAmex: custom?.cvv?.placeholder ?? fields.cvv.placeholderAmex,
+                    validation: .init(
+                        errorEmpty: fields.cvv.validation.errorEmpty,
+                        errorIncomplete: fields.cvv.validation.errorIncomplete
+                    )
+                ),
+                issuer: .init(
+                    label: custom?.issuer?.label ?? fields.issuer.label,
+                    placeholder: custom?.issuer?.placeholder ?? fields.issuer.placeholder
+                ),
+                document: .init(
+                    label: custom?.document?.label ?? fields.document.label,
+                    placeholder: custom?.document?.placeholder ?? fields.document.placeholder,
+                    validation: .init(
+                        errorEmpty: fields.document.validation.errorEmpty,
+                        errorIncomplete: fields.document.validation.errorIncomplete,
+                        errorInvalid: fields.document.validation.errorInvalid
+                    )
+                )
+            ),
+            identificationTypes: data.identificationTypes
+        )
+    }
+}

--- a/Sources/MercadoPagoCheckout/Domain/UseCases/InitializeCardFormUseCase.swift
+++ b/Sources/MercadoPagoCheckout/Domain/UseCases/InitializeCardFormUseCase.swift
@@ -29,16 +29,15 @@ struct InitializeCardFormUseCase: Sendable {
         data: CardFormInitializationInput,
         config _: MercadoPagoCheckout.CardFormConfiguration
     ) -> CardFormInitializationOutput {
-        let custom: CardFormCustomTexts? = nil
         let fields = data.fields
 
         return CardFormInitializationOutput(
-            title: custom?.title ?? data.title,
-            button: custom?.button ?? data.buttonVariants.save,
+            title: data.title,
+            button: data.buttonVariants.save,
             fields: .init(
                 cardNumber: .init(
-                    label: custom?.cardNumber?.label ?? fields.cardNumber.label,
-                    placeholder: custom?.cardNumber?.placeholder ?? fields.cardNumber.placeholder,
+                    label: fields.cardNumber.label,
+                    placeholder: fields.cardNumber.placeholder,
                     validation: .init(
                         errorEmpty: fields.cardNumber.validation.errorEmpty,
                         errorIncomplete: fields.cardNumber.validation.errorIncomplete,
@@ -48,8 +47,8 @@ struct InitializeCardFormUseCase: Sendable {
                     )
                 ),
                 cardHolder: .init(
-                    label: custom?.cardHolder?.label ?? fields.cardHolder.label,
-                    placeholder: custom?.cardHolder?.placeholder ?? fields.cardHolder.placeholder,
+                    label: fields.cardHolder.label,
+                    placeholder: fields.cardHolder.placeholder,
                     helperText: fields.cardHolder.helperText,
                     validation: .init(
                         errorEmpty: fields.cardHolder.validation.errorEmpty,
@@ -58,8 +57,8 @@ struct InitializeCardFormUseCase: Sendable {
                     )
                 ),
                 expiration: .init(
-                    label: custom?.expiration?.label ?? fields.expiration.label,
-                    placeholder: custom?.expiration?.placeholder ?? fields.expiration.placeholder,
+                    label: fields.expiration.label,
+                    placeholder: fields.expiration.placeholder,
                     validation: .init(
                         errorEmpty: fields.expiration.validation.errorEmpty,
                         errorIncomplete: fields.expiration.validation.errorIncomplete,
@@ -67,21 +66,21 @@ struct InitializeCardFormUseCase: Sendable {
                     )
                 ),
                 cvv: .init(
-                    label: custom?.cvv?.label ?? fields.cvv.label,
-                    placeholderDefault: custom?.cvv?.placeholder ?? fields.cvv.placeholderDefault,
-                    placeholderAmex: custom?.cvv?.placeholder ?? fields.cvv.placeholderAmex,
+                    label: fields.cvv.label,
+                    placeholderDefault: fields.cvv.placeholderDefault,
+                    placeholderAmex: fields.cvv.placeholderAmex,
                     validation: .init(
                         errorEmpty: fields.cvv.validation.errorEmpty,
                         errorIncomplete: fields.cvv.validation.errorIncomplete
                     )
                 ),
                 issuer: .init(
-                    label: custom?.issuer?.label ?? fields.issuer.label,
-                    placeholder: custom?.issuer?.placeholder ?? fields.issuer.placeholder
+                    label: fields.issuer.label,
+                    placeholder: fields.issuer.placeholder
                 ),
                 document: .init(
-                    label: custom?.document?.label ?? fields.document.label,
-                    placeholder: custom?.document?.placeholder ?? fields.document.placeholder,
+                    label: fields.document.label,
+                    placeholder: fields.document.placeholder,
                     validation: .init(
                         errorEmpty: fields.document.validation.errorEmpty,
                         errorIncomplete: fields.document.validation.errorIncomplete,

--- a/Tests/MercadoPagoCheckoutTests/Data/LocalCardFormInitializationRepositoryTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Data/LocalCardFormInitializationRepositoryTests.swift
@@ -1,0 +1,127 @@
+//
+//  LocalCardFormInitializationRepositoryTests.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 16/03/26.
+//
+
+@testable import CoreMethods
+@testable import MercadoPagoCheckout
+@testable import MPFoundation
+import XCTest
+
+final class LocalCardFormInitializationRepositoryTests: XCTestCase {
+    // MARK: - Helpers
+
+    private func makeSUT() async -> (repository: LocalCardFormInitializationRepository, service: MockCheckoutService) {
+        let service = MockCheckoutService()
+        await service.setIdentificationTypesResult(.success([]))
+        let repository = LocalCardFormInitializationRepository(service: service)
+        return (repository, service)
+    }
+
+    // MARK: - Tests
+
+    func testFetchReturnsAllFields() async throws {
+        // Arrange
+        let sut = await makeSUT()
+
+        // Act
+        let data = try await sut.repository.fetchInitialization()
+
+        // Assert
+        XCTAssertFalse(data.title.isEmpty)
+        XCTAssertFalse(data.buttonVariants.save.isEmpty)
+        XCTAssertFalse(data.fields.cardNumber.label.isEmpty)
+        XCTAssertFalse(data.fields.cardNumber.placeholder.isEmpty)
+        XCTAssertFalse(data.fields.cardHolder.label.isEmpty)
+        XCTAssertFalse(data.fields.cardHolder.placeholder.isEmpty)
+        XCTAssertFalse(data.fields.expiration.label.isEmpty)
+        XCTAssertFalse(data.fields.expiration.placeholder.isEmpty)
+        XCTAssertFalse(data.fields.cvv.label.isEmpty)
+        XCTAssertFalse(data.fields.cvv.placeholderDefault.isEmpty)
+        XCTAssertFalse(data.fields.cvv.placeholderAmex.isEmpty)
+        XCTAssertFalse(data.fields.issuer.label.isEmpty)
+        XCTAssertFalse(data.fields.issuer.placeholder.isEmpty)
+        XCTAssertFalse(data.fields.document.label.isEmpty)
+        XCTAssertFalse(data.fields.document.placeholder.isEmpty)
+    }
+
+    func testTitleMatchesMPStrings() async throws {
+        // Arrange
+        let sut = await makeSUT()
+
+        // Act
+        let data = try await sut.repository.fetchInitialization()
+
+        // Assert
+        XCTAssertEqual(data.title, MPStrings.CardForm.title)
+    }
+
+    func testButtonVariantsSaveExists() async throws {
+        // Arrange
+        let sut = await makeSUT()
+
+        // Act
+        let data = try await sut.repository.fetchInitialization()
+
+        // Assert
+        XCTAssertFalse(data.buttonVariants.save.isEmpty)
+    }
+
+    func testCardNumberLabelsMatchMPStrings() async throws {
+        // Arrange
+        let sut = await makeSUT()
+
+        // Act
+        let data = try await sut.repository.fetchInitialization()
+
+        // Assert
+        XCTAssertEqual(data.fields.cardNumber.label, MPStrings.CardForm.CardNumber.label)
+        XCTAssertEqual(data.fields.cardNumber.placeholder, MPStrings.CardForm.CardNumber.placeholder)
+    }
+
+    func testValidationTexts_cardNumber() async throws {
+        // Arrange
+        let sut = await makeSUT()
+
+        // Act
+        let data = try await sut.repository.fetchInitialization()
+        let validation = data.fields.cardNumber.validation
+
+        // Assert
+        XCTAssertEqual(validation.errorEmpty, MPStrings.CardForm.CardNumber.errorEmpty)
+        XCTAssertEqual(validation.errorIncomplete, MPStrings.CardForm.CardNumber.errorIncomplete)
+        XCTAssertEqual(validation.errorInvalid, MPStrings.CardForm.CardNumber.errorInvalid)
+    }
+
+    func testFetchReturnsIdentificationTypes() async throws {
+        // Arrange
+        let service = MockCheckoutService()
+        let expectedType = IdentificationType(id: "CPF", name: "CPF", type: "number", minLenght: 11, maxLenght: 11)
+        await service.setIdentificationTypesResult(.success([expectedType]))
+        let repository = LocalCardFormInitializationRepository(service: service)
+
+        // Act
+        let data = try await repository.fetchInitialization()
+
+        // Assert
+        XCTAssertEqual(data.identificationTypes.count, 1)
+        XCTAssertEqual(data.identificationTypes.first?.id, "CPF")
+    }
+
+    func testFetchPropagatesServiceError() async {
+        // Arrange
+        let service = MockCheckoutService()
+        await service.setIdentificationTypesResult(.failure(MockCheckoutService.MockError.resultNotSet))
+        let repository = LocalCardFormInitializationRepository(service: service)
+
+        // Act & Assert
+        do {
+            _ = try await repository.fetchInitialization()
+            XCTFail("Expected error to propagate")
+        } catch {
+            XCTAssertTrue(error is MockCheckoutService.MockError)
+        }
+    }
+}

--- a/Tests/MercadoPagoCheckoutTests/Mocks/CardFormInitializationStub.swift
+++ b/Tests/MercadoPagoCheckoutTests/Mocks/CardFormInitializationStub.swift
@@ -1,0 +1,130 @@
+//
+//  CardFormInitializationStub.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 16/03/26.
+//
+
+@testable import MercadoPagoCheckout
+
+// MARK: - Input (CardFormInitializationInput - Repository → UseCase)
+
+enum CardFormInitializationInputStub {
+    static func makeDefaultFields() -> CardFormTexts.Fields {
+        .init(
+            cardNumber: .init(
+                label: "Card number",
+                placeholder: "0000 0000 0000 0000",
+                validation: .init(
+                    errorEmpty: "Enter a card number",
+                    errorIncomplete: "Card number is incomplete",
+                    errorInvalid: "Card number is invalid",
+                    errorSellerExclusion: "%@ is not accepted",
+                    errorTypeNotAllowed: "%@ cards are not accepted"
+                )
+            ),
+            cardHolder: .init(
+                label: "Cardholder name",
+                placeholder: "e.g. JOHN DOE",
+                helperText: "As shown on card",
+                validation: .init(
+                    errorEmpty: "Enter a name",
+                    errorIncomplete: "Name is too short",
+                    errorInvalidFormat: "Invalid characters"
+                )
+            ),
+            expiration: .init(
+                label: "Expiration",
+                placeholder: "MM/YY",
+                validation: .init(
+                    errorEmpty: "Enter expiration",
+                    errorIncomplete: "Expiration incomplete",
+                    errorInvalid: "Expiration invalid"
+                )
+            ),
+            cvv: .init(
+                label: "Security code",
+                placeholderDefault: "123",
+                placeholderAmex: "1234",
+                validation: .init(
+                    errorEmpty: "Enter security code",
+                    errorIncomplete: "Security code incomplete"
+                )
+            ),
+            issuer: .init(
+                label: "Issuer",
+                placeholder: "Select issuer"
+            ),
+            document: .init(
+                label: "Document",
+                placeholder: "Enter document",
+                validation: .init(
+                    errorEmpty: "Enter document",
+                    errorIncomplete: "Document incomplete",
+                    errorInvalid: "Document invalid"
+                )
+            )
+        )
+    }
+}
+
+// MARK: - Output (CardFormInitializationOutput - UseCase output)
+
+enum CardFormInitializationOutputStub {
+    static func makeDefaultFields() -> CardFormTexts.Fields {
+        .init(
+            cardNumber: .init(
+                label: "Card number",
+                placeholder: "0000 0000 0000 0000",
+                validation: .init(
+                    errorEmpty: "Enter a card number",
+                    errorIncomplete: "Card number is incomplete",
+                    errorInvalid: "Card number is invalid",
+                    errorSellerExclusion: "%@ is not accepted",
+                    errorTypeNotAllowed: "%@ cards are not accepted"
+                )
+            ),
+            cardHolder: .init(
+                label: "Cardholder name",
+                placeholder: "e.g. JOHN DOE",
+                helperText: "As shown on card",
+                validation: .init(
+                    errorEmpty: "Enter a name",
+                    errorIncomplete: "Name is too short",
+                    errorInvalidFormat: "Invalid characters"
+                )
+            ),
+            expiration: .init(
+                label: "Expiration",
+                placeholder: "MM/YY",
+                validation: .init(
+                    errorEmpty: "Enter expiration",
+                    errorIncomplete: "Expiration incomplete",
+                    errorInvalid: "Expiration invalid"
+                )
+            ),
+            cvv: .init(
+                label: "Security code",
+                placeholderDefault: "123",
+                placeholderAmex: "1234",
+                validation: .init(
+                    errorEmpty: "Enter security code",
+                    errorIncomplete: "Security code incomplete"
+                )
+            ),
+            issuer: .init(
+                label: "Issuer",
+                placeholder: "Select issuer"
+            ),
+            document: .init(
+                label: "Document",
+                placeholder: "Enter document",
+                validation: .init(
+                    errorEmpty: "Enter document",
+                    errorIncomplete: "Document incomplete",
+                    errorInvalid: "Document invalid"
+                )
+            )
+        )
+    }
+}

--- a/Tests/MercadoPagoCheckoutTests/Mocks/MockCardFormInitializationRepository.swift
+++ b/Tests/MercadoPagoCheckoutTests/Mocks/MockCardFormInitializationRepository.swift
@@ -1,0 +1,38 @@
+//
+//  MockCardFormInitializationRepository.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 16/03/26.
+//
+
+import CoreMethods
+import Foundation
+@testable import MercadoPagoCheckout
+
+final class MockCardFormInitializationRepository: CardFormInitializationRepository {
+    nonisolated(unsafe) var mockData: CardFormInitializationInput?
+    nonisolated(unsafe) var shouldThrow = false
+
+    func fetchInitialization() async throws -> CardFormInitializationInput {
+        if self.shouldThrow { throw NSError(domain: "test", code: -1) }
+        return self.mockData ?? Self.makeDefault()
+    }
+
+    static func makeDefault() -> CardFormInitializationInput {
+        CardFormInitializationInput(
+            title: "Default Header",
+            buttonVariants: .init(save: "Save", pay: ""),
+            fields: CardFormInitializationInputStub.makeDefaultFields(),
+            identificationTypes: []
+        )
+    }
+
+    static func makeDefault(identificationTypes: [IdentificationType]) -> CardFormInitializationInput {
+        CardFormInitializationInput(
+            title: "Default Header",
+            buttonVariants: .init(save: "Save", pay: ""),
+            fields: CardFormInitializationInputStub.makeDefaultFields(),
+            identificationTypes: identificationTypes
+        )
+    }
+}

--- a/Tests/MercadoPagoCheckoutTests/UseCases/InitializeCardFormUseCaseTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/UseCases/InitializeCardFormUseCaseTests.swift
@@ -36,10 +36,9 @@ final class InitializeCardFormUseCaseTests: XCTestCase {
     }
 
     private func makeConfig(
-        amount: Double? = nil,
-        customTexts: CardFormCustomTexts? = nil
+        amount: Double? = nil
     ) -> MercadoPagoCheckout.CardFormConfiguration {
-        MercadoPagoCheckout.CardFormConfiguration(amount: amount, customTexts: customTexts)
+        MercadoPagoCheckout.CardFormConfiguration(amount: amount)
     }
 
     // MARK: - Success Cases
@@ -80,29 +79,7 @@ final class InitializeCardFormUseCaseTests: XCTestCase {
         XCTAssertEqual(result.fields.document.placeholder, defaultFields.document.placeholder)
     }
 
-    // MARK: - Text Resolution (custom title)
-
-    func testExecute_customTitle_overridesHeader() async throws {
-        let sut = self.makeSUT()
-        let customTexts = CardFormCustomTexts(title: "My Custom Title")
-        let result = try await sut.useCase.execute(config: self.makeConfig(customTexts: customTexts))
-
-        XCTAssertEqual(result.title, "My Custom Title")
-    }
-
-    // MARK: - Text Resolution (partial customization)
-
-    func testExecute_partialCardNumber_overridesOnlyLabel() async throws {
-        let sut = self.makeSUT()
-        let customTexts = CardFormCustomTexts(cardNumber: .init(label: "Custom Card Number Label"))
-        let result = try await sut.useCase.execute(config: self.makeConfig(customTexts: customTexts))
-        let defaultFields = CardFormInitializationOutputStub.makeDefaultFields()
-
-        XCTAssertEqual(result.fields.cardNumber.label, "Custom Card Number Label")
-        XCTAssertEqual(result.fields.cardNumber.placeholder, defaultFields.cardNumber.placeholder)
-    }
-
-    // MARK: - Text Resolution (CVV placeholder)
+    // MARK: - CVV placeholders
 
     func testExecute_noCvvCustom_preservesBothPlaceholders() async throws {
         let sut = self.makeSUT()
@@ -111,83 +88,6 @@ final class InitializeCardFormUseCaseTests: XCTestCase {
 
         XCTAssertEqual(result.fields.cvv.placeholderDefault, defaultFields.cvv.placeholderDefault)
         XCTAssertEqual(result.fields.cvv.placeholderAmex, defaultFields.cvv.placeholderAmex)
-    }
-
-    func testExecute_customCvvPlaceholder_overridesBoth() async throws {
-        let sut = self.makeSUT()
-        let customTexts = CardFormCustomTexts(cvv: .init(placeholder: "Custom CVV"))
-        let result = try await sut.useCase.execute(config: self.makeConfig(customTexts: customTexts))
-
-        XCTAssertEqual(result.fields.cvv.placeholderDefault, "Custom CVV")
-        XCTAssertEqual(result.fields.cvv.placeholderAmex, "Custom CVV")
-    }
-
-    // MARK: - Text Resolution (empty custom texts = nil)
-
-    func testExecute_emptyCustomTexts_sameAsNil() async throws {
-        let sut = self.makeSUT()
-        let withEmpty = try await sut.useCase.execute(config: self.makeConfig(customTexts: CardFormCustomTexts()))
-        let withNil = try await sut.useCase.execute(config: self.makeConfig())
-
-        XCTAssertEqual(withEmpty.title, withNil.title)
-        XCTAssertEqual(withEmpty.fields.cardNumber.label, withNil.fields.cardNumber.label)
-        XCTAssertEqual(withEmpty.fields.cardNumber.placeholder, withNil.fields.cardNumber.placeholder)
-        XCTAssertEqual(withEmpty.fields.cardHolder.label, withNil.fields.cardHolder.label)
-        XCTAssertEqual(withEmpty.fields.cardHolder.placeholder, withNil.fields.cardHolder.placeholder)
-        XCTAssertEqual(withEmpty.fields.expiration.label, withNil.fields.expiration.label)
-        XCTAssertEqual(withEmpty.fields.expiration.placeholder, withNil.fields.expiration.placeholder)
-        XCTAssertEqual(withEmpty.fields.cvv.label, withNil.fields.cvv.label)
-        XCTAssertEqual(withEmpty.fields.issuer.label, withNil.fields.issuer.label)
-        XCTAssertEqual(withEmpty.fields.issuer.placeholder, withNil.fields.issuer.placeholder)
-        XCTAssertEqual(withEmpty.fields.document.label, withNil.fields.document.label)
-        XCTAssertEqual(withEmpty.fields.document.placeholder, withNil.fields.document.placeholder)
-    }
-
-    // MARK: - Text Resolution (all fields customized)
-
-    func testExecute_allFieldsCustomized() async throws {
-        let sut = self.makeSUT()
-        let customTexts = CardFormCustomTexts(
-            title: "CT",
-            cardNumber: .init(label: "CN-L", placeholder: "CN-P"),
-            cardHolder: .init(label: "CH-L", placeholder: "CH-P"),
-            expiration: .init(label: "EX-L", placeholder: "EX-P"),
-            cvv: .init(label: "CV-L", placeholder: "CV-P"),
-            issuer: .init(label: "IS-L", placeholder: "IS-P"),
-            document: .init(label: "DO-L", placeholder: "DO-P")
-        )
-        let result = try await sut.useCase.execute(config: self.makeConfig(customTexts: customTexts))
-
-        XCTAssertEqual(result.title, "CT")
-        XCTAssertEqual(result.fields.cardNumber.label, "CN-L")
-        XCTAssertEqual(result.fields.cardNumber.placeholder, "CN-P")
-        XCTAssertEqual(result.fields.cardHolder.label, "CH-L")
-        XCTAssertEqual(result.fields.cardHolder.placeholder, "CH-P")
-        XCTAssertEqual(result.fields.expiration.label, "EX-L")
-        XCTAssertEqual(result.fields.expiration.placeholder, "EX-P")
-        XCTAssertEqual(result.fields.cvv.label, "CV-L")
-        XCTAssertEqual(result.fields.cvv.placeholderDefault, "CV-P")
-        XCTAssertEqual(result.fields.cvv.placeholderAmex, "CV-P")
-        XCTAssertEqual(result.fields.issuer.label, "IS-L")
-        XCTAssertEqual(result.fields.issuer.placeholder, "IS-P")
-        XCTAssertEqual(result.fields.document.label, "DO-L")
-        XCTAssertEqual(result.fields.document.placeholder, "DO-P")
-    }
-
-    // MARK: - Text Resolution (validation data preserved)
-
-    func testExecute_validationDataPreservedAfterCustomization() async throws {
-        let sut = self.makeSUT()
-        let customTexts = CardFormCustomTexts(title: "Custom", cardNumber: .init(label: "Custom"))
-        let result = try await sut.useCase.execute(config: self.makeConfig(customTexts: customTexts))
-        let defaultFields = CardFormInitializationOutputStub.makeDefaultFields()
-
-        XCTAssertEqual(result.fields.cardNumber.validation.errorEmpty, defaultFields.cardNumber.validation.errorEmpty)
-        XCTAssertEqual(result.fields.cardNumber.validation.errorInvalid, defaultFields.cardNumber.validation.errorInvalid)
-        XCTAssertEqual(result.fields.cardHolder.validation.errorEmpty, defaultFields.cardHolder.validation.errorEmpty)
-        XCTAssertEqual(result.fields.expiration.validation.errorEmpty, defaultFields.expiration.validation.errorEmpty)
-        XCTAssertEqual(result.fields.cvv.validation.errorEmpty, defaultFields.cvv.validation.errorEmpty)
-        XCTAssertEqual(result.fields.document.validation.errorEmpty, defaultFields.document.validation.errorEmpty)
     }
 
     // MARK: - Button Resolution
@@ -218,21 +118,6 @@ final class InitializeCardFormUseCaseTests: XCTestCase {
         let result = try await sut.useCase.execute(config: self.makeConfig(amount: 100.0))
 
         XCTAssertEqual(result.button, "Pagar")
-    }
-
-    func testExecute_customButtonOverridesVariantResolution() async throws {
-        let sut = self.makeSUT()
-        sut.repository.mockData = CardFormInitializationInput(
-            title: "Header",
-            buttonVariants: .init(save: "Guardar", pay: "Pagar"),
-            fields: CardFormInitializationInputStub.makeDefaultFields(),
-            identificationTypes: []
-        )
-        let customTexts = CardFormCustomTexts(button: "Custom Button")
-
-        let result = try await sut.useCase.execute(config: self.makeConfig(amount: 100.0, customTexts: customTexts))
-
-        XCTAssertEqual(result.button, "Custom Button")
     }
 
     // MARK: - Error Cases

--- a/Tests/MercadoPagoCheckoutTests/UseCases/InitializeCardFormUseCaseTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/UseCases/InitializeCardFormUseCaseTests.swift
@@ -1,0 +1,251 @@
+//
+//  InitializeCardFormUseCaseTests.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 16/03/26.
+//
+
+@testable import CoreMethods
+@testable import MercadoPagoCheckout
+import XCTest
+
+final class InitializeCardFormUseCaseTests: XCTestCase {
+    // MARK: - Types
+
+    typealias SUT = (
+        useCase: InitializeCardFormUseCase,
+        repository: MockCardFormInitializationRepository
+    )
+
+    // MARK: - Stubs
+
+    private static let stubIdentificationType = IdentificationType(
+        id: "CPF",
+        name: "CPF",
+        type: "number",
+        minLenght: 11,
+        maxLenght: 11
+    )
+
+    // MARK: - Helpers
+
+    private func makeSUT() -> SUT {
+        let repository = MockCardFormInitializationRepository()
+        let useCase = InitializeCardFormUseCase(repository: repository)
+        return (useCase, repository)
+    }
+
+    private func makeConfig(
+        amount: Double? = nil,
+        customTexts: CardFormCustomTexts? = nil
+    ) -> MercadoPagoCheckout.CardFormConfiguration {
+        MercadoPagoCheckout.CardFormConfiguration(amount: amount, customTexts: customTexts)
+    }
+
+    // MARK: - Success Cases
+
+    func testExecute_returnsInitResultAndTypes() async throws {
+        let sut = self.makeSUT()
+        sut.repository.mockData = MockCardFormInitializationRepository.makeDefault(
+            identificationTypes: [Self.stubIdentificationType]
+        )
+
+        let result = try await sut.useCase.execute(config: self.makeConfig())
+
+        XCTAssertEqual(result.identificationTypes.count, 1)
+        XCTAssertEqual(result.identificationTypes.first?.id, "CPF")
+        XCTAssertEqual(result.title, "Default Header")
+        XCTAssertEqual(result.button, "Save")
+    }
+
+    // MARK: - Text Resolution (no customization)
+
+    func testExecute_noCustomization_returnsDefaults() async throws {
+        let sut = self.makeSUT()
+        let result = try await sut.useCase.execute(config: self.makeConfig())
+        let defaultFields = CardFormInitializationOutputStub.makeDefaultFields()
+
+        XCTAssertEqual(result.title, "Default Header")
+        XCTAssertEqual(result.fields.cardNumber.label, defaultFields.cardNumber.label)
+        XCTAssertEqual(result.fields.cardNumber.placeholder, defaultFields.cardNumber.placeholder)
+        XCTAssertEqual(result.fields.cardHolder.label, defaultFields.cardHolder.label)
+        XCTAssertEqual(result.fields.cardHolder.placeholder, defaultFields.cardHolder.placeholder)
+        XCTAssertEqual(result.fields.cardHolder.helperText, defaultFields.cardHolder.helperText)
+        XCTAssertEqual(result.fields.expiration.label, defaultFields.expiration.label)
+        XCTAssertEqual(result.fields.expiration.placeholder, defaultFields.expiration.placeholder)
+        XCTAssertEqual(result.fields.cvv.label, defaultFields.cvv.label)
+        XCTAssertEqual(result.fields.issuer.label, defaultFields.issuer.label)
+        XCTAssertEqual(result.fields.issuer.placeholder, defaultFields.issuer.placeholder)
+        XCTAssertEqual(result.fields.document.label, defaultFields.document.label)
+        XCTAssertEqual(result.fields.document.placeholder, defaultFields.document.placeholder)
+    }
+
+    // MARK: - Text Resolution (custom title)
+
+    func testExecute_customTitle_overridesHeader() async throws {
+        let sut = self.makeSUT()
+        let customTexts = CardFormCustomTexts(title: "My Custom Title")
+        let result = try await sut.useCase.execute(config: self.makeConfig(customTexts: customTexts))
+
+        XCTAssertEqual(result.title, "My Custom Title")
+    }
+
+    // MARK: - Text Resolution (partial customization)
+
+    func testExecute_partialCardNumber_overridesOnlyLabel() async throws {
+        let sut = self.makeSUT()
+        let customTexts = CardFormCustomTexts(cardNumber: .init(label: "Custom Card Number Label"))
+        let result = try await sut.useCase.execute(config: self.makeConfig(customTexts: customTexts))
+        let defaultFields = CardFormInitializationOutputStub.makeDefaultFields()
+
+        XCTAssertEqual(result.fields.cardNumber.label, "Custom Card Number Label")
+        XCTAssertEqual(result.fields.cardNumber.placeholder, defaultFields.cardNumber.placeholder)
+    }
+
+    // MARK: - Text Resolution (CVV placeholder)
+
+    func testExecute_noCvvCustom_preservesBothPlaceholders() async throws {
+        let sut = self.makeSUT()
+        let result = try await sut.useCase.execute(config: self.makeConfig())
+        let defaultFields = CardFormInitializationOutputStub.makeDefaultFields()
+
+        XCTAssertEqual(result.fields.cvv.placeholderDefault, defaultFields.cvv.placeholderDefault)
+        XCTAssertEqual(result.fields.cvv.placeholderAmex, defaultFields.cvv.placeholderAmex)
+    }
+
+    func testExecute_customCvvPlaceholder_overridesBoth() async throws {
+        let sut = self.makeSUT()
+        let customTexts = CardFormCustomTexts(cvv: .init(placeholder: "Custom CVV"))
+        let result = try await sut.useCase.execute(config: self.makeConfig(customTexts: customTexts))
+
+        XCTAssertEqual(result.fields.cvv.placeholderDefault, "Custom CVV")
+        XCTAssertEqual(result.fields.cvv.placeholderAmex, "Custom CVV")
+    }
+
+    // MARK: - Text Resolution (empty custom texts = nil)
+
+    func testExecute_emptyCustomTexts_sameAsNil() async throws {
+        let sut = self.makeSUT()
+        let withEmpty = try await sut.useCase.execute(config: self.makeConfig(customTexts: CardFormCustomTexts()))
+        let withNil = try await sut.useCase.execute(config: self.makeConfig())
+
+        XCTAssertEqual(withEmpty.title, withNil.title)
+        XCTAssertEqual(withEmpty.fields.cardNumber.label, withNil.fields.cardNumber.label)
+        XCTAssertEqual(withEmpty.fields.cardNumber.placeholder, withNil.fields.cardNumber.placeholder)
+        XCTAssertEqual(withEmpty.fields.cardHolder.label, withNil.fields.cardHolder.label)
+        XCTAssertEqual(withEmpty.fields.cardHolder.placeholder, withNil.fields.cardHolder.placeholder)
+        XCTAssertEqual(withEmpty.fields.expiration.label, withNil.fields.expiration.label)
+        XCTAssertEqual(withEmpty.fields.expiration.placeholder, withNil.fields.expiration.placeholder)
+        XCTAssertEqual(withEmpty.fields.cvv.label, withNil.fields.cvv.label)
+        XCTAssertEqual(withEmpty.fields.issuer.label, withNil.fields.issuer.label)
+        XCTAssertEqual(withEmpty.fields.issuer.placeholder, withNil.fields.issuer.placeholder)
+        XCTAssertEqual(withEmpty.fields.document.label, withNil.fields.document.label)
+        XCTAssertEqual(withEmpty.fields.document.placeholder, withNil.fields.document.placeholder)
+    }
+
+    // MARK: - Text Resolution (all fields customized)
+
+    func testExecute_allFieldsCustomized() async throws {
+        let sut = self.makeSUT()
+        let customTexts = CardFormCustomTexts(
+            title: "CT",
+            cardNumber: .init(label: "CN-L", placeholder: "CN-P"),
+            cardHolder: .init(label: "CH-L", placeholder: "CH-P"),
+            expiration: .init(label: "EX-L", placeholder: "EX-P"),
+            cvv: .init(label: "CV-L", placeholder: "CV-P"),
+            issuer: .init(label: "IS-L", placeholder: "IS-P"),
+            document: .init(label: "DO-L", placeholder: "DO-P")
+        )
+        let result = try await sut.useCase.execute(config: self.makeConfig(customTexts: customTexts))
+
+        XCTAssertEqual(result.title, "CT")
+        XCTAssertEqual(result.fields.cardNumber.label, "CN-L")
+        XCTAssertEqual(result.fields.cardNumber.placeholder, "CN-P")
+        XCTAssertEqual(result.fields.cardHolder.label, "CH-L")
+        XCTAssertEqual(result.fields.cardHolder.placeholder, "CH-P")
+        XCTAssertEqual(result.fields.expiration.label, "EX-L")
+        XCTAssertEqual(result.fields.expiration.placeholder, "EX-P")
+        XCTAssertEqual(result.fields.cvv.label, "CV-L")
+        XCTAssertEqual(result.fields.cvv.placeholderDefault, "CV-P")
+        XCTAssertEqual(result.fields.cvv.placeholderAmex, "CV-P")
+        XCTAssertEqual(result.fields.issuer.label, "IS-L")
+        XCTAssertEqual(result.fields.issuer.placeholder, "IS-P")
+        XCTAssertEqual(result.fields.document.label, "DO-L")
+        XCTAssertEqual(result.fields.document.placeholder, "DO-P")
+    }
+
+    // MARK: - Text Resolution (validation data preserved)
+
+    func testExecute_validationDataPreservedAfterCustomization() async throws {
+        let sut = self.makeSUT()
+        let customTexts = CardFormCustomTexts(title: "Custom", cardNumber: .init(label: "Custom"))
+        let result = try await sut.useCase.execute(config: self.makeConfig(customTexts: customTexts))
+        let defaultFields = CardFormInitializationOutputStub.makeDefaultFields()
+
+        XCTAssertEqual(result.fields.cardNumber.validation.errorEmpty, defaultFields.cardNumber.validation.errorEmpty)
+        XCTAssertEqual(result.fields.cardNumber.validation.errorInvalid, defaultFields.cardNumber.validation.errorInvalid)
+        XCTAssertEqual(result.fields.cardHolder.validation.errorEmpty, defaultFields.cardHolder.validation.errorEmpty)
+        XCTAssertEqual(result.fields.expiration.validation.errorEmpty, defaultFields.expiration.validation.errorEmpty)
+        XCTAssertEqual(result.fields.cvv.validation.errorEmpty, defaultFields.cvv.validation.errorEmpty)
+        XCTAssertEqual(result.fields.document.validation.errorEmpty, defaultFields.document.validation.errorEmpty)
+    }
+
+    // MARK: - Button Resolution
+
+    func testExecute_withoutAmount_usesSaveButton() async throws {
+        let sut = self.makeSUT()
+        sut.repository.mockData = CardFormInitializationInput(
+            title: "Header",
+            buttonVariants: .init(save: "Guardar", pay: "Pagar"),
+            fields: CardFormInitializationInputStub.makeDefaultFields(),
+            identificationTypes: []
+        )
+
+        let result = try await sut.useCase.execute(config: self.makeConfig(amount: nil))
+
+        XCTAssertEqual(result.button, "Guardar")
+    }
+
+    func testExecute_withAmount_usesPayButton() async throws {
+        let sut = self.makeSUT()
+        sut.repository.mockData = CardFormInitializationInput(
+            title: "Header",
+            buttonVariants: .init(save: "Guardar", pay: "Pagar"),
+            fields: CardFormInitializationInputStub.makeDefaultFields(),
+            identificationTypes: []
+        )
+
+        let result = try await sut.useCase.execute(config: self.makeConfig(amount: 100.0))
+
+        XCTAssertEqual(result.button, "Pagar")
+    }
+
+    func testExecute_customButtonOverridesVariantResolution() async throws {
+        let sut = self.makeSUT()
+        sut.repository.mockData = CardFormInitializationInput(
+            title: "Header",
+            buttonVariants: .init(save: "Guardar", pay: "Pagar"),
+            fields: CardFormInitializationInputStub.makeDefaultFields(),
+            identificationTypes: []
+        )
+        let customTexts = CardFormCustomTexts(button: "Custom Button")
+
+        let result = try await sut.useCase.execute(config: self.makeConfig(amount: 100.0, customTexts: customTexts))
+
+        XCTAssertEqual(result.button, "Custom Button")
+    }
+
+    // MARK: - Error Cases
+
+    func testExecute_repositoryFails_throws() async {
+        let sut = self.makeSUT()
+        sut.repository.shouldThrow = true
+
+        do {
+            _ = try await sut.useCase.execute(config: self.makeConfig())
+            XCTFail("Expected repository error to propagate")
+        } catch {
+            XCTAssertEqual((error as NSError).domain, "test")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `CardFormInitializationInput`, `CardFormInitializationOutput`, and `CardFormTexts` domain models
- Introduces `CardFormInitializationRepository` protocol and `LocalCardFormInitializationRepository` implementation
- Adds `InitializeCardFormUseCase` for card form initialization logic
- Full test coverage: repository tests, use case tests, stubs, and mocks

## Context
This is **PR 1/2** of the Card Form initialization architecture split.
The domain layer is fully self-contained with no changes to existing files.

### PR chain:
1. **This PR** — Domain layer (models, use case, repository)
2. Rules & data and view integration refactor

## Test plan
- [x] Unit tests for `LocalCardFormInitializationRepository`
- [x] Unit tests for `InitializeCardFormUseCase`
- [x] Mock and stub infrastructure for dependent PRs