### PR TITLE
[CHOBK-3687] (Feature): Card Form rules, data and view integration

### DIFF
--- a/Sources/MPFoundation/Localization/MPStrings+CardForm.swift
+++ b/Sources/MPFoundation/Localization/MPStrings+CardForm.swift
@@ -61,9 +61,9 @@ extension MPStrings {
                 localized("card_number.error.debit_balance")
             }
 
-            /// Seller exclusion error (card brand not accepted)
+            /// Method not allowed error (card brand not accepted)
             /// - Parameter brand: The card brand name
-            package static func errorSellerExclusion(brand: String) -> String {
+            package static func errorMethodNotAllowed(brand: String) -> String {
                 localized("card_number.error.seller_exclusion", brand)
             }
 
@@ -109,7 +109,7 @@ extension MPStrings {
             }
 
             /// Invalid format error
-            package static var errorInvalidFormat: String {
+            package static var errorInvalid: String {
                 localized("card_holder.error.invalid_format")
             }
 

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -17,11 +17,10 @@ struct CardFormBrick: View {
     @State private var paymentData: MPPaymentData
     @ObservedObject private var brickViewModel: CardFormBrickViewModel
 
-    private let configuration: MercadoPagoCheckout.CheckoutConfiguration
+    private var configuration: MercadoPagoCheckout.CheckoutConfiguration
     private let themeDark: MPTheme
     private let themeLight: MPTheme
     private let transactionAmount: Double?
-    private let configuration: MercadoPagoCheckout.CheckoutConfiguration
 
     private let onResult: (MercadoPagoCheckoutResult) -> Void
 
@@ -64,9 +63,11 @@ struct CardFormBrick: View {
         }
         .mpTask {
             do {
-                try await self.brickViewModel.loadInitData()
+                try await self.brickViewModel.load()
+            } catch let error as MercadoPagoCheckoutError {
+                self.onResult(.error(error))
             } catch {
-                self.onResult(.error(.serviceError(error.localizedDescription)))
+                self.onResult(.error(MercadoPagoCheckoutError(code: .unknown, localizedDescription: error.localizedDescription, location: .initialization)))
             }
         }
     }
@@ -75,8 +76,8 @@ struct CardFormBrick: View {
         CardFormScreen(
             initResult: initResult,
             transactionAmount: self.transactionAmount,
-            onBack: { context in self.cancelCheckout(context: context) },
             viewModel: CardFormViewModel(configuration: self.configuration, initResult: initResult),
+            onBack: { context in self.cancelCheckout(context: context) },
             onSuccess: { paymentData in
                 self.paymentData = paymentData
                 self.completeCheckout()

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -39,7 +39,7 @@ struct CardFormBrick: View {
         self.transactionAmount = configuration.type.configuration.amount
         self.configuration = configuration
         self._paymentData = State(initialValue: MPPaymentData(transactionAmount: self.transactionAmount))
-        self._brickViewModel = ObservedObject(wrappedValue: CardFormBrickViewModel(configuration: configuration))
+        self.brickViewModel = CardFormBrickViewModel(configuration: configuration)
     }
 
     var body: some View {

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -67,7 +67,12 @@ struct CardFormBrick: View {
             } catch let error as MercadoPagoCheckoutError {
                 self.onResult(.error(error))
             } catch {
-                self.onResult(.error(MercadoPagoCheckoutError(code: .unknown, localizedDescription: error.localizedDescription, location: .initialization)))
+                let checkoutError = MercadoPagoCheckoutError(
+                    code: .unknown,
+                    localizedDescription: error.localizedDescription,
+                    location: .initialization
+                )
+                self.onResult(.error(checkoutError))
             }
         }
     }

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -15,8 +15,9 @@ struct CardFormBrick: View {
 
     @State private var route: Route?
     @State private var paymentData: MPPaymentData
-    @ObservedObject private var cardFormViewModel: CardFormViewModel
+    @ObservedObject private var brickViewModel: CardFormBrickViewModel
 
+    private let configuration: MercadoPagoCheckout.CheckoutConfiguration
     private let themeDark: MPTheme
     private let themeLight: MPTheme
     private let transactionAmount: Double?
@@ -31,13 +32,14 @@ struct CardFormBrick: View {
         appearance: MercadoPagoCheckout.CheckoutAppearance,
         onResult: @escaping (MercadoPagoCheckoutResult) -> Void
     ) {
+        self.configuration = configuration
         self.onResult = onResult
         self.themeDark = appearance.dark
         self.themeLight = appearance.light
         self.transactionAmount = configuration.type.configuration.amount
         self.configuration = configuration
         self._paymentData = State(initialValue: MPPaymentData(transactionAmount: self.transactionAmount))
-        self._cardFormViewModel = ObservedObject(wrappedValue: CardFormViewModel(configuration: configuration))
+        self._brickViewModel = ObservedObject(wrappedValue: CardFormBrickViewModel(configuration: configuration))
     }
 
     var body: some View {
@@ -47,7 +49,7 @@ struct CardFormBrick: View {
         ) {
             NavigationView {
                 ZStack {
-                    switch self.cardFormViewModel.screenState {
+                    switch self.brickViewModel.screenState {
                     case .loading:
                         MPProgressIndicator()
                             .size(.xlarge)
@@ -62,7 +64,7 @@ struct CardFormBrick: View {
         }
         .mpTask {
             do {
-                try await self.cardFormViewModel.loadInitData()
+                try await self.brickViewModel.loadInitData()
             } catch {
                 self.onResult(.error(.serviceError(error.localizedDescription)))
             }
@@ -73,8 +75,8 @@ struct CardFormBrick: View {
         CardFormScreen(
             initResult: initResult,
             transactionAmount: self.transactionAmount,
-            viewModel: self.cardFormViewModel,
             onBack: { context in self.cancelCheckout(context: context) },
+            viewModel: CardFormViewModel(configuration: self.configuration, initResult: initResult),
             onSuccess: { paymentData in
                 self.paymentData = paymentData
                 self.completeCheckout()

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -15,7 +15,7 @@ struct CardFormBrick: View {
 
     @State private var route: Route?
     @State private var paymentData: MPPaymentData
-    @State private var cardFormViewModel: CardFormViewModel
+    @ObservedObject private var cardFormViewModel: CardFormViewModel
 
     private let themeDark: MPTheme
     private let themeLight: MPTheme
@@ -37,7 +37,7 @@ struct CardFormBrick: View {
         self.transactionAmount = configuration.type.configuration.amount
         self.configuration = configuration
         self._paymentData = State(initialValue: MPPaymentData(transactionAmount: self.transactionAmount))
-        self._cardFormViewModel = State(initialValue: CardFormViewModel(configuration: configuration))
+        self._cardFormViewModel = ObservedObject(wrappedValue: CardFormViewModel(configuration: configuration))
     }
 
     var body: some View {
@@ -47,16 +47,31 @@ struct CardFormBrick: View {
         ) {
             NavigationView {
                 ZStack {
-                    self.cardFormScreen()
+                    switch self.cardFormViewModel.screenState {
+                    case .loading:
+                        MPProgressIndicator()
+                            .size(.xlarge)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    case let .ready(initResult):
+                        self.cardFormScreen(initResult: initResult)
+                    }
                     self.navigationLinks()
                 }
             }
             .navigationViewStyle(StackNavigationViewStyle())
         }
+        .mpTask {
+            do {
+                try await self.cardFormViewModel.loadInitData()
+            } catch {
+                self.onResult(.error(.serviceError(error.localizedDescription)))
+            }
+        }
     }
 
-    private func cardFormScreen() -> some View {
+    private func cardFormScreen(initResult: CardFormInitializationOutput) -> some View {
         CardFormScreen(
+            initResult: initResult,
             transactionAmount: self.transactionAmount,
             viewModel: self.cardFormViewModel,
             onBack: { context in self.cancelCheckout(context: context) },

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
@@ -34,7 +34,7 @@ final class CardFormBrickViewModel: ObservableObject {
 
     // MARK: - Initialization
 
-    func loadInitData() async throws {
+    func load() async throws(MercadoPagoCheckoutError) {
         let config = self.extractCardFormConfig()
         let result = try await self.initializeUseCase.execute(config: config)
         self.screenState = .ready(result)

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Guilherme Prata Costa on 18/03/26.
 //
+import Foundation
 
 @MainActor
 final class CardFormBrickViewModel: ObservableObject {

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
@@ -1,0 +1,50 @@
+//
+//  CardFormBrickViewModel.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 18/03/26.
+//
+
+@MainActor
+final class CardFormBrickViewModel: ObservableObject {
+    enum ScreenState {
+        case loading
+        case ready(CardFormInitializationOutput)
+    }
+
+    // MARK: - Published State
+
+    @Published private(set) var screenState: ScreenState = .loading
+
+    // MARK: - Dependencies
+
+    private let configuration: MercadoPagoCheckout.CheckoutConfiguration
+    private let initializeUseCase: InitializeCardFormUseCase
+
+    // MARK: - Init
+
+    init(
+        configuration: MercadoPagoCheckout.CheckoutConfiguration,
+        initializeUseCase: InitializeCardFormUseCase = InitializeCardFormUseCase()
+    ) {
+        self.configuration = configuration
+        self.initializeUseCase = initializeUseCase
+    }
+
+    // MARK: - Initialization
+
+    func loadInitData() async throws {
+        let config = self.extractCardFormConfig()
+        let result = try await self.initializeUseCase.execute(config: config)
+        self.screenState = .ready(result)
+    }
+
+    // MARK: - Private
+
+    private func extractCardFormConfig() -> MercadoPagoCheckout.CardFormConfiguration {
+        if case let .cardForm(config) = configuration.type {
+            return config
+        }
+        return MercadoPagoCheckout.CardFormConfiguration()
+    }
+}

--- a/Sources/MercadoPagoCheckout/Data/Repositories/LocalCardFormInitializationRepository.swift
+++ b/Sources/MercadoPagoCheckout/Data/Repositories/LocalCardFormInitializationRepository.swift
@@ -33,7 +33,7 @@ struct LocalCardFormInitializationRepository: CardFormInitializationRepository {
                         errorEmpty: MPStrings.CardForm.CardNumber.errorEmpty,
                         errorIncomplete: MPStrings.CardForm.CardNumber.errorIncomplete,
                         errorInvalid: MPStrings.CardForm.CardNumber.errorInvalid,
-                        errorMethodNotAllowed: MPStrings.CardForm.CardNumber.errorSellerExclusion(brand: "%@"),
+                        errorMethodNotAllowed: MPStrings.CardForm.CardNumber.errorMethodNotAllowed(brand: "%@"),
                         errorTypeNotAllowed: MPStrings.CardForm.CardNumber.errorTypeNotAllowed(cardType: "%@")
                     )
                 ),
@@ -44,7 +44,7 @@ struct LocalCardFormInitializationRepository: CardFormInitializationRepository {
                     validation: .init(
                         errorEmpty: MPStrings.CardForm.CardHolder.errorEmpty,
                         errorIncomplete: MPStrings.CardForm.CardHolder.errorIncomplete,
-                        errorInvalid: MPStrings.CardForm.CardHolder.errorInvalidFormat
+                        errorInvalid: MPStrings.CardForm.CardHolder.errorInvalid
                     )
                 ),
                 expiration: .init(

--- a/Sources/MercadoPagoCheckout/Data/Repositories/LocalCardFormInitializationRepository.swift
+++ b/Sources/MercadoPagoCheckout/Data/Repositories/LocalCardFormInitializationRepository.swift
@@ -33,7 +33,7 @@ struct LocalCardFormInitializationRepository: CardFormInitializationRepository {
                         errorEmpty: MPStrings.CardForm.CardNumber.errorEmpty,
                         errorIncomplete: MPStrings.CardForm.CardNumber.errorIncomplete,
                         errorInvalid: MPStrings.CardForm.CardNumber.errorInvalid,
-                        errorSellerExclusion: MPStrings.CardForm.CardNumber.errorSellerExclusion(brand: "%@"),
+                        errorMethodNotAllowed: MPStrings.CardForm.CardNumber.errorSellerExclusion(brand: "%@"),
                         errorTypeNotAllowed: MPStrings.CardForm.CardNumber.errorTypeNotAllowed(cardType: "%@")
                     )
                 ),
@@ -44,7 +44,7 @@ struct LocalCardFormInitializationRepository: CardFormInitializationRepository {
                     validation: .init(
                         errorEmpty: MPStrings.CardForm.CardHolder.errorEmpty,
                         errorIncomplete: MPStrings.CardForm.CardHolder.errorIncomplete,
-                        errorInvalidFormat: MPStrings.CardForm.CardHolder.errorInvalidFormat
+                        errorInvalid: MPStrings.CardForm.CardHolder.errorInvalidFormat
                     )
                 ),
                 expiration: .init(

--- a/Sources/MercadoPagoCheckout/Domain/Model/CardFormTexts.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Model/CardFormTexts.swift
@@ -24,7 +24,7 @@ enum CardFormTexts {
             let errorEmpty: String
             let errorIncomplete: String
             let errorInvalid: String
-            let errorSellerExclusion: String
+            let errorMethodNotAllowed: String
             let errorTypeNotAllowed: String
         }
     }
@@ -38,7 +38,7 @@ enum CardFormTexts {
         struct Validation {
             let errorEmpty: String
             let errorIncomplete: String
-            let errorInvalidFormat: String
+            let errorInvalid: String
         }
     }
 

--- a/Sources/MercadoPagoCheckout/Domain/UseCases/InitializeCardFormUseCase.swift
+++ b/Sources/MercadoPagoCheckout/Domain/UseCases/InitializeCardFormUseCase.swift
@@ -42,7 +42,7 @@ struct InitializeCardFormUseCase: Sendable {
                         errorEmpty: fields.cardNumber.validation.errorEmpty,
                         errorIncomplete: fields.cardNumber.validation.errorIncomplete,
                         errorInvalid: fields.cardNumber.validation.errorInvalid,
-                        errorMethodNotAllowed: fields.cardNumber.validation.errorSellerExclusion,
+                        errorMethodNotAllowed: fields.cardNumber.validation.errorMethodNotAllowed,
                         errorTypeNotAllowed: fields.cardNumber.validation.errorTypeNotAllowed
                     )
                 ),
@@ -53,7 +53,7 @@ struct InitializeCardFormUseCase: Sendable {
                     validation: .init(
                         errorEmpty: fields.cardHolder.validation.errorEmpty,
                         errorIncomplete: fields.cardHolder.validation.errorIncomplete,
-                        errorInvalidFormat: fields.cardHolder.validation.errorInvalidFormat
+                        errorInvalid: fields.cardHolder.validation.errorInvalid
                     )
                 ),
                 expiration: .init(

--- a/Sources/MercadoPagoCheckout/Domain/UseCases/InitializeCardFormUseCase.swift
+++ b/Sources/MercadoPagoCheckout/Domain/UseCases/InitializeCardFormUseCase.swift
@@ -42,7 +42,7 @@ struct InitializeCardFormUseCase: Sendable {
                         errorEmpty: fields.cardNumber.validation.errorEmpty,
                         errorIncomplete: fields.cardNumber.validation.errorIncomplete,
                         errorInvalid: fields.cardNumber.validation.errorInvalid,
-                        errorSellerExclusion: fields.cardNumber.validation.errorSellerExclusion,
+                        errorMethodNotAllowed: fields.cardNumber.validation.errorSellerExclusion,
                         errorTypeNotAllowed: fields.cardNumber.validation.errorTypeNotAllowed
                     )
                 ),

--- a/Sources/MercadoPagoCheckout/Domain/UseCases/InitializeCardFormUseCase.swift
+++ b/Sources/MercadoPagoCheckout/Domain/UseCases/InitializeCardFormUseCase.swift
@@ -18,9 +18,15 @@ struct InitializeCardFormUseCase: Sendable {
 
     /// Fetches initialization data from the repository,
     /// then applies business rules (button selection, custom text overrides).
-    func execute(config: MercadoPagoCheckout.CardFormConfiguration) async throws -> CardFormInitializationOutput {
-        let data = try await repository.fetchInitialization()
-        return self.mapToResult(data: data, config: config)
+    func execute(config: MercadoPagoCheckout.CardFormConfiguration) async throws(MercadoPagoCheckoutError) -> CardFormInitializationOutput {
+        do {
+            let data = try await repository.fetchInitialization()
+            return self.mapToResult(data: data, config: config)
+        } catch let error as APIClientError {
+            throw .init(from: error, location: .initialization)
+        } catch {
+            throw .init(code: .unknown, localizedDescription: error.localizedDescription, location: .identification)
+        }
     }
 
     // MARK: - Business Rules

--- a/Sources/MercadoPagoCheckout/Domain/UseCases/InitializeCardFormUseCase.swift
+++ b/Sources/MercadoPagoCheckout/Domain/UseCases/InitializeCardFormUseCase.swift
@@ -33,13 +33,14 @@ struct InitializeCardFormUseCase: Sendable {
 
     private func mapToResult(
         data: CardFormInitializationInput,
-        config _: MercadoPagoCheckout.CardFormConfiguration
+        config: MercadoPagoCheckout.CardFormConfiguration
     ) -> CardFormInitializationOutput {
         let fields = data.fields
+        let button = config.amount != nil ? data.buttonVariants.pay : data.buttonVariants.save
 
         return CardFormInitializationOutput(
             title: data.title,
-            button: data.buttonVariants.save,
+            button: button,
             fields: .init(
                 cardNumber: .init(
                     label: fields.cardNumber.label,

--- a/Sources/MercadoPagoCheckout/Domain/UseCases/InitializeCardFormUseCase.swift
+++ b/Sources/MercadoPagoCheckout/Domain/UseCases/InitializeCardFormUseCase.swift
@@ -33,14 +33,13 @@ struct InitializeCardFormUseCase: Sendable {
 
     private func mapToResult(
         data: CardFormInitializationInput,
-        config: MercadoPagoCheckout.CardFormConfiguration
+        config _: MercadoPagoCheckout.CardFormConfiguration
     ) -> CardFormInitializationOutput {
         let fields = data.fields
-        let button = config.amount != nil ? data.buttonVariants.pay : data.buttonVariants.save
 
         return CardFormInitializationOutput(
             title: data.title,
-            button: button,
+            button: data.buttonVariants.save,
             fields: .init(
                 cardNumber: .init(
                     label: fields.cardNumber.label,

--- a/Sources/MercadoPagoCheckout/Model/Public/MercadoPagoCheckoutError.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/MercadoPagoCheckoutError.swift
@@ -27,6 +27,7 @@ public struct MercadoPagoCheckoutError: Error, LocalizedError, CustomDebugString
         case paymentMethods
         case installments
         case issuer
+        case initialization
     }
 
     public let code: Code

--- a/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
+++ b/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
@@ -89,7 +89,7 @@ package struct CardNumberRule: CardFormRuleType {
     private func validateExternalError(_ error: CardAcceptanceError) -> String? {
         switch error {
         case let .paymentMethodNotAllowed(method):
-            return String(format: self.validation.errorSellerExclusion, method)
+            return String(format: self.validation.errorMethodNotAllowed, method)
         case let .paymentTypeNotAllowed(cardType):
             guard let cardType else {
                 return self.validation.errorInvalid
@@ -135,7 +135,7 @@ package struct CardHolderRule: CardFormRuleType {
 
         let allowed = CharacterSet.letters.union(.whitespaces).union(.decimalDigits)
         if clearValue.unicodeScalars.contains(where: { !allowed.contains($0) }) {
-            return self.validation.errorInvalidFormat
+            return self.validation.errorInvalid
         }
 
         if clearValue.count < 2 {

--- a/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
+++ b/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
@@ -45,8 +45,13 @@ package struct RequiredRule: CardFormRuleType {
 // MARK: Card Number Rule
 
 package struct CardNumberRule: CardFormRuleType {
+    private let validation: CardFormTexts.CardNumberField.Validation
     private var min = 13, max = 19
     private var externalError: CardAcceptanceError?
+
+    init(validation: CardFormTexts.CardNumberField.Validation) {
+        self.validation = validation
+    }
 
     package mutating func apply(_ requirement: CardValidationRequirement) {
         if case let .cardNumberRange(newMin, newMax) = requirement {
@@ -59,11 +64,11 @@ package struct CardNumberRule: CardFormRuleType {
 
     package func validate(_ value: String) -> String? {
         let digits = value.filter(\.isNumber)
-        if digits.isEmpty { return MPStrings.CardForm.CardNumber.errorEmpty }
+        if digits.isEmpty { return self.validation.errorEmpty }
         if let externalError { return self.validateExternalError(externalError) }
-        if digits.count < self.min { return MPStrings.CardForm.CardNumber.errorIncomplete }
-        if self.isAllRepeatedDigits(digits) { return MPStrings.CardForm.CardNumber.errorInvalid }
-        if !self.luhnCheck(digits) { return MPStrings.CardForm.CardNumber.errorInvalid }
+        if digits.count < self.min { return self.validation.errorIncomplete }
+        if self.isAllRepeatedDigits(digits) { return self.validation.errorInvalid }
+        if !self.luhnCheck(digits) { return self.validation.errorInvalid }
         return nil
     }
 
@@ -72,7 +77,7 @@ package struct CardNumberRule: CardFormRuleType {
         guard !digits.isEmpty else { return nil }
         if let externalError { return self.validateExternalError(externalError) }
         guard digits.count >= self.min else { return nil }
-        if self.isAllRepeatedDigits(digits) { return MPStrings.CardForm.CardNumber.errorInvalid }
+        if self.isAllRepeatedDigits(digits) { return self.validation.errorInvalid }
         return nil
     }
 
@@ -84,12 +89,16 @@ package struct CardNumberRule: CardFormRuleType {
     private func validateExternalError(_ error: CardAcceptanceError) -> String? {
         switch error {
         case let .paymentMethodNotAllowed(method):
-            return MPStrings.CardForm.CardNumber.errorSellerExclusion(brand: method)
+            return String(format: self.validation.errorSellerExclusion, method)
         case let .paymentTypeNotAllowed(cardType):
             guard let cardType else {
-                return MPStrings.CardForm.CardNumber.errorInvalid
+                return self.validation.errorInvalid
             }
-            return MPStrings.CardForm.CardNumber.errorTypeNotAllowed(cardType: self.cardTypeDisplayName(cardType))
+            return String(format: self.validation.errorTypeNotAllowed, self.cardTypeDisplayName(cardType))
+        case .paymentMethodNotFound:
+            return self.validation.errorInvalid
+        case .networkError, .serviceError:
+            return nil
         }
     }
 
@@ -111,11 +120,45 @@ package struct CardNumberRule: CardFormRuleType {
     }
 }
 
+// MARK: - Card Holder Rule
+
+package struct CardHolderRule: CardFormRuleType {
+    private let validation: CardFormTexts.CardHolderField.Validation
+
+    init(validation: CardFormTexts.CardHolderField.Validation) {
+        self.validation = validation
+    }
+
+    package func validate(_ value: String) -> String? {
+        let clearValue = value.trimmingCharacters(in: .whitespaces)
+        guard !clearValue.isEmpty else { return self.validation.errorEmpty }
+
+        let allowed = CharacterSet.letters.union(.whitespaces).union(.decimalDigits)
+        if clearValue.unicodeScalars.contains(where: { !allowed.contains($0) }) {
+            return self.validation.errorInvalidFormat
+        }
+
+        if clearValue.count < 2 {
+            return self.validation.errorIncomplete
+        }
+
+        return nil
+    }
+}
+
+// MARK: - Expiration Date Rule
+
 package struct ExpirationDateRule: CardFormRuleType {
+    private let validation: CardFormTexts.ExpirationField.Validation
+
+    init(validation: CardFormTexts.ExpirationField.Validation) {
+        self.validation = validation
+    }
+
     package func validate(_ value: String) -> String? {
         let digits = value.filter(\.isNumber)
-        if digits.isEmpty { return MPStrings.CardForm.Expiration.errorEmpty }
-        guard digits.count == 4 else { return MPStrings.CardForm.Expiration.errorIncomplete }
+        if digits.isEmpty { return self.validation.errorEmpty }
+        guard digits.count == 4 else { return self.validation.errorIncomplete }
 
         let month = Int(digits.prefix(2)) ?? 0
         let year = (Int(digits.suffix(2)) ?? 0) + 2000
@@ -127,30 +170,41 @@ package struct ExpirationDateRule: CardFormRuleType {
         let isInvalidMonth = !(1 ... 12).contains(month)
         let isExpired = year < currentYear || (year == currentYear && month < currentMonth)
 
-        return (isInvalidMonth || isExpired) ? MPStrings.CardForm.Expiration.errorInvalid : nil
+        return (isInvalidMonth || isExpired) ? self.validation.errorInvalid : nil
     }
 }
 
 // MARK: - Security Code Rule
 
 package struct SecurityCodeRule: CardFormRuleType {
+    private let validation: CardFormTexts.CVVField.Validation
     private var length = 3
+
+    init(validation: CardFormTexts.CVVField.Validation) {
+        self.validation = validation
+    }
+
     package mutating func apply(_ requirement: CardValidationRequirement) {
         if case let .securityCodeLength(newLen) = requirement { self.length = newLen }
     }
 
     package func validate(_ value: String) -> String? {
         let digits = value.filter(\.isNumber)
-        if digits.isEmpty { return MPStrings.CardForm.CVV.errorEmpty }
-        return digits.count < self.length ? MPStrings.CardForm.CVV.errorIncomplete : nil
+        if digits.isEmpty { return self.validation.errorEmpty }
+        return digits.count < self.length ? self.validation.errorIncomplete : nil
     }
 }
 
 // MARK: - Document Rule
 
 package struct DocumentRule: CardFormRuleType {
+    private let validation: CardFormTexts.DocumentField.Validation
     private var maxLength = 20
     private var minLength = 1
+
+    init(validation: CardFormTexts.DocumentField.Validation) {
+        self.validation = validation
+    }
 
     package mutating func apply(_ requirement: CardValidationRequirement) {
         if case let .documentLength(minLen, maxLen) = requirement {
@@ -161,29 +215,9 @@ package struct DocumentRule: CardFormRuleType {
 
     package func validate(_ value: String) -> String? {
         let digits = value.filter(\.isNumber)
-        if digits.isEmpty { return MPStrings.CardForm.Document.errorEmpty }
-        if !(self.minLength ... self.maxLength).contains(digits.count) { return MPStrings.CardForm.Document.errorIncomplete }
-        if digits.allSatisfy({ $0 == "0" }) { return MPStrings.CardForm.Document.errorInvalid }
-        return nil
-    }
-}
-
-// MARK: - Card Holder Rule
-
-package struct CardHolderRule: CardFormRuleType {
-    package func validate(_ value: String) -> String? {
-        let clearValue = value.trimmingCharacters(in: .whitespaces)
-        guard !clearValue.isEmpty else { return MPStrings.CardForm.CardHolder.errorEmpty }
-
-        let allowed = CharacterSet.letters.union(.whitespaces).union(.decimalDigits)
-        if clearValue.unicodeScalars.contains(where: { !allowed.contains($0) }) {
-            return MPStrings.CardForm.CardHolder.errorInvalidFormat
-        }
-
-        if clearValue.count < 2 {
-            return MPStrings.CardForm.CardHolder.errorIncomplete
-        }
-
+        if digits.isEmpty { return self.validation.errorEmpty }
+        if !(self.minLength ... self.maxLength).contains(digits.count) { return self.validation.errorIncomplete }
+        if digits.allSatisfy({ $0 == "0" }) { return self.validation.errorInvalid }
         return nil
     }
 }

--- a/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
+++ b/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
@@ -95,10 +95,6 @@ package struct CardNumberRule: CardFormRuleType {
                 return self.validation.errorInvalid
             }
             return String(format: self.validation.errorTypeNotAllowed, self.cardTypeDisplayName(cardType))
-        case .paymentMethodNotFound:
-            return self.validation.errorInvalid
-        case .networkError, .serviceError:
-            return nil
         }
     }
 

--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 struct CardFormScreen: View {
     private let onBack: (MPCancelledFormContext) -> Void
+    private let initResult: CardFormInitializationOutput
+    private let onBack: () -> Void
     private let onSuccess: (MPPaymentData) -> Void
     private let onFailure: (MercadoPagoCheckoutError) -> Void
     private let transactionAmount: Double?
@@ -18,7 +20,7 @@ struct CardFormScreen: View {
 
     // MARK: States View
 
-    @State private var cardForm = CardFormData()
+    @State private var cardForm: CardFormData
     @State private var isSnackbarPresented = false
     @State private var footerHeight: CGFloat = 0
 
@@ -27,12 +29,15 @@ struct CardFormScreen: View {
     @Environment(\.checkoutTheme) var theme: MPTheme
 
     init(
+        initResult: CardFormInitializationOutput,
         transactionAmount: Double?,
         viewModel: CardFormViewModel,
         onBack: @escaping (MPCancelledFormContext) -> Void = { _ in },
         onSuccess: @escaping (MPPaymentData) -> Void = { _ in },
         onFailure: @escaping (MercadoPagoCheckoutError) -> Void = { _ in }
     ) {
+        self.initResult = initResult
+        self._cardForm = State(initialValue: CardFormData(fields: initResult.fields))
         self._viewModel = ObservedObject(wrappedValue: viewModel)
         self.onBack = onBack
         self.onSuccess = onSuccess
@@ -41,101 +46,99 @@ struct CardFormScreen: View {
     }
 
     var body: some View {
-        Group {
-            switch self.viewModel.screenState {
-            case .loading:
-                MPProgressIndicator()
-                    .size(.xlarge)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            case .ready:
-                MPHeader(
-                    title: MPStrings.CardForm.title,
-                    onBack: { self.onBack(self.cardForm.cancelledFormContext) },
-                    footer: {
-                        MPFooter(
-                            title: MPStrings.Common.total,
-                            amount: self.viewModel.footerAmount(),
-                            buttonData: .init(
-                                text: MPStrings.CardForm.button,
-                                onClick: {
-                                    await self.viewModel.submitCardData(
-                                        cardForm: self.cardForm,
-                                        transactionAmount: self.transactionAmount,
-                                        onSuccess: { self.onSuccess($0) },
-                                        onFailure: { self.onFailure($0) }
+        MPHeader(
+            title: self.initResult.title,
+            onBack: { self.onBack() },
+            footer: {
+                MPFooter(
+                    title: MPStrings.Common.total,
+                    amount: self.viewModel.footerAmount(),
+                    buttonData: .init(
+                        text: self.initResult.button,
+                        onClick: {
+                            Task {
+                                do {
+                                    let paymentData = try await self.viewModel.submitPaymentData(
+                                        self.transactionAmount,
+                                        cardFormData: self.cardForm
                                     )
+                                    self.onSuccess(paymentData)
+                                } catch let error as MercadoPagoCheckoutError {
+                                    self.onFailure(error)
+                                } catch {
+                                    self.onFailure(.serviceError(error.localizedDescription))
                                 }
-                            )
-                        )
-                        .isLoading(self.viewModel.isTokenizing)
-                        .disabled(!self.cardForm.isFormValid(isSecurityCodeMandatory: self.viewModel.isSecurityCodeMandatory))
-                        .background(
-                            GeometryReader { geo in
-                                Color.clear.onAppear { self.footerHeight = geo.size.height }
                             }
-                        )
-                    },
-                    content: {
-                        VStack(spacing: self.theme.spacings.xsmall) {
-                            MPTextField(
-                                text: self.$cardForm.cardNumber,
-                                label: MPStrings.CardForm.CardNumber.label,
-                                placeholder: MPStrings.CardForm.CardNumber.placeholder,
-                                errorMessage: self.cardForm.$cardNumber,
-                                liveErrorMessage: self.cardForm.cardNumberLiveErrors,
-                                keyboard: .numberPad,
-                                onEditingChanged: { isEditing in
-                                    if !isEditing { self.viewModel.retryBinFetch() }
-                                },
-                                formatter: self.viewModel.cardNumberFormatter
-                            )
-
-                            MPTextField(
-                                text: self.$cardForm.cardHolder,
-                                label: MPStrings.CardForm.CardHolder.label,
-                                placeholder: MPStrings.CardForm.CardHolder.placeholder,
-                                helperText: MPStrings.CardForm.CardHolder.helperText,
-                                errorMessage: self.cardForm.$cardHolder
-                            )
-
-                            MPTextField(
-                                text: self.$cardForm.expirationDate,
-                                label: MPStrings.CardForm.Expiration.label,
-                                placeholder: MPStrings.CardForm.Expiration.placeholder,
-                                errorMessage: self.cardForm.$expirationDate,
-                                keyboard: .numberPad,
-                                formatter: self.viewModel.expirationDateFormatter
-                            )
-
-                            if self.viewModel.isSecurityCodeMandatory {
-                                MPTextField(
-                                    text: self.$cardForm.securityCode,
-                                    label: MPStrings.CardForm.CVV.label,
-                                    placeholder: self.viewModel.cvvPlaceholder,
-                                    errorMessage: self.cardForm.$securityCode,
-                                    keyboard: .numberPad,
-                                    formatter: self.viewModel.securityCodeFormatter,
-                                    popoverText: self.viewModel.cvvTooltipText
-                                )
-                            }
-
-                            MPTextField(
-                                text: self.$cardForm.documentHolder,
-                                label: MPStrings.CardForm.Document.label,
-                                placeholder: self.viewModel.selectTypeDocument?.getPlaceholder(),
-                                errorMessage: self.cardForm.$documentHolder,
-                                keyboard: self.viewModel.selectTypeDocument?.getKeyboardType() ?? .default,
-                                formatter: self.viewModel.documentFormatter,
-                                prefix: {
-                                    self.dropdownDocument()
-                                }
-                            )
                         }
-                        .padding(.horizontal, self.theme.spacings.micro)
+                    )
+                )
+                .isLoading(self.viewModel.isTokenizing)
+                .disabled(!self.cardForm.isFormValid(isSecurityCodeMandatory: self.viewModel.isSecurityCodeMandatory))
+                .background(
+                    GeometryReader { geo in
+                        Color.clear.onAppear { self.footerHeight = geo.size.height }
                     }
                 )
+            },
+            content: {
+                VStack(spacing: self.theme.spacings.xsmall) {
+                    MPTextField(
+                        text: self.$cardForm.cardNumber,
+                        label: self.initResult.fields.cardNumber.label,
+                        placeholder: self.initResult.fields.cardNumber.placeholder,
+                        errorMessage: self.cardForm.$cardNumber,
+                        liveErrorMessage: self.cardForm.cardNumberLiveErrors,
+                        keyboard: .numberPad,
+                        onEditingChanged: { isEditing in
+                            if !isEditing { self.viewModel.retryBinFetch() }
+                        },
+                        formatter: self.viewModel.cardNumberFormatter
+                    )
+
+                    MPTextField(
+                        text: self.$cardForm.cardHolder,
+                        label: self.initResult.fields.cardHolder.label,
+                        placeholder: self.initResult.fields.cardHolder.placeholder,
+                        helperText: self.initResult.fields.cardHolder.helperText,
+                        errorMessage: self.cardForm.$cardHolder
+                    )
+
+                    MPTextField(
+                        text: self.$cardForm.expirationDate,
+                        label: self.initResult.fields.expiration.label,
+                        placeholder: self.initResult.fields.expiration.placeholder,
+                        errorMessage: self.cardForm.$expirationDate,
+                        keyboard: .numberPad,
+                        formatter: self.viewModel.expirationDateFormatter
+                    )
+
+                    if self.viewModel.isSecurityCodeMandatory {
+                        MPTextField(
+                            text: self.$cardForm.securityCode,
+                            label: self.initResult.fields.cvv.label,
+                            placeholder: self.viewModel.cvvPlaceholder,
+                            errorMessage: self.cardForm.$securityCode,
+                            keyboard: .numberPad,
+                            formatter: self.viewModel.securityCodeFormatter,
+                            popoverText: self.viewModel.cvvTooltipText
+                        )
+                    }
+
+                    MPTextField(
+                        text: self.$cardForm.documentHolder,
+                        label: self.initResult.fields.document.label,
+                        placeholder: self.viewModel.selectTypeDocument?.getPlaceholder(),
+                        errorMessage: self.cardForm.$documentHolder,
+                        keyboard: self.viewModel.selectTypeDocument?.getKeyboardType() ?? .default,
+                        formatter: self.viewModel.documentFormatter,
+                        prefix: {
+                            self.dropdownDocument()
+                        }
+                    )
+                }
+                .padding(.horizontal, self.theme.spacings.micro)
             }
-        }
+        )
         .messageSnackbar(
             isPresented: self.$isSnackbarPresented,
             text: MPStrings.Errors.generic,
@@ -143,15 +146,6 @@ struct CardFormScreen: View {
             bottomPadding: self.footerHeight
         )
         .background(self.theme.colors.background.primary.edgesIgnoringSafeArea(.all))
-        .mpTask {
-            do {
-                try await self.viewModel.loadIdentificationTypes()
-            } catch let error as MercadoPagoCheckoutError {
-                self.onFailure(error)
-            } catch {
-                self.onFailure(MercadoPagoCheckoutError(code: .unknown, localizedDescription: error.localizedDescription, location: .identification))
-            }
-        }
         .mpOnChange(of: self.cardForm.cardNumber) { newValue in
             self.viewModel.onCardNumberChange(newValue)
         }
@@ -243,24 +237,5 @@ struct CardFormScreen: View {
     private func updateIdentificationTypes(_ identificationType: IdentificationType?) {
         guard let identificationType else { return }
         self.cardForm.setDocumentLength(identificationType.minLenght, identificationType.maxLenght)
-    }
-}
-
-struct CardForm_Previews: PreviewProvider {
-    static var previews: some View {
-        ThemeProvider(
-            light: MPLightTheme(),
-            dark: MPLightTheme()
-        ) {
-            CardFormScreen(
-                transactionAmount: 100,
-                viewModel: .init(
-                    configuration: .init(
-                        type: .cardForm(cardFormConfiguration: .init()),
-                        paymentMethod: []
-                    )
-                )
-            )
-        }
     }
 }

--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -10,13 +10,12 @@ import SwiftUI
 
 struct CardFormScreen: View {
     private let onBack: (MPCancelledFormContext) -> Void
-    private let initResult: CardFormInitializationOutput
-    private let onBack: () -> Void
     private let onSuccess: (MPPaymentData) -> Void
     private let onFailure: (MercadoPagoCheckoutError) -> Void
     private let transactionAmount: Double?
 
     @ObservedObject private var viewModel: CardFormViewModel
+    private let initResult: CardFormInitializationOutput
 
     // MARK: States View
 
@@ -48,27 +47,20 @@ struct CardFormScreen: View {
     var body: some View {
         MPHeader(
             title: self.initResult.title,
-            onBack: { self.onBack() },
+            onBack: { self.onBack(self.cardForm.cancelledFormContext) },
             footer: {
                 MPFooter(
                     title: MPStrings.Common.total,
                     amount: self.viewModel.footerAmount(),
                     buttonData: .init(
-                        text: self.initResult.button,
+                        text: MPStrings.CardForm.button,
                         onClick: {
-                            Task {
-                                do {
-                                    let paymentData = try await self.viewModel.submitPaymentData(
-                                        self.transactionAmount,
-                                        cardFormData: self.cardForm
-                                    )
-                                    self.onSuccess(paymentData)
-                                } catch let error as MercadoPagoCheckoutError {
-                                    self.onFailure(error)
-                                } catch {
-                                    self.onFailure(.serviceError(error.localizedDescription))
-                                }
-                            }
+                            await self.viewModel.submitCardData(
+                                cardForm: self.cardForm,
+                                transactionAmount: self.transactionAmount,
+                                onSuccess: { self.onSuccess($0) },
+                                onFailure: { self.onFailure($0) }
+                            )
                         }
                     )
                 )

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -10,16 +10,10 @@ import SwiftUI
 
 @MainActor
 final class CardFormViewModel: ObservableObject {
-    enum ScreenState {
-        case loading
-        case ready(CardFormInitializationOutput)
-    }
-
     // MARK: - Dependencies
 
     private let configuration: MercadoPagoCheckout.CheckoutConfiguration
     private let service: CheckoutServiceProtocol
-    private let initializeUseCase: InitializeCardFormUseCase
 
     // MARK: - Formatters
 
@@ -44,7 +38,6 @@ final class CardFormViewModel: ObservableObject {
     @Published private(set) var binNetworkError: MercadoPagoCheckoutError?
     @Published private(set) var showSnackbar = false
     @Published private(set) var isTokenizing = false
-    @Published private(set) var screenState: ScreenState = .loading
 
     var cvvPlaceholder: String {
         self.binData?.paymentMethod.card?.securityCode.length == Self.amexSecurityCodeLength
@@ -85,29 +78,13 @@ final class CardFormViewModel: ObservableObject {
 
     init(
         configuration: MercadoPagoCheckout.CheckoutConfiguration,
-        service: CheckoutServiceProtocol = CheckoutService(),
-        initializeUseCase: InitializeCardFormUseCase = InitializeCardFormUseCase()
+        initResult: CardFormInitializationOutput,
+        service: CheckoutServiceProtocol = CheckoutService()
     ) {
         self.configuration = configuration
         self.service = service
-        self.initializeUseCase = initializeUseCase
-    }
-
-    // MARK: - Initialization
-
-    func loadInitData() async throws {
-        let config = self.extractCardFormConfig()
-        let result = try await self.initializeUseCase.execute(config: config)
-        self.identificationTypes = result.identificationTypes
-        self.selectTypeDocument = result.identificationTypes.first
-        self.screenState = .ready(result)
-    }
-
-    private func extractCardFormConfig() -> MercadoPagoCheckout.CardFormConfiguration {
-        if case let .cardForm(config) = configuration.type {
-            return config
-        }
-        return MercadoPagoCheckout.CardFormConfiguration()
+        self.identificationTypes = initResult.identificationTypes
+        self.selectTypeDocument = initResult.identificationTypes.first
     }
 
     // MARK: - Formatter Updates

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -8,17 +8,18 @@ import CoreMethods
 import MPComponents
 import SwiftUI
 
-enum CardFormScreenState {
-    case loading
-    case ready
-}
-
 @MainActor
 final class CardFormViewModel: ObservableObject {
+    enum ScreenState {
+        case loading
+        case ready(CardFormInitializationOutput)
+    }
+
     // MARK: - Dependencies
 
     private let configuration: MercadoPagoCheckout.CheckoutConfiguration
     private let service: CheckoutServiceProtocol
+    private let initializeUseCase: InitializeCardFormUseCase
 
     // MARK: - Formatters
 
@@ -29,7 +30,6 @@ final class CardFormViewModel: ObservableObject {
 
     // MARK: - Published State
 
-    @Published private(set) var screenState: CardFormScreenState = .loading
     @Published var selectTypeDocument: IdentificationType? {
         didSet { self.updateIdentificationType() }
     }
@@ -44,6 +44,7 @@ final class CardFormViewModel: ObservableObject {
     @Published private(set) var binNetworkError: MercadoPagoCheckoutError?
     @Published private(set) var showSnackbar = false
     @Published private(set) var isTokenizing = false
+    @Published private(set) var screenState: ScreenState = .loading
 
     var cvvPlaceholder: String {
         self.binData?.paymentMethod.card?.securityCode.length == Self.amexSecurityCodeLength
@@ -84,19 +85,29 @@ final class CardFormViewModel: ObservableObject {
 
     init(
         configuration: MercadoPagoCheckout.CheckoutConfiguration,
-        service: CheckoutServiceProtocol = CheckoutService()
+        service: CheckoutServiceProtocol = CheckoutService(),
+        initializeUseCase: InitializeCardFormUseCase = InitializeCardFormUseCase()
     ) {
         self.configuration = configuration
         self.service = service
+        self.initializeUseCase = initializeUseCase
     }
 
-    // MARK: - Identification Types
+    // MARK: - Initialization
 
-    func loadIdentificationTypes() async throws {
-        let types = try await withRetry { try await self.service.identificationTypes() }
-        self.identificationTypes = types
-        self.selectTypeDocument = types.first
-        self.screenState = .ready
+    func loadInitData() async throws {
+        let config = self.extractCardFormConfig()
+        let result = try await self.initializeUseCase.execute(config: config)
+        self.identificationTypes = result.identificationTypes
+        self.selectTypeDocument = result.identificationTypes.first
+        self.screenState = .ready(result)
+    }
+
+    private func extractCardFormConfig() -> MercadoPagoCheckout.CardFormConfiguration {
+        if case let .cardForm(config) = configuration.type {
+            return config
+        }
+        return MercadoPagoCheckout.CardFormConfiguration()
     }
 
     // MARK: - Formatter Updates

--- a/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
+++ b/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
@@ -7,35 +7,39 @@
 import MPComponents
 
 struct CardFormData {
-    @CardFormValidate(
-        RequiredRule(MPStrings.CardForm.CardNumber.errorEmpty),
-        CardNumberRule()
-    )
-    var cardNumber = ""
+    @CardFormValidate var cardNumber: String
+    @CardFormValidate var cardHolder: String
+    @CardFormValidate var expirationDate: String
+    @CardFormValidate var securityCode: String
+    @CardFormValidate var documentHolder: String
 
-    @CardFormValidate(
-        RequiredRule(MPStrings.CardForm.CardHolder.errorEmpty),
-        CardHolderRule()
-    )
-    var cardHolder = ""
-
-    @CardFormValidate(
-        RequiredRule(MPStrings.CardForm.Expiration.errorEmpty),
-        ExpirationDateRule()
-    )
-    var expirationDate = ""
-
-    @CardFormValidate(
-        RequiredRule(MPStrings.CardForm.CVV.errorEmpty),
-        SecurityCodeRule()
-    )
-    var securityCode = ""
-
-    @CardFormValidate(
-        RequiredRule(MPStrings.CardForm.Document.errorEmpty),
-        DocumentRule()
-    )
-    var documentHolder = ""
+    init(fields: CardFormTexts.Fields) {
+        _cardNumber = CardFormValidate(
+            wrappedValue: "",
+            RequiredRule(fields.cardNumber.validation.errorEmpty),
+            CardNumberRule(validation: fields.cardNumber.validation)
+        )
+        _cardHolder = CardFormValidate(
+            wrappedValue: "",
+            RequiredRule(fields.cardHolder.validation.errorEmpty),
+            CardHolderRule(validation: fields.cardHolder.validation)
+        )
+        _expirationDate = CardFormValidate(
+            wrappedValue: "",
+            RequiredRule(fields.expiration.validation.errorEmpty),
+            ExpirationDateRule(validation: fields.expiration.validation)
+        )
+        _securityCode = CardFormValidate(
+            wrappedValue: "",
+            RequiredRule(fields.cvv.validation.errorEmpty),
+            SecurityCodeRule(validation: fields.cvv.validation)
+        )
+        _documentHolder = CardFormValidate(
+            wrappedValue: "",
+            RequiredRule(fields.document.validation.errorEmpty),
+            DocumentRule(validation: fields.document.validation)
+        )
+    }
 
     private var cardAcceptanceError: CardAcceptanceError?
 

--- a/Tests/MercadoPagoCheckoutTests/CardFormDataTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/CardFormDataTests.swift
@@ -13,7 +13,7 @@ final class CardFormDataTests: XCTestCase {
 
     func test_isFormValid_whenAllFieldsValid_shouldReturnTrue() {
         // Arrange
-        var form = CardFormData()
+        var form = CardFormData(fields: CardFormInitializationOutputStub.makeDefaultFields())
         form.cardNumber = "4111111111111111"
         form.cardHolder = "John Doe"
         form.expirationDate = "0130"
@@ -26,7 +26,7 @@ final class CardFormDataTests: XCTestCase {
 
     func test_isFormValid_whenSecurityCodeEmptyAndMandatory_shouldReturnFalse() {
         // Arrange
-        var form = CardFormData()
+        var form = CardFormData(fields: CardFormInitializationOutputStub.makeDefaultFields())
         form.cardNumber = "4111111111111111"
         form.cardHolder = "John Doe"
         form.expirationDate = "0130"
@@ -39,7 +39,7 @@ final class CardFormDataTests: XCTestCase {
 
     func test_isFormValid_whenSecurityCodeNotMandatory_withEmptyCode_shouldReturnTrue() {
         // Arrange
-        var form = CardFormData()
+        var form = CardFormData(fields: CardFormInitializationOutputStub.makeDefaultFields())
         form.cardNumber = "4111111111111111"
         form.cardHolder = "John Doe"
         form.expirationDate = "0130"
@@ -52,7 +52,7 @@ final class CardFormDataTests: XCTestCase {
 
     func test_isFormValid_whenSecurityCodeMandatory_withEmptyCode_shouldReturnFalse() {
         // Arrange
-        var form = CardFormData()
+        var form = CardFormData(fields: CardFormInitializationOutputStub.makeDefaultFields())
         form.cardNumber = "4111111111111111"
         form.cardHolder = "John Doe"
         form.expirationDate = "0130"

--- a/Tests/MercadoPagoCheckoutTests/Mocks/CardFormInitializationStub.swift
+++ b/Tests/MercadoPagoCheckoutTests/Mocks/CardFormInitializationStub.swift
@@ -19,7 +19,7 @@ enum CardFormInitializationInputStub {
                     errorEmpty: "Enter a card number",
                     errorIncomplete: "Card number is incomplete",
                     errorInvalid: "Card number is invalid",
-                    errorSellerExclusion: "%@ is not accepted",
+                    errorMethodNotAllowed: "%@ is not accepted",
                     errorTypeNotAllowed: "%@ cards are not accepted"
                 )
             ),
@@ -30,7 +30,7 @@ enum CardFormInitializationInputStub {
                 validation: .init(
                     errorEmpty: "Enter a name",
                     errorIncomplete: "Name is too short",
-                    errorInvalidFormat: "Invalid characters"
+                    errorInvalid: "Invalid characters"
                 )
             ),
             expiration: .init(
@@ -89,7 +89,7 @@ enum CardFormInitializationOutputStub {
                     errorEmpty: "Enter a card number",
                     errorIncomplete: "Card number is incomplete",
                     errorInvalid: "Card number is invalid",
-                    errorSellerExclusion: "%@ is not accepted",
+                    errorMethodNotAllowed: "%@ is not accepted",
                     errorTypeNotAllowed: "%@ cards are not accepted"
                 )
             ),
@@ -100,7 +100,7 @@ enum CardFormInitializationOutputStub {
                 validation: .init(
                     errorEmpty: "Enter a name",
                     errorIncomplete: "Name is too short",
-                    errorInvalidFormat: "Invalid characters"
+                    errorInvalid: "Invalid characters"
                 )
             ),
             expiration: .init(

--- a/Tests/MercadoPagoCheckoutTests/Mocks/CardFormInitializationStub.swift
+++ b/Tests/MercadoPagoCheckoutTests/Mocks/CardFormInitializationStub.swift
@@ -71,6 +71,15 @@ enum CardFormInitializationInputStub {
 // MARK: - Output (CardFormInitializationOutput - UseCase output)
 
 enum CardFormInitializationOutputStub {
+    static func make(identificationTypes: [IdentificationType] = []) -> CardFormInitializationOutput {
+        CardFormInitializationOutput(
+            title: "Default Header",
+            button: "Save",
+            fields: Self.makeDefaultFields(),
+            identificationTypes: identificationTypes
+        )
+    }
+
     static func makeDefaultFields() -> CardFormTexts.Fields {
         .init(
             cardNumber: .init(

--- a/Tests/MercadoPagoCheckoutTests/Mocks/CardFormInitializationStub.swift
+++ b/Tests/MercadoPagoCheckoutTests/Mocks/CardFormInitializationStub.swift
@@ -5,6 +5,7 @@
 //  Created by Guilherme Prata Costa on 16/03/26.
 //
 
+@testable import CoreMethods
 @testable import MercadoPagoCheckout
 
 // MARK: - Input (CardFormInitializationInput - Repository → UseCase)

--- a/Tests/MercadoPagoCheckoutTests/Rules/CardFormRulesTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Rules/CardFormRulesTests.swift
@@ -10,11 +10,54 @@
 import XCTest
 
 final class CardFormRulesTests: XCTestCase {
+    // MARK: - Default Validation Data Helpers
+
+    private static func defaultCardNumberValidation() -> CardFormTexts.CardNumberField.Validation {
+        .init(
+            errorEmpty: MPStrings.CardForm.CardNumber.errorEmpty,
+            errorIncomplete: MPStrings.CardForm.CardNumber.errorIncomplete,
+            errorInvalid: MPStrings.CardForm.CardNumber.errorInvalid,
+            errorSellerExclusion: MPStrings.CardForm.CardNumber.errorSellerExclusion(brand: "%@"),
+            errorTypeNotAllowed: MPStrings.CardForm.CardNumber.errorTypeNotAllowed(cardType: "%@")
+        )
+    }
+
+    private static func defaultCardHolderValidation() -> CardFormTexts.CardHolderField.Validation {
+        .init(
+            errorEmpty: MPStrings.CardForm.CardHolder.errorEmpty,
+            errorIncomplete: MPStrings.CardForm.CardHolder.errorIncomplete,
+            errorInvalidFormat: MPStrings.CardForm.CardHolder.errorInvalidFormat
+        )
+    }
+
+    private static func defaultExpirationValidation() -> CardFormTexts.ExpirationField.Validation {
+        .init(
+            errorEmpty: MPStrings.CardForm.Expiration.errorEmpty,
+            errorIncomplete: MPStrings.CardForm.Expiration.errorIncomplete,
+            errorInvalid: MPStrings.CardForm.Expiration.errorInvalid
+        )
+    }
+
+    private static func defaultCVVValidation() -> CardFormTexts.CVVField.Validation {
+        .init(
+            errorEmpty: MPStrings.CardForm.CVV.errorEmpty,
+            errorIncomplete: MPStrings.CardForm.CVV.errorIncomplete
+        )
+    }
+
+    private static func defaultDocumentValidation() -> CardFormTexts.DocumentField.Validation {
+        .init(
+            errorEmpty: MPStrings.CardForm.Document.errorEmpty,
+            errorIncomplete: MPStrings.CardForm.Document.errorIncomplete,
+            errorInvalid: MPStrings.CardForm.Document.errorInvalid
+        )
+    }
+
     // MARK: - CardNumberRule
 
     func test_cardNumberRule_whenEmpty_shouldReturnEmptyError() {
         // Arrange
-        let rule = CardNumberRule()
+        let rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
 
         // Act
         let result = rule.validate("")
@@ -25,7 +68,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardNumberRule_whenBelowMinLength_shouldReturnIncompleteError() {
         // Arrange
-        var rule = CardNumberRule()
+        var rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
         rule.apply(.cardNumberRange(min: 16, max: 16))
 
         // Act
@@ -37,9 +80,9 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardNumberRule_whenValidLuhn_shouldReturnNil() {
         // Arrange
-        let rule = CardNumberRule()
+        let rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
 
-        // Act — 4111111111111111 is a valid Luhn number
+        // Act -- 4111111111111111 is a valid Luhn number
         let result = rule.validate("4111 1111 1111 1111")
 
         // Assert
@@ -48,9 +91,9 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardNumberRule_whenInvalidLuhn_shouldReturnInvalidError() {
         // Arrange
-        let rule = CardNumberRule()
+        let rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
 
-        // Act — invalid Luhn
+        // Act -- invalid Luhn
         let result = rule.validate("4111 1111 1111 1112")
 
         // Assert
@@ -59,9 +102,9 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardNumberRule_whenAllDigitsSame_shouldReturnInvalidError() {
         // Arrange
-        let rule = CardNumberRule()
+        let rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
 
-        // Act — all digits repeated (1111111111111111)
+        // Act -- all digits repeated (1111111111111111)
         let result = rule.validate("1111 1111 1111 1111")
 
         // Assert
@@ -70,9 +113,9 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardNumberRule_whenAllDigitsSameDifferentDigit_shouldReturnInvalidError() {
         // Arrange
-        let rule = CardNumberRule()
+        let rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
 
-        // Act — all digits repeated (4444444444444444)
+        // Act -- all digits repeated (4444444444444444)
         let result = rule.validate("4444 4444 4444 4444")
 
         // Assert
@@ -81,7 +124,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardNumberRule_whenPaymentMethodNotAllowed_shouldReturnSellerExclusionError() {
         // Arrange
-        var rule = CardNumberRule()
+        var rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
         rule.apply(.cardNumberExternalError(.paymentMethodNotAllowed("visa")))
 
         // Act
@@ -94,7 +137,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardNumberRule_whenPaymentTypeNotAllowedCredit_shouldReturnTypeNotAllowedError() {
         // Arrange
-        var rule = CardNumberRule()
+        var rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
         rule.apply(.cardNumberExternalError(.paymentTypeNotAllowed(.credit)))
 
         // Act
@@ -106,7 +149,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardNumberRule_whenPaymentTypeNotAllowedDebit_shouldReturnTypeNotAllowedError() {
         // Arrange
-        var rule = CardNumberRule()
+        var rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
         rule.apply(.cardNumberExternalError(.paymentTypeNotAllowed(.debit)))
 
         // Act
@@ -118,7 +161,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardNumberRule_whenPaymentTypeNotAllowedPrepaid_shouldReturnTypeNotAllowedError() {
         // Arrange
-        var rule = CardNumberRule()
+        var rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
         rule.apply(.cardNumberExternalError(.paymentTypeNotAllowed(.prepaid)))
 
         // Act
@@ -130,23 +173,23 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardNumberRule_whenPaymentTypeNotAllowedNil_shouldReturnInvalidError() {
         // Arrange
-        var rule = CardNumberRule()
+        var rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
         rule.apply(.cardNumberExternalError(.paymentTypeNotAllowed(nil)))
 
         // Act
         let result = rule.validate("4111 1111 1111 1111")
 
-        // Assert — nil card type should use generic invalid error (not a broken sentence)
+        // Assert -- nil card type should use generic invalid error (not a broken sentence)
         XCTAssertNotNil(result)
     }
 
     func test_cardNumberRule_whenExternalErrorCleared_shouldValidateNormally() {
         // Arrange
-        var rule = CardNumberRule()
+        var rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
         rule.apply(.cardNumberExternalError(.paymentMethodNotAllowed("visa")))
         rule.apply(.cardNumberExternalError(nil))
 
-        // Act — valid Luhn, no external error
+        // Act -- valid Luhn, no external error
         let result = rule.validate("4111 1111 1111 1111")
 
         // Assert
@@ -157,7 +200,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardNumberRule_validateLive_whenEmpty_shouldReturnNil() {
         // Arrange
-        let rule = CardNumberRule()
+        let rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
 
         // Act
         let result = rule.validateLive("")
@@ -167,8 +210,8 @@ final class CardFormRulesTests: XCTestCase {
     }
 
     func test_cardNumberRule_validateLive_whenBelowMinLength_shouldReturnNil() {
-        // Arrange — number with fewer than 13 digits should not trigger live errors
-        var rule = CardNumberRule()
+        // Arrange -- number with fewer than 13 digits should not trigger live errors
+        var rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
         rule.apply(.cardNumberRange(min: 16, max: 16))
 
         // Act
@@ -180,7 +223,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardNumberRule_validateLive_whenAllDigitsSameAndComplete_shouldReturnInvalidError() {
         // Arrange
-        let rule = CardNumberRule()
+        let rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
 
         // Act
         let result = rule.validateLive("1111 1111 1111 1111")
@@ -191,9 +234,9 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardNumberRule_validateLive_whenValidNumber_shouldReturnNil() {
         // Arrange
-        let rule = CardNumberRule()
+        let rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
 
-        // Act — 4111111111111111 is a valid non-repeated number
+        // Act -- 4111111111111111 is a valid non-repeated number
         let result = rule.validateLive("4111 1111 1111 1111")
 
         // Assert
@@ -202,7 +245,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardNumberRule_validateLive_whenExternalError_shouldReturnError() {
         // Arrange
-        var rule = CardNumberRule()
+        var rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
         rule.apply(.cardNumberExternalError(.paymentMethodNotAllowed("visa")))
 
         // Act
@@ -214,7 +257,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardNumberRule_validateLive_whenExternalErrorCleared_shouldReturnNil() {
         // Arrange
-        var rule = CardNumberRule()
+        var rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
         rule.apply(.cardNumberExternalError(.paymentMethodNotAllowed("visa")))
         rule.apply(.cardNumberExternalError(nil))
 
@@ -226,8 +269,8 @@ final class CardFormRulesTests: XCTestCase {
     }
 
     func test_cardNumberRule_validateLive_whenEmptyWithExternalError_shouldReturnNil() {
-        // Arrange — external error set but field is empty: should not show error
-        var rule = CardNumberRule()
+        // Arrange -- external error set but field is empty: should not show error
+        var rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
         rule.apply(.cardNumberExternalError(.paymentMethodNotAllowed("visa")))
 
         // Act
@@ -241,7 +284,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardHolderRule_whenEmpty_shouldReturnEmptyError() {
         // Arrange
-        let rule = CardHolderRule()
+        let rule = CardHolderRule(validation: Self.defaultCardHolderValidation())
 
         // Act
         let result = rule.validate("")
@@ -252,7 +295,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardHolderRule_whenOnlyWhitespace_shouldReturnEmptyError() {
         // Arrange
-        let rule = CardHolderRule()
+        let rule = CardHolderRule(validation: Self.defaultCardHolderValidation())
 
         // Act
         let result = rule.validate("   ")
@@ -263,7 +306,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardHolderRule_whenSingleChar_shouldReturnIncompleteError() {
         // Arrange
-        let rule = CardHolderRule()
+        let rule = CardHolderRule(validation: Self.defaultCardHolderValidation())
 
         // Act
         let result = rule.validate("A")
@@ -274,7 +317,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardHolderRule_whenLettersOnly_shouldReturnNil() {
         // Arrange
-        let rule = CardHolderRule()
+        let rule = CardHolderRule(validation: Self.defaultCardHolderValidation())
 
         // Act
         let result = rule.validate("Maria Lopez")
@@ -285,7 +328,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardHolderRule_whenLettersAndNumbers_shouldReturnNil() {
         // Arrange
-        let rule = CardHolderRule()
+        let rule = CardHolderRule(validation: Self.defaultCardHolderValidation())
 
         // Act
         let result = rule.validate("John 2nd")
@@ -296,7 +339,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardHolderRule_whenSpecialCharacters_shouldReturnInvalidFormatError() {
         // Arrange
-        let rule = CardHolderRule()
+        let rule = CardHolderRule(validation: Self.defaultCardHolderValidation())
 
         // Act
         let result = rule.validate("Maria @Lopez")
@@ -307,7 +350,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardHolderRule_whenHashCharacter_shouldReturnInvalidFormatError() {
         // Arrange
-        let rule = CardHolderRule()
+        let rule = CardHolderRule(validation: Self.defaultCardHolderValidation())
 
         // Act
         let result = rule.validate("Jo#hn")
@@ -318,7 +361,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardHolderRule_whenAccentedLetters_shouldReturnNil() {
         // Arrange
-        let rule = CardHolderRule()
+        let rule = CardHolderRule(validation: Self.defaultCardHolderValidation())
 
         // Act
         let result = rule.validate("María López")
@@ -381,7 +424,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_securityCodeRule_whenEmpty_shouldReturnEmptyError() {
         // Arrange
-        let rule = SecurityCodeRule()
+        let rule = SecurityCodeRule(validation: Self.defaultCVVValidation())
 
         // Act
         let result = rule.validate("")
@@ -391,8 +434,8 @@ final class CardFormRulesTests: XCTestCase {
     }
 
     func test_securityCodeRule_whenIncomplete_shouldReturnIncompleteError() {
-        // Arrange — default length is 3
-        let rule = SecurityCodeRule()
+        // Arrange -- default length is 3
+        let rule = SecurityCodeRule(validation: Self.defaultCVVValidation())
 
         // Act
         let result = rule.validate("12")
@@ -403,7 +446,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_securityCodeRule_whenCompleteWithDefaultLength_shouldReturnNil() {
         // Arrange
-        let rule = SecurityCodeRule()
+        let rule = SecurityCodeRule(validation: Self.defaultCVVValidation())
 
         // Act
         let result = rule.validate("123")
@@ -414,7 +457,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_securityCodeRule_whenAmexLengthApplied_withFourDigits_shouldReturnNil() {
         // Arrange
-        var rule = SecurityCodeRule()
+        var rule = SecurityCodeRule(validation: Self.defaultCVVValidation())
         rule.apply(.securityCodeLength(4))
 
         // Act
@@ -426,7 +469,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_securityCodeRule_whenAmexLengthApplied_withThreeDigits_shouldReturnIncompleteError() {
         // Arrange
-        var rule = SecurityCodeRule()
+        var rule = SecurityCodeRule(validation: Self.defaultCVVValidation())
         rule.apply(.securityCodeLength(4))
 
         // Act
@@ -434,5 +477,101 @@ final class CardFormRulesTests: XCTestCase {
 
         // Assert
         XCTAssertNotNil(result)
+    }
+
+    // MARK: - Custom Validation Texts
+
+    func test_cardNumberRule_usesCustomValidationTexts() {
+        // Arrange
+        let customValidation = CardFormTexts.CardNumberField.Validation(
+            errorEmpty: "CUSTOM_EMPTY",
+            errorIncomplete: "CUSTOM_INCOMPLETE",
+            errorInvalid: "CUSTOM_INVALID",
+            errorSellerExclusion: "CUSTOM_EXCLUSION %@",
+            errorTypeNotAllowed: "CUSTOM_TYPE %@"
+        )
+        let rule = CardNumberRule(validation: customValidation)
+
+        // Act / Assert -- empty
+        XCTAssertEqual(rule.validate(""), "CUSTOM_EMPTY")
+
+        // Act / Assert -- invalid (all same digits)
+        XCTAssertEqual(rule.validate("1111 1111 1111 1111"), "CUSTOM_INVALID")
+
+        // Act / Assert -- incomplete
+        var ruleWithRange = CardNumberRule(validation: customValidation)
+        ruleWithRange.apply(.cardNumberRange(min: 16, max: 16))
+        XCTAssertEqual(ruleWithRange.validate("4111 1111"), "CUSTOM_INCOMPLETE")
+    }
+
+    func test_cardHolderRule_usesCustomValidationTexts() {
+        // Arrange
+        let customValidation = CardFormTexts.CardHolderField.Validation(
+            errorEmpty: "CUSTOM_EMPTY",
+            errorIncomplete: "CUSTOM_INCOMPLETE",
+            errorInvalidFormat: "CUSTOM_FORMAT"
+        )
+        let rule = CardHolderRule(validation: customValidation)
+
+        // Act / Assert -- empty
+        XCTAssertEqual(rule.validate(""), "CUSTOM_EMPTY")
+
+        // Act / Assert -- incomplete (single char)
+        XCTAssertEqual(rule.validate("A"), "CUSTOM_INCOMPLETE")
+
+        // Act / Assert -- invalid format
+        XCTAssertEqual(rule.validate("Jo@hn"), "CUSTOM_FORMAT")
+    }
+
+    func test_expirationDateRule_usesCustomValidationTexts() {
+        // Arrange
+        let customValidation = CardFormTexts.ExpirationField.Validation(
+            errorEmpty: "CUSTOM_EMPTY",
+            errorIncomplete: "CUSTOM_INCOMPLETE",
+            errorInvalid: "CUSTOM_INVALID"
+        )
+        let rule = ExpirationDateRule(validation: customValidation)
+
+        // Act / Assert -- empty
+        XCTAssertEqual(rule.validate(""), "CUSTOM_EMPTY")
+
+        // Act / Assert -- incomplete (only 2 digits)
+        XCTAssertEqual(rule.validate("12"), "CUSTOM_INCOMPLETE")
+
+        // Act / Assert -- invalid (month 13)
+        XCTAssertEqual(rule.validate("1399"), "CUSTOM_INVALID")
+    }
+
+    func test_securityCodeRule_usesCustomValidationTexts() {
+        // Arrange
+        let customValidation = CardFormTexts.CVVField.Validation(
+            errorEmpty: "CUSTOM_EMPTY",
+            errorIncomplete: "CUSTOM_INCOMPLETE"
+        )
+        let rule = SecurityCodeRule(validation: customValidation)
+
+        // Act / Assert -- empty
+        XCTAssertEqual(rule.validate(""), "CUSTOM_EMPTY")
+
+        // Act / Assert -- incomplete
+        XCTAssertEqual(rule.validate("12"), "CUSTOM_INCOMPLETE")
+    }
+
+    func test_documentRule_usesCustomValidationTexts() {
+        // Arrange
+        let customValidation = CardFormTexts.DocumentField.Validation(
+            errorEmpty: "CUSTOM_EMPTY",
+            errorIncomplete: "CUSTOM_INCOMPLETE",
+            errorInvalid: "CUSTOM_INVALID"
+        )
+        let rule = DocumentRule(validation: customValidation)
+
+        // Act / Assert -- empty
+        XCTAssertEqual(rule.validate(""), "CUSTOM_EMPTY")
+
+        // Act / Assert -- invalid (all zeros)
+        var ruleWithLen = DocumentRule(validation: customValidation)
+        ruleWithLen.apply(.documentLength(min: 3, max: 3))
+        XCTAssertEqual(ruleWithLen.validate("000"), "CUSTOM_INVALID")
     }
 }

--- a/Tests/MercadoPagoCheckoutTests/Rules/CardFormRulesTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Rules/CardFormRulesTests.swift
@@ -17,7 +17,7 @@ final class CardFormRulesTests: XCTestCase {
             errorEmpty: MPStrings.CardForm.CardNumber.errorEmpty,
             errorIncomplete: MPStrings.CardForm.CardNumber.errorIncomplete,
             errorInvalid: MPStrings.CardForm.CardNumber.errorInvalid,
-            errorSellerExclusion: MPStrings.CardForm.CardNumber.errorSellerExclusion(brand: "%@"),
+            errorMethodNotAllowed: MPStrings.CardForm.CardNumber.errorMethodNotAllowed(brand: "%@"),
             errorTypeNotAllowed: MPStrings.CardForm.CardNumber.errorTypeNotAllowed(cardType: "%@")
         )
     }
@@ -26,7 +26,7 @@ final class CardFormRulesTests: XCTestCase {
         .init(
             errorEmpty: MPStrings.CardForm.CardHolder.errorEmpty,
             errorIncomplete: MPStrings.CardForm.CardHolder.errorIncomplete,
-            errorInvalidFormat: MPStrings.CardForm.CardHolder.errorInvalidFormat
+            errorInvalid: MPStrings.CardForm.CardHolder.errorInvalid
         )
     }
 
@@ -487,7 +487,7 @@ final class CardFormRulesTests: XCTestCase {
             errorEmpty: "CUSTOM_EMPTY",
             errorIncomplete: "CUSTOM_INCOMPLETE",
             errorInvalid: "CUSTOM_INVALID",
-            errorSellerExclusion: "CUSTOM_EXCLUSION %@",
+            errorMethodNotAllowed: "CUSTOM_EXCLUSION %@",
             errorTypeNotAllowed: "CUSTOM_TYPE %@"
         )
         let rule = CardNumberRule(validation: customValidation)
@@ -509,7 +509,7 @@ final class CardFormRulesTests: XCTestCase {
         let customValidation = CardFormTexts.CardHolderField.Validation(
             errorEmpty: "CUSTOM_EMPTY",
             errorIncomplete: "CUSTOM_INCOMPLETE",
-            errorInvalidFormat: "CUSTOM_FORMAT"
+            errorInvalid: "CUSTOM_FORMAT"
         )
         let rule = CardHolderRule(validation: customValidation)
 

--- a/Tests/MercadoPagoCheckoutTests/UseCases/InitializeCardFormUseCaseTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/UseCases/InitializeCardFormUseCaseTests.swift
@@ -92,7 +92,7 @@ final class InitializeCardFormUseCaseTests: XCTestCase {
 
     // MARK: - Button Resolution
 
-    func testExecute_withoutAmount_usesSaveButton() async throws {
+    func testExecute_usesSaveButton() async throws {
         let sut = self.makeSUT()
         sut.repository.mockData = CardFormInitializationInput(
             title: "Header",
@@ -101,23 +101,9 @@ final class InitializeCardFormUseCaseTests: XCTestCase {
             identificationTypes: []
         )
 
-        let result = try await sut.useCase.execute(config: self.makeConfig(amount: nil))
+        let result = try await sut.useCase.execute(config: self.makeConfig())
 
         XCTAssertEqual(result.button, "Guardar")
-    }
-
-    func testExecute_withAmount_usesPayButton() async throws {
-        let sut = self.makeSUT()
-        sut.repository.mockData = CardFormInitializationInput(
-            title: "Header",
-            buttonVariants: .init(save: "Guardar", pay: "Pagar"),
-            fields: CardFormInitializationInputStub.makeDefaultFields(),
-            identificationTypes: []
-        )
-
-        let result = try await sut.useCase.execute(config: self.makeConfig(amount: 100.0))
-
-        XCTAssertEqual(result.button, "Pagar")
     }
 
     // MARK: - Error Cases

--- a/Tests/MercadoPagoCheckoutTests/UseCases/InitializeCardFormUseCaseTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/UseCases/InitializeCardFormUseCaseTests.swift
@@ -129,8 +129,10 @@ final class InitializeCardFormUseCaseTests: XCTestCase {
         do {
             _ = try await sut.useCase.execute(config: self.makeConfig())
             XCTFail("Expected repository error to propagate")
+        } catch let error as MercadoPagoCheckoutError {
+            XCTAssertEqual(error.code, .unknown)
         } catch {
-            XCTAssertEqual((error as NSError).domain, "test")
+            XCTFail("Expected MercadoPagoCheckoutError, got \(error)")
         }
     }
 }

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
@@ -791,24 +791,6 @@ final class CardFormViewModelTests: XCTestCase {
         XCTAssertEqual(captured?.documentType, IdentificationTypeStub.cpf.id)
     }
 
-    func test_submitPaymentData_whenBinDataIsNil_shouldThrow() async {
-        // Arrange
-        let sut = self.makeSUT()
-        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
-        sut.viewModel.onCardNumberChange("12345678")
-        await self.waitForChange(sut.viewModel.$binData)
-        await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
-        // No bin fetch triggered — binData remains nil
-
-        // Act & Assert
-        do {
-            _ = try await sut.viewModel.submitPaymentData(nil, cardFormData: CardFormDataStub.validForm)
-            XCTFail("Expected error to be thrown when binData is nil")
-        } catch {
-            // Expected — binData guard throws
-        }
-    }
-
     func test_submitCardData_whenDocumentTypeIsSelected_shouldIncludePayer() async {
         // Arrange
         let sut = self.makeSUT(identificationTypes: [IdentificationTypeStub.cpf])
@@ -872,21 +854,6 @@ final class CardFormViewModelTests: XCTestCase {
         // Assert
         XCTAssertEqual(capturedPaymentData?.paymentMethodId, "visa")
         XCTAssertEqual(capturedPaymentData?.paymentTypeId, "credit_card")
-    }
-
-    func test_submitPaymentData_whenBinDataIsNilAfterConfigure_shouldThrow() async throws {
-        // Arrange
-        let sut = self.makeSUT(identificationTypes: [IdentificationTypeStub.cpf])
-        await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
-        // No bin fetch triggered — binData remains nil
-
-        // Act & Assert
-        do {
-            _ = try await sut.viewModel.submitPaymentData(100.0, cardFormData: CardFormDataStub.validForm)
-            XCTFail("Expected error when binData is nil")
-        } catch {
-            // Expected — guard let binData throws
-        }
     }
 
     func test_submitPaymentData_whenBinDataHasIssuer_shouldIncludeIssuerId() async throws {

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
@@ -18,7 +18,8 @@ final class CardFormViewModelTests: XCTestCase {
 
     typealias SUT = (
         viewModel: CardFormViewModel,
-        service: MockCheckoutService
+        service: MockCheckoutService,
+        repository: MockCardFormInitializationRepository
     )
 
     // MARK: - Properties
@@ -146,22 +147,26 @@ final class CardFormViewModelTests: XCTestCase {
 
     private func makeSUT() -> SUT {
         let service = MockCheckoutService()
+        let repository = MockCardFormInitializationRepository()
         let configuration = MercadoPagoCheckout.CheckoutConfiguration(
             type: .cardForm(cardFormConfiguration: .init()),
             paymentMethod: [.card(allowedTypes: [.credit, .debit, .prepaid])]
         )
-        let viewModel = CardFormViewModel(configuration: configuration, service: service)
-        return (viewModel, service)
+        let useCase = InitializeCardFormUseCase(repository: repository)
+        let viewModel = CardFormViewModel(configuration: configuration, service: service, initializeUseCase: useCase)
+        return (viewModel, service, repository)
     }
 
     private func makeSUTWithAmount(_ amount: Double) -> SUT {
         let service = MockCheckoutService()
+        let repository = MockCardFormInitializationRepository()
         let configuration = MercadoPagoCheckout.CheckoutConfiguration(
             type: .cardForm(cardFormConfiguration: .init(amount: amount)),
             paymentMethod: [.card(allowedTypes: [.credit, .debit, .prepaid])]
         )
-        let viewModel = CardFormViewModel(configuration: configuration, service: service)
-        return (viewModel, service)
+        let useCase = InitializeCardFormUseCase(repository: repository)
+        let viewModel = CardFormViewModel(configuration: configuration, service: service, initializeUseCase: useCase)
+        return (viewModel, service, repository)
     }
 
     private enum CardTokenStub {
@@ -199,7 +204,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     private enum CardFormDataStub {
         static var validForm: CardFormData {
-            var form = CardFormData()
+            var form = CardFormData(fields: CardFormInitializationOutputStub.makeDefaultFields())
             form.cardNumber = "4111111111111111"
             form.cardHolder = "John Doe"
             form.expirationDate = "12/27"
@@ -207,6 +212,19 @@ final class CardFormViewModelTests: XCTestCase {
             form.documentHolder = "12345678900"
             return form
         }
+    }
+
+    private func setupIdentificationTypes(_ sut: SUT) async throws {
+        sut.repository.mockData = MockCardFormInitializationRepository.makeDefault(
+            identificationTypes: [IdentificationTypeStub.cpf]
+        )
+        try await sut.viewModel.loadInitData()
+    }
+
+    private func setupBinData(_ sut: SUT) async {
+        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binData)
     }
 
     private func waitForChange<T>(
@@ -224,14 +242,6 @@ final class CardFormViewModelTests: XCTestCase {
 
     // MARK: - Init
 
-    func test_init_screenStateShouldBeLoading() {
-        // Arrange / Act
-        let sut = self.makeSUT()
-
-        // Assert
-        XCTAssertEqual(sut.viewModel.screenState, .loading)
-    }
-
     func test_init_binDataShouldBeNil() {
         // Arrange / Act
         let sut = self.makeSUT()
@@ -248,88 +258,64 @@ final class CardFormViewModelTests: XCTestCase {
         XCTAssertNil(sut.viewModel.cardAcceptanceError)
     }
 
-    // MARK: - loadIdentificationTypes
+    // MARK: - loadInitData
 
-    func test_loadIdentificationTypes_whenSuccess_shouldSetReadyState() async {
-        // Arrange
+    func test_init_screenStateShouldBeLoading() {
+        // Arrange / Act
         let sut = self.makeSUT()
-        await sut.service.setIdentificationTypesResult(.success([IdentificationTypeStub.cpf]))
-
-        // Act
-        try? await sut.viewModel.loadIdentificationTypes()
 
         // Assert
-        XCTAssertEqual(sut.viewModel.screenState, .ready)
+        if case .loading = sut.viewModel.screenState {} else {
+            XCTFail("Expected .loading state")
+        }
     }
 
-    func test_loadIdentificationTypes_whenSuccess_withTypes_shouldUpdateSelectTypeDocument() async {
+    func test_loadInitData_whenSuccess_shouldSetReadyStateAndTypes() async throws {
         // Arrange
         let sut = self.makeSUT()
-        await sut.service.setIdentificationTypesResult(.success([IdentificationTypeStub.cpf, IdentificationTypeStub.cnpj]))
-
-        // Act
-        try? await sut.viewModel.loadIdentificationTypes()
-
-        // Assert
-        XCTAssertEqual(sut.viewModel.selectTypeDocument, IdentificationTypeStub.cpf)
-    }
-
-    func test_loadIdentificationTypes_whenSuccess_withEmptyTypes_shouldKeepDefaultDocument() async {
-        // Arrange
-        let sut = self.makeSUT()
-        let defaultDocument = sut.viewModel.selectTypeDocument
-        await sut.service.setIdentificationTypesResult(.success([]))
-
-        // Act
-        try? await sut.viewModel.loadIdentificationTypes()
-
-        // Assert
-        XCTAssertEqual(sut.viewModel.selectTypeDocument, defaultDocument)
-        XCTAssertEqual(sut.viewModel.screenState, .ready)
-    }
-
-    func test_loadIdentificationTypes_whenError_shouldKeepDefaultDocument() async {
-        // Arrange
-        let sut = self.makeSUT()
-        let defaultDocument = sut.viewModel.selectTypeDocument
-        await sut.service.setIdentificationTypesResult(.failure(MockCheckoutService.MockError.resultNotSet))
-
-        // Act
-        try? await sut.viewModel.loadIdentificationTypes()
-
-        // Assert
-        XCTAssertEqual(sut.viewModel.selectTypeDocument, defaultDocument)
-    }
-
-    func test_loadIdentificationTypes_whenFirstAttemptFails_andRetrySucceeds_shouldSetTypes() async {
-        // Arrange — first call fails, second (retry) succeeds
-        let sut = self.makeSUT()
-        await sut.service.setSequentialIdentificationTypesResults(
-            .failure(MockCheckoutService.MockError.resultNotSet),
-            .success([IdentificationTypeStub.cpf])
+        sut.repository.mockData = MockCardFormInitializationRepository.makeDefault(
+            identificationTypes: [IdentificationTypeStub.cpf, IdentificationTypeStub.cnpj]
         )
 
         // Act
-        try? await sut.viewModel.loadIdentificationTypes()
+        try await sut.viewModel.loadInitData()
 
         // Assert
-        XCTAssertEqual(sut.viewModel.screenState, .ready)
+        if case .ready = sut.viewModel.screenState {} else {
+            XCTFail("Expected .ready state")
+        }
         XCTAssertEqual(sut.viewModel.selectTypeDocument, IdentificationTypeStub.cpf)
     }
 
-    func test_loadIdentificationTypes_whenBothAttemptsFail_shouldLeaveTypesEmpty() async {
-        // Arrange — both attempts fail
+    func test_loadInitData_whenEmptyTypes_shouldSetReadyState() async throws {
+        // Arrange
         let sut = self.makeSUT()
-        await sut.service.setSequentialIdentificationTypesResults(
-            .failure(MockCheckoutService.MockError.resultNotSet),
-            .failure(MockCheckoutService.MockError.resultNotSet)
-        )
+        // default mock returns empty identificationTypes
 
         // Act
-        try? await sut.viewModel.loadIdentificationTypes()
+        try await sut.viewModel.loadInitData()
 
         // Assert
-        XCTAssertTrue(sut.viewModel.identificationTypes.isEmpty)
+        if case .ready = sut.viewModel.screenState {} else {
+            XCTFail("Expected .ready state")
+        }
+        XCTAssertNil(sut.viewModel.selectTypeDocument)
+    }
+
+    func test_loadInitData_whenRepositoryFails_shouldThrowAndStayLoading() async {
+        // Arrange
+        let sut = self.makeSUT()
+        sut.repository.shouldThrow = true
+
+        // Act & Assert
+        do {
+            try await sut.viewModel.loadInitData()
+            XCTFail("Expected error to be thrown")
+        } catch {
+            if case .loading = sut.viewModel.screenState {} else {
+                XCTFail("Expected .loading state after failure")
+            }
+        }
     }
 
     // MARK: - onCardNumberChange
@@ -702,9 +688,7 @@ final class CardFormViewModelTests: XCTestCase {
     func test_submitCardData_whenServiceSucceeds_shouldCallOnSuccessWithToken() async {
         // Arrange
         let sut = self.makeSUT()
-        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
-        sut.viewModel.onCardNumberChange("12345678")
-        await self.waitForChange(sut.viewModel.$binData)
+        await self.setupBinData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
         var capturedPaymentData: MPPaymentData?
 
@@ -723,6 +707,7 @@ final class CardFormViewModelTests: XCTestCase {
     func test_submitCardData_whenServiceFails_shouldCallOnFailure() async {
         // Arrange
         let sut = self.makeSUT()
+        await self.setupBinData(sut)
         await sut.service.setCreateCardTokenResult(.failure(MockCheckoutService.MockError.resultNotSet))
         var capturedError: MercadoPagoCheckoutError?
 
@@ -759,9 +744,7 @@ final class CardFormViewModelTests: XCTestCase {
     func test_submitCardData_shouldResetIsTokenizingAfterCompletion() async {
         // Arrange
         let sut = self.makeSUT()
-        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
-        sut.viewModel.onCardNumberChange("12345678")
-        await self.waitForChange(sut.viewModel.$binData)
+        await self.setupBinData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
 
         // Act
@@ -779,9 +762,7 @@ final class CardFormViewModelTests: XCTestCase {
     func test_submitCardData_shouldStripSpacesFromCardNumber() async {
         // Arrange
         let sut = self.makeSUT()
-        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
-        sut.viewModel.onCardNumberChange("12345678")
-        await self.waitForChange(sut.viewModel.$binData)
+        await self.setupBinData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
         var cardForm = CardFormDataStub.validForm
         cardForm.cardNumber = "4111 1111 1111 1111"
@@ -802,9 +783,7 @@ final class CardFormViewModelTests: XCTestCase {
     func test_submitCardData_shouldPrefixYearWithCurrentCentury() async {
         // Arrange
         let sut = self.makeSUT()
-        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
-        sut.viewModel.onCardNumberChange("12345678")
-        await self.waitForChange(sut.viewModel.$binData)
+        await self.setupBinData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
         var cardForm = CardFormDataStub.validForm
         cardForm.expirationDate = "12/27"
@@ -827,9 +806,7 @@ final class CardFormViewModelTests: XCTestCase {
     func test_submitCardData_shouldStripMaskFromDocument() async {
         // Arrange
         let sut = self.makeSUT()
-        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
-        sut.viewModel.onCardNumberChange("12345678")
-        await self.waitForChange(sut.viewModel.$binData)
+        await self.setupBinData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
         var cardForm = CardFormDataStub.validForm
         cardForm.documentHolder = "123.456.789-09"
@@ -850,11 +827,8 @@ final class CardFormViewModelTests: XCTestCase {
     func test_submitCardData_whenCalledWithDocumentTypeSelected_shouldPassDocumentType() async {
         // Arrange
         let sut = self.makeSUT()
-        await sut.service.setIdentificationTypesResult(.success([IdentificationTypeStub.cpf]))
-        try? await sut.viewModel.loadIdentificationTypes()
-        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
-        sut.viewModel.onCardNumberChange("12345678")
-        await self.waitForChange(sut.viewModel.$binData)
+        try await self.setupIdentificationTypes(sut)
+        await self.setupBinData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
 
         // Act
@@ -870,35 +844,29 @@ final class CardFormViewModelTests: XCTestCase {
         XCTAssertEqual(captured?.documentType, IdentificationTypeStub.cpf.id)
     }
 
-    func test_submitCardData_whenDocumentTypeIsNil_shouldHaveNilPayer() async {
-        // Arrange — no identificationTypes loaded, selectTypeDocument is nil
+    func test_submitPaymentData_whenBinDataIsNil_shouldThrow() async {
+        // Arrange
         let sut = self.makeSUT()
         await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
         sut.viewModel.onCardNumberChange("12345678")
         await self.waitForChange(sut.viewModel.$binData)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
-        var capturedPaymentData: MPPaymentData?
+        // No bin fetch triggered — binData remains nil
 
-        // Act
-        await sut.viewModel.submitCardData(
-            cardForm: CardFormDataStub.validForm,
-            transactionAmount: nil,
-            onSuccess: { capturedPaymentData = $0 },
-            onFailure: { XCTFail("Expected success, got error: \($0)") }
-        )
-
-        // Assert
-        XCTAssertNil(capturedPaymentData?.payer)
+        // Act & Assert
+        do {
+            _ = try await sut.viewModel.submitPaymentData(nil, cardFormData: CardFormDataStub.validForm)
+            XCTFail("Expected error to be thrown when binData is nil")
+        } catch {
+            // Expected — binData guard throws
+        }
     }
 
     func test_submitCardData_whenDocumentTypeIsSelected_shouldIncludePayer() async {
         // Arrange
         let sut = self.makeSUT()
-        await sut.service.setIdentificationTypesResult(.success([IdentificationTypeStub.cpf]))
-        try? await sut.viewModel.loadIdentificationTypes()
-        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
-        sut.viewModel.onCardNumberChange("12345678")
-        await self.waitForChange(sut.viewModel.$binData)
+        try await self.setupIdentificationTypes(sut)
+        await self.setupBinData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
         var cardForm = CardFormDataStub.validForm
         cardForm.documentHolder = "12345678900"
@@ -920,11 +888,8 @@ final class CardFormViewModelTests: XCTestCase {
     func test_submitCardData_whenDocumentTypeIsSelected_shouldSetTransactionAmountAndInstallment() async {
         // Arrange
         let sut = self.makeSUT()
-        await sut.service.setIdentificationTypesResult(.success([IdentificationTypeStub.cpf]))
-        try? await sut.viewModel.loadIdentificationTypes()
-        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
-        sut.viewModel.onCardNumberChange("12345678")
-        await self.waitForChange(sut.viewModel.$binData)
+        try await self.setupIdentificationTypes(sut)
+        await self.setupBinData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
         var capturedPaymentData: MPPaymentData?
 
@@ -945,6 +910,7 @@ final class CardFormViewModelTests: XCTestCase {
     func test_submitCardData_whenBinDataIsAvailable_shouldIncludePaymentMethodAndTypeIds() async {
         // Arrange
         let sut = self.makeSUT()
+        try await self.setupIdentificationTypes(sut)
         await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
         sut.viewModel.onCardNumberChange("12345678")
         await self.waitForChange(sut.viewModel.$binData)
@@ -964,11 +930,26 @@ final class CardFormViewModelTests: XCTestCase {
         XCTAssertEqual(capturedPaymentData?.paymentTypeId, "credit_card")
     }
 
-    func test_submitCardData_whenBinDataHasIssuer_shouldIncludeIssuerId() async {
+    func test_submitPaymentData_whenBinDataIsNilAfterConfigure_shouldThrow() async throws {
         // Arrange
         let sut = self.makeSUT()
-        await sut.service.setIdentificationTypesResult(.success([IdentificationTypeStub.cpf]))
-        try? await sut.viewModel.loadIdentificationTypes()
+        try await self.setupIdentificationTypes(sut)
+        await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
+        // No bin fetch triggered — binData remains nil
+
+        // Act & Assert
+        do {
+            _ = try await sut.viewModel.submitPaymentData(100.0, cardFormData: CardFormDataStub.validForm)
+            XCTFail("Expected error when binData is nil")
+        } catch {
+            // Expected — guard let binData throws
+        }
+    }
+
+    func test_submitPaymentData_whenBinDataHasIssuer_shouldIncludeIssuerId() async throws {
+        // Arrange
+        let sut = self.makeSUT()
+        try await self.setupIdentificationTypes(sut)
         let binDataWithIssuer = CardBinData(
             paymentMethod: CardBinDataStub.visa.paymentMethod,
             issuer: IssuerStub.bradesco,

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
@@ -213,10 +213,6 @@ final class CardFormViewModelTests: XCTestCase {
         }
     }
 
-    private func setupIdentificationTypes() -> SUT {
-        self.makeSUT(identificationTypes: [IdentificationTypeStub.cpf])
-    }
-
     private func setupBinData(_ sut: SUT) async {
         await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
         sut.viewModel.onCardNumberChange("12345678")
@@ -778,7 +774,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_submitCardData_whenCalledWithDocumentTypeSelected_shouldPassDocumentType() async {
         // Arrange
-        let sut = self.setupIdentificationTypes()
+        let sut = self.makeSUT(identificationTypes: [IdentificationTypeStub.cpf])
         await self.setupBinData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
 
@@ -815,7 +811,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_submitCardData_whenDocumentTypeIsSelected_shouldIncludePayer() async {
         // Arrange
-        let sut = self.setupIdentificationTypes()
+        let sut = self.makeSUT(identificationTypes: [IdentificationTypeStub.cpf])
         await self.setupBinData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
         var cardForm = CardFormDataStub.validForm
@@ -837,7 +833,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_submitCardData_whenDocumentTypeIsSelected_shouldSetTransactionAmountAndInstallment() async {
         // Arrange
-        let sut = self.setupIdentificationTypes()
+        let sut = self.makeSUT(identificationTypes: [IdentificationTypeStub.cpf])
         await self.setupBinData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
         var capturedPaymentData: MPPaymentData?
@@ -858,7 +854,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_submitCardData_whenBinDataIsAvailable_shouldIncludePaymentMethodAndTypeIds() async {
         // Arrange
-        let sut = self.setupIdentificationTypes()
+        let sut = self.makeSUT(identificationTypes: [IdentificationTypeStub.cpf])
         await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
         sut.viewModel.onCardNumberChange("12345678")
         await self.waitForChange(sut.viewModel.$binData)
@@ -880,7 +876,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_submitPaymentData_whenBinDataIsNilAfterConfigure_shouldThrow() async throws {
         // Arrange
-        let sut = self.setupIdentificationTypes()
+        let sut = self.makeSUT(identificationTypes: [IdentificationTypeStub.cpf])
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
         // No bin fetch triggered — binData remains nil
 
@@ -895,7 +891,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_submitPaymentData_whenBinDataHasIssuer_shouldIncludeIssuerId() async throws {
         // Arrange
-        let sut = self.setupIdentificationTypes()
+        let sut = self.makeSUT(identificationTypes: [IdentificationTypeStub.cpf])
         let binDataWithIssuer = CardBinData(
             paymentMethod: CardBinDataStub.visa.paymentMethod,
             issuer: IssuerStub.bradesco,

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
@@ -18,8 +18,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     typealias SUT = (
         viewModel: CardFormViewModel,
-        service: MockCheckoutService,
-        repository: MockCardFormInitializationRepository
+        service: MockCheckoutService
     )
 
     // MARK: - Properties
@@ -145,28 +144,28 @@ final class CardFormViewModelTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makeSUT() -> SUT {
+    private func makeSUT(
+        identificationTypes: [IdentificationType] = []
+    ) -> SUT {
         let service = MockCheckoutService()
-        let repository = MockCardFormInitializationRepository()
         let configuration = MercadoPagoCheckout.CheckoutConfiguration(
             type: .cardForm(cardFormConfiguration: .init()),
             paymentMethod: [.card(allowedTypes: [.credit, .debit, .prepaid])]
         )
-        let useCase = InitializeCardFormUseCase(repository: repository)
-        let viewModel = CardFormViewModel(configuration: configuration, service: service, initializeUseCase: useCase)
-        return (viewModel, service, repository)
+        let initResult = CardFormInitializationOutputStub.make(identificationTypes: identificationTypes)
+        let viewModel = CardFormViewModel(configuration: configuration, initResult: initResult, service: service)
+        return (viewModel, service)
     }
 
     private func makeSUTWithAmount(_ amount: Double) -> SUT {
         let service = MockCheckoutService()
-        let repository = MockCardFormInitializationRepository()
         let configuration = MercadoPagoCheckout.CheckoutConfiguration(
             type: .cardForm(cardFormConfiguration: .init(amount: amount)),
             paymentMethod: [.card(allowedTypes: [.credit, .debit, .prepaid])]
         )
-        let useCase = InitializeCardFormUseCase(repository: repository)
-        let viewModel = CardFormViewModel(configuration: configuration, service: service, initializeUseCase: useCase)
-        return (viewModel, service, repository)
+        let initResult = CardFormInitializationOutputStub.make(identificationTypes: [])
+        let viewModel = CardFormViewModel(configuration: configuration, initResult: initResult, service: service)
+        return (viewModel, service)
     }
 
     private enum CardTokenStub {
@@ -214,11 +213,8 @@ final class CardFormViewModelTests: XCTestCase {
         }
     }
 
-    private func setupIdentificationTypes(_ sut: SUT) async throws {
-        sut.repository.mockData = MockCardFormInitializationRepository.makeDefault(
-            identificationTypes: [IdentificationTypeStub.cpf]
-        )
-        try await sut.viewModel.loadInitData()
+    private func setupIdentificationTypes() -> SUT {
+        self.makeSUT(identificationTypes: [IdentificationTypeStub.cpf])
     }
 
     private func setupBinData(_ sut: SUT) async {
@@ -258,64 +254,20 @@ final class CardFormViewModelTests: XCTestCase {
         XCTAssertNil(sut.viewModel.cardAcceptanceError)
     }
 
-    // MARK: - loadInitData
+    func test_init_withIdentificationTypes_shouldSelectFirst() {
+        // Arrange / Act
+        let sut = self.makeSUT(identificationTypes: [IdentificationTypeStub.cpf, IdentificationTypeStub.cnpj])
 
-    func test_init_screenStateShouldBeLoading() {
+        // Assert
+        XCTAssertEqual(sut.viewModel.selectTypeDocument, IdentificationTypeStub.cpf)
+    }
+
+    func test_init_withNoIdentificationTypes_shouldSelectNil() {
         // Arrange / Act
         let sut = self.makeSUT()
 
         // Assert
-        if case .loading = sut.viewModel.screenState {} else {
-            XCTFail("Expected .loading state")
-        }
-    }
-
-    func test_loadInitData_whenSuccess_shouldSetReadyStateAndTypes() async throws {
-        // Arrange
-        let sut = self.makeSUT()
-        sut.repository.mockData = MockCardFormInitializationRepository.makeDefault(
-            identificationTypes: [IdentificationTypeStub.cpf, IdentificationTypeStub.cnpj]
-        )
-
-        // Act
-        try await sut.viewModel.loadInitData()
-
-        // Assert
-        if case .ready = sut.viewModel.screenState {} else {
-            XCTFail("Expected .ready state")
-        }
-        XCTAssertEqual(sut.viewModel.selectTypeDocument, IdentificationTypeStub.cpf)
-    }
-
-    func test_loadInitData_whenEmptyTypes_shouldSetReadyState() async throws {
-        // Arrange
-        let sut = self.makeSUT()
-        // default mock returns empty identificationTypes
-
-        // Act
-        try await sut.viewModel.loadInitData()
-
-        // Assert
-        if case .ready = sut.viewModel.screenState {} else {
-            XCTFail("Expected .ready state")
-        }
         XCTAssertNil(sut.viewModel.selectTypeDocument)
-    }
-
-    func test_loadInitData_whenRepositoryFails_shouldThrowAndStayLoading() async {
-        // Arrange
-        let sut = self.makeSUT()
-        sut.repository.shouldThrow = true
-
-        // Act & Assert
-        do {
-            try await sut.viewModel.loadInitData()
-            XCTFail("Expected error to be thrown")
-        } catch {
-            if case .loading = sut.viewModel.screenState {} else {
-                XCTFail("Expected .loading state after failure")
-            }
-        }
     }
 
     // MARK: - onCardNumberChange
@@ -826,8 +778,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_submitCardData_whenCalledWithDocumentTypeSelected_shouldPassDocumentType() async {
         // Arrange
-        let sut = self.makeSUT()
-        try await self.setupIdentificationTypes(sut)
+        let sut = self.setupIdentificationTypes()
         await self.setupBinData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
 
@@ -864,8 +815,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_submitCardData_whenDocumentTypeIsSelected_shouldIncludePayer() async {
         // Arrange
-        let sut = self.makeSUT()
-        try await self.setupIdentificationTypes(sut)
+        let sut = self.setupIdentificationTypes()
         await self.setupBinData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
         var cardForm = CardFormDataStub.validForm
@@ -887,8 +837,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_submitCardData_whenDocumentTypeIsSelected_shouldSetTransactionAmountAndInstallment() async {
         // Arrange
-        let sut = self.makeSUT()
-        try await self.setupIdentificationTypes(sut)
+        let sut = self.setupIdentificationTypes()
         await self.setupBinData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
         var capturedPaymentData: MPPaymentData?
@@ -909,8 +858,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_submitCardData_whenBinDataIsAvailable_shouldIncludePaymentMethodAndTypeIds() async {
         // Arrange
-        let sut = self.makeSUT()
-        try await self.setupIdentificationTypes(sut)
+        let sut = self.setupIdentificationTypes()
         await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
         sut.viewModel.onCardNumberChange("12345678")
         await self.waitForChange(sut.viewModel.$binData)
@@ -932,8 +880,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_submitPaymentData_whenBinDataIsNilAfterConfigure_shouldThrow() async throws {
         // Arrange
-        let sut = self.makeSUT()
-        try await self.setupIdentificationTypes(sut)
+        let sut = self.setupIdentificationTypes()
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
         // No bin fetch triggered — binData remains nil
 
@@ -948,8 +895,7 @@ final class CardFormViewModelTests: XCTestCase {
 
     func test_submitPaymentData_whenBinDataHasIssuer_shouldIncludeIssuerId() async throws {
         // Arrange
-        let sut = self.makeSUT()
-        try await self.setupIdentificationTypes(sut)
+        let sut = self.setupIdentificationTypes()
         let binDataWithIssuer = CardBinData(
             paymentMethod: CardBinDataStub.visa.paymentMethod,
             issuer: IssuerStub.bradesco,


### PR DESCRIPTION
## Summary
- Refactors `CardFormRules` to use the new `CardFormTexts` model for centralized text definitions
- Updates `CardFormData` field mappings to work with the new initialization output
- Integrates `InitializeCardFormUseCase` into `CardFormBrick`, `CardFormScreen`, and `CardFormViewModel`
- Updated test coverage for rules, data, and view model layers

## Context
**PR 2/2** of the Card Form initialization architecture.
Depends on PR #129 (domain layer).

### PR chain:
1. #129 — Domain layer (models, use case, repository)
2. **This PR** — Rules, data refactor + view layer integration

## Test plan
- [x] `CardFormRulesTests` updated
- [x] `CardFormDataTests` updated
- [x] `CardFormViewModelTests` updated