### PR TITLE
[3687] (Fix)Fix translations and add new locales (CL, CO, PE, UY)

### DIFF
--- a/Sources/MPFoundation/Resources/es-AR.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-AR.lproj/Localizable.strings
@@ -5,11 +5,11 @@
   Extraído de: MLA (Voseado).tokens.json
 */
 
-// MARK: - Form Title & Buttons
+/* MARK: - Form Title & Buttons */
 "form.title" = "Ingresá tu tarjeta";
 "form.button" = "Guardar tarjeta";
 
-// MARK: - Card Number
+/* MARK: - Card Number */
 "card_number.label" = "Número de tarjeta";
 "card_number.placeholder" = "1234 1234 1234 1234";
 "card_number.error.empty" = "Completá este campo.";
@@ -22,7 +22,7 @@
 "card_number.error.debit_only" = "La tienda solo acepta tarjetas de débito.";
 "card_number.error.type_not_allowed" = "La tienda no acepta %@.";
 
-// MARK: - Card Holder
+/* MARK: - Card Holder */
 "card_holder.label" = "Nombre del titular";
 "card_holder.placeholder" = "Ej.: María López";
 "card_holder.error.empty" = "Completá este campo.";
@@ -30,14 +30,14 @@
 "card_holder.error.invalid_format" = "Ingresá solo letras y números.";
 "card_holder.helper.text" = "Como aparece en la tarjeta.";
 
-// MARK: - Expiration Date
+/* MARK: - Expiration Date */
 "expiration.label" = "Vencimiento";
 "expiration.placeholder" = "MM/AA";
 "expiration.error.empty" = "Completá este campo.";
 "expiration.error.incomplete" = "Ingresá la fecha completa.";
 "expiration.error.invalid" = "Ingresá una fecha válida.";
 
-// MARK: - Security Code (CVV)
+/* MARK: - Security Code (CVV) */
 "cvv.label" = "Código de seguridad";
 "cvv.placeholder.default" = "Ej.: 123";
 "cvv.placeholder.amex" = "Ej.: 1234";
@@ -52,12 +52,12 @@
 "cvv.tooltip.unknown.default" = "Es un número de 3 dígitos que está en el dorso de tu tarjeta.";
 "cvv.tooltip.unknown.amex" = "Es un número de 4 dígitos. Lo encontrás al frente de tu tarjeta o en la app de tu banco o billetera.";
 
-// MARK: - Issuer (Multiple Issuers)
+/* MARK: - Issuer (Multiple Issuers) */
 "issuer.label" = "Entidad emisora";
 "issuer.placeholder" = "Seleccioná una opción.";
 "issuer.error.empty" = "Seleccioná una opción.";
 
-// MARK: - Document
+/* MARK: - Document */
 "document.label" = "Documento del titular";
 "document.type" = "DNI";
 "document.placeholder" = "99.999.999";
@@ -66,13 +66,13 @@
 "document.error.invalid" = "Ingresá un documento válido.";
 "document.error.funding" = "Solo podrás ingresar dinero con tarjetas a tu nombre.";
 
-// MARK: - Installments
+/* MARK: - Installments */
 "installments.title" = "Elegí las cuotas";
 "installments.show_more" = "Mostrar más opciones";
 "installments.show_less" = "Mostrar menos opciones";
 "installments.interest_free" = "Sin interés";
 
-// MARK: - Common
+/* MARK: - Common */
 "common.cancel" = "Cancelar";
 "common.confirm" = "Confirmar";
 "common.continue" = "Continuar";
@@ -83,12 +83,12 @@
 "common.loading" = "Cargando...";
 "common.accessibility.textfield.moreInfo" = "Más información";
 "common.total" = "Total";
-"common.currency" = "$"
+"common.currency" = "$";
 "common.credit" = "Crédito";
 "common.debit" = "Débito";
 "common.prepaid" = "Prepaga";
 
-// MARK: - Errors
+/* MARK: - Errors */
 "error.generic" = "Algo salió mal. Por favor, intentá de nuevo.";
 "error.network" = "Error de conexión. Verificá tu conexión a internet.";
 

--- a/Sources/MPFoundation/Resources/es-CL.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-CL.lproj/Localizable.strings
@@ -1,0 +1,93 @@
+/*
+  Localizable.strings (Spanish - Chile)
+  MercadoPagoSDK
+
+  Extraído de: MLC.tokens.json
+*/
+
+/* MARK: - Form Title & Buttons */
+"form.title" = "Ingresa tu tarjeta";
+"form.button" = "Guardar tarjeta";
+
+/* MARK: - Card Number */
+"card_number.label" = "Número de tarjeta";
+"card_number.placeholder" = "1234 1234 1234 1234";
+"card_number.error.empty" = "Completa este campo.";
+"card_number.error.incomplete" = "Ingresa el número completo.";
+"card_number.error.invalid" = "Ingrésalo como aparece en la tarjeta.";
+"card_number.error.credit_limit" = "Ingresa una tarjeta con límite suficiente para pagar el monto.";
+"card_number.error.debit_balance" = "Ingresa una tarjeta con saldo suficiente para pagar el monto.";
+"card_number.error.seller_exclusion" = "La tienda no acepta tarjetas %@.";
+"card_number.error.credit_only" = "La tienda solo acepta tarjetas de crédito.";
+"card_number.error.debit_only" = "La tienda solo acepta tarjetas de débito.";
+"card_number.error.type_not_allowed" = "La tienda no acepta %@.";
+
+/* MARK: - Card Holder */
+"card_holder.label" = "Nombre del titular";
+"card_holder.placeholder" = "Ej.: María López";
+"card_holder.error.empty" = "Completa este campo.";
+"card_holder.error.incomplete" = "Ingresa el nombre tal como aparece en la tarjeta.";
+"card_holder.error.invalid_format" = "Ingresa solo letras y números.";
+"card_holder.helper.text" = "Como aparece en la tarjeta.";
+
+/* MARK: - Expiration Date */
+"expiration.label" = "Vencimiento";
+"expiration.placeholder" = "MM/AA";
+"expiration.error.empty" = "Completa este campo.";
+"expiration.error.incomplete" = "Ingresa la fecha completa.";
+"expiration.error.invalid" = "Ingresa una fecha válida.";
+
+/* MARK: - Security Code (CVV) */
+"cvv.label" = "Código de seguridad";
+"cvv.placeholder.default" = "Ej.: 123";
+"cvv.placeholder.amex" = "Ej.: 1234";
+"cvv.error.empty" = "Completa este campo.";
+"cvv.error.incomplete" = "Ingresa el código completo.";
+"cvv.optional" = "Dato opcional.";
+"cvv.tooltip.static" = "Es un número de %ld dígitos que está %@ de tu tarjeta.";
+"cvv.tooltip.location.back" = "en el dorso";
+"cvv.tooltip.location.front" = "en el frente";
+"cvv.tooltip.dynamic.default" = "Es un número de 3 dígitos que encuentras en la app de tu banco o billetera.";
+"cvv.tooltip.dynamic.amex" = "Es un número de 4 dígitos que encuentras en la app de tu banco o billetera.";
+"cvv.tooltip.unknown.default" = "Es un número de 3 dígitos que está en el dorso de tu tarjeta.";
+"cvv.tooltip.unknown.amex" = "Es un número de 4 dígitos. Lo encuentras al frente de tu tarjeta o en la app de tu banco o billetera.";
+
+/* MARK: - Issuer (Multiple Issuers) */
+"issuer.label" = "Entidad emisora";
+"issuer.placeholder" = "Selecciona una opción.";
+"issuer.error.empty" = "Selecciona una opción.";
+
+/* MARK: - Document */
+"document.label" = "Documento del titular";
+"document.type" = "RUT";
+"document.placeholder" = "99.999.999-9";
+"document.error.empty" = "Completa este campo.";
+"document.error.incomplete" = "Ingresa el documento completo.";
+"document.error.invalid" = "Ingresa un documento válido.";
+"document.error.funding" = "Solo podrás ingresar dinero con tarjetas a tu nombre.";
+
+/* MARK: - Installments */
+"installments.title" = "Elige las cuotas";
+"installments.show_more" = "Mostrar más opciones";
+"installments.show_less" = "Mostrar menos opciones";
+"installments.interest_free" = "Sin interés";
+
+/* MARK: - Common */
+"common.cancel" = "Cancelar";
+"common.confirm" = "Confirmar";
+"common.continue" = "Continuar";
+"common.back" = "Volver";
+"common.close" = "Cerrar";
+"common.error" = "Error";
+"common.retry" = "Reintentar";
+"common.loading" = "Cargando...";
+"common.accessibility.textfield.moreInfo" = "Más información";
+"common.total" = "Total";
+"common.currency" = "$";
+"common.credit" = "Crédito";
+"common.debit" = "Débito";
+"common.prepaid" = "Prepago";
+
+/* MARK: - Errors */
+"error.generic" = "Algo salió mal. Por favor, intenta de nuevo.";
+"error.network" = "Error de conexión. Verifica tu conexión a internet.";

--- a/Sources/MPFoundation/Resources/es-CO.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-CO.lproj/Localizable.strings
@@ -1,0 +1,93 @@
+/*
+  Localizable.strings (Spanish - Colombia)
+  MercadoPagoSDK
+
+  Extraído de: MCO.tokens.json
+*/
+
+/* MARK: - Form Title & Buttons */
+"form.title" = "Ingresa tu tarjeta";
+"form.button" = "Guardar tarjeta";
+
+/* MARK: - Card Number */
+"card_number.label" = "Número de tarjeta";
+"card_number.placeholder" = "1234 1234 1234 1234";
+"card_number.error.empty" = "Completa este campo.";
+"card_number.error.incomplete" = "Ingresa el número completo.";
+"card_number.error.invalid" = "Ingrésalo como aparece en la tarjeta.";
+"card_number.error.credit_limit" = "Ingresa una tarjeta con límite suficiente para pagar el monto.";
+"card_number.error.debit_balance" = "Ingresa una tarjeta con saldo suficiente para pagar el monto.";
+"card_number.error.seller_exclusion" = "La tienda no acepta tarjetas %@.";
+"card_number.error.credit_only" = "La tienda solo acepta tarjetas de crédito.";
+"card_number.error.debit_only" = "La tienda solo acepta tarjetas de débito.";
+"card_number.error.type_not_allowed" = "La tienda no acepta %@.";
+
+/* MARK: - Card Holder */
+"card_holder.label" = "Nombre del titular";
+"card_holder.placeholder" = "Ej.: María López";
+"card_holder.error.empty" = "Completa este campo.";
+"card_holder.error.incomplete" = "Ingresa el nombre tal como aparece en la tarjeta.";
+"card_holder.error.invalid_format" = "Ingresa solo letras y números.";
+"card_holder.helper.text" = "Como aparece en la tarjeta.";
+
+/* MARK: - Expiration Date */
+"expiration.label" = "Vencimiento";
+"expiration.placeholder" = "MM/AA";
+"expiration.error.empty" = "Completa este campo.";
+"expiration.error.incomplete" = "Ingresa la fecha completa.";
+"expiration.error.invalid" = "Ingresa una fecha válida.";
+
+/* MARK: - Security Code (CVV) */
+"cvv.label" = "Código de seguridad";
+"cvv.placeholder.default" = "Ej.: 123";
+"cvv.placeholder.amex" = "Ej.: 1234";
+"cvv.error.empty" = "Completa este campo.";
+"cvv.error.incomplete" = "Ingresa el código completo.";
+"cvv.optional" = "Dato opcional.";
+"cvv.tooltip.static" = "Es un número de %ld dígitos que está %@ de tu tarjeta.";
+"cvv.tooltip.location.back" = "en el dorso";
+"cvv.tooltip.location.front" = "en el frente";
+"cvv.tooltip.dynamic.default" = "Es un número de 3 dígitos que encuentras en la app de tu banco o billetera.";
+"cvv.tooltip.dynamic.amex" = "Es un número de 4 dígitos que encuentras en la app de tu banco o billetera.";
+"cvv.tooltip.unknown.default" = "Es un número de 3 dígitos que está en el dorso de tu tarjeta.";
+"cvv.tooltip.unknown.amex" = "Es un número de 4 dígitos. Lo encuentras al frente de tu tarjeta o en la app de tu banco o billetera.";
+
+/* MARK: - Issuer (Multiple Issuers) */
+"issuer.label" = "Entidad emisora";
+"issuer.placeholder" = "Selecciona una opción.";
+"issuer.error.empty" = "Selecciona una opción.";
+
+/* MARK: - Document */
+"document.label" = "Documento del titular";
+"document.type" = "CC";
+"document.placeholder" = "9.999.999.999";
+"document.error.empty" = "Completa este campo.";
+"document.error.incomplete" = "Ingresa el documento completo.";
+"document.error.invalid" = "Ingresa un documento válido.";
+"document.error.funding" = "Solo podrás ingresar dinero con tarjetas a tu nombre.";
+
+/* MARK: - Installments */
+"installments.title" = "Elige las cuotas";
+"installments.show_more" = "Mostrar más opciones";
+"installments.show_less" = "Mostrar menos opciones";
+"installments.interest_free" = "Sin interés";
+
+/* MARK: - Common */
+"common.cancel" = "Cancelar";
+"common.confirm" = "Confirmar";
+"common.continue" = "Continuar";
+"common.back" = "Volver";
+"common.close" = "Cerrar";
+"common.error" = "Error";
+"common.retry" = "Reintentar";
+"common.loading" = "Cargando...";
+"common.accessibility.textfield.moreInfo" = "Más información";
+"common.total" = "Total";
+"common.currency" = "$";
+"common.credit" = "Crédito";
+"common.debit" = "Débito";
+"common.prepaid" = "Prepago";
+
+/* MARK: - Errors */
+"error.generic" = "Algo salió mal. Por favor, intenta de nuevo.";
+"error.network" = "Error de conexión. Verifica tu conexión a internet.";

--- a/Sources/MPFoundation/Resources/es-MX.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-MX.lproj/Localizable.strings
@@ -5,11 +5,11 @@
   Extraído de: MLM.tokens.json
 */
 
-// MARK: - Form Title & Buttons
+/* MARK: - Form Title & Buttons */
 "form.title" = "Ingresá tu tarjeta";
 "form.button" = "Guardar tarjeta";
 
-// MARK: - Card Number
+/* MARK: - Card Number */
 "card_number.label" = "Número de tarjeta";
 "card_number.placeholder" = "1234 1234 1234 1234";
 "card_number.error.empty" = "Completa este campo.";
@@ -22,7 +22,7 @@
 "card_number.error.debit_only" = "La tienda solo acepta tarjetas de débito.";
 "card_number.error.type_not_allowed" = "La tienda no acepta %@.";
 
-// MARK: - Card Holder
+/* MARK: - Card Holder */
 "card_holder.label" = "Nombre del titular";
 "card_holder.placeholder" = "Ej.: María López";
 "card_holder.error.empty" = "Completa este campo.";
@@ -30,14 +30,14 @@
 "card_holder.error.invalid_format" = "Ingresa solo letras y números.";
 "card_holder.helper.text" = "Como aparece en la tarjeta.";
 
-// MARK: - Expiration Date
+/* MARK: - Expiration Date */
 "expiration.label" = "Vencimiento";
 "expiration.placeholder" = "MM/AA";
 "expiration.error.empty" = "Completa este campo.";
 "expiration.error.incomplete" = "Ingresa la fecha completa.";
 "expiration.error.invalid" = "Ingresa una fecha válida.";
 
-// MARK: - Security Code (CVV)
+/* MARK: - Security Code (CVV) */
 "cvv.label" = "Código de seguridad";
 "cvv.placeholder.default" = "Ej.: 123";
 "cvv.placeholder.amex" = "Ej.: 1234";
@@ -52,12 +52,12 @@
 "cvv.tooltip.unknown.default" = "Es un número de 3 dígitos que está en el dorso de tu tarjeta.";
 "cvv.tooltip.unknown.amex" = "Es un número de 4 dígitos. Lo encuentras al frente de tu tarjeta o en la app de tu banco o billetera.";
 
-// MARK: - Issuer (Multiple Issuers)
+/* MARK: - Issuer (Multiple Issuers) */
 "issuer.label" = "Entidad emisora";
 "issuer.placeholder" = "Selecciona una opción.";
 "issuer.error.empty" = "Selecciona una opción.";
 
-// MARK: - Document
+/* MARK: - Document */
 "document.label" = "Documento del titular";
 "document.type" = "";
 "document.placeholder" = "";
@@ -66,13 +66,13 @@
 "document.error.invalid" = "Ingresa un documento válido.";
 "document.error.funding" = "Solo podrás ingresar dinero con tarjetas a tu nombre.";
 
-// MARK: - Installments
+/* MARK: - Installments */
 "installments.title" = "Elige las mensualidades";
 "installments.show_more" = "Mostrar más opciones";
 "installments.show_less" = "Mostrar menos opciones";
 "installments.interest_free" = "Sin intereses";
 
-// MARK: - Common
+/* MARK: - Common */
 "common.cancel" = "Cancelar";
 "common.confirm" = "Confirmar";
 "common.continue" = "Continuar";
@@ -88,7 +88,7 @@
 "common.debit" = "Débito";
 "common.prepaid" = "Prepagada";
 
-// MARK: - Errors
+/* MARK: - Errors */
 "error.generic" = "Algo salió mal. Por favor, intenta de nuevo.";
 "error.network" = "Error de conexión. Verifica tu conexión a internet.";
 

--- a/Sources/MPFoundation/Resources/es-PE.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-PE.lproj/Localizable.strings
@@ -1,0 +1,93 @@
+/*
+  Localizable.strings (Spanish - Peru)
+  MercadoPagoSDK
+
+  Extraído de: MPE.tokens.json
+*/
+
+/* MARK: - Form Title & Buttons */
+"form.title" = "Ingresa tu tarjeta";
+"form.button" = "Guardar tarjeta";
+
+/* MARK: - Card Number */
+"card_number.label" = "Número de tarjeta";
+"card_number.placeholder" = "1234 1234 1234 1234";
+"card_number.error.empty" = "Completa este campo.";
+"card_number.error.incomplete" = "Ingresa el número completo.";
+"card_number.error.invalid" = "Ingrésalo como aparece en la tarjeta.";
+"card_number.error.credit_limit" = "Ingresa una tarjeta con límite suficiente para pagar el monto.";
+"card_number.error.debit_balance" = "Ingresa una tarjeta con saldo suficiente para pagar el monto.";
+"card_number.error.seller_exclusion" = "La tienda no acepta tarjetas %@.";
+"card_number.error.credit_only" = "La tienda solo acepta tarjetas de crédito.";
+"card_number.error.debit_only" = "La tienda solo acepta tarjetas de débito.";
+"card_number.error.type_not_allowed" = "La tienda no acepta %@.";
+
+/* MARK: - Card Holder */
+"card_holder.label" = "Nombre del titular";
+"card_holder.placeholder" = "Ej.: María López";
+"card_holder.error.empty" = "Completa este campo.";
+"card_holder.error.incomplete" = "Ingresa el nombre tal como aparece en la tarjeta.";
+"card_holder.error.invalid_format" = "Ingresa solo letras y números.";
+"card_holder.helper.text" = "Como aparece en la tarjeta.";
+
+/* MARK: - Expiration Date */
+"expiration.label" = "Vencimiento";
+"expiration.placeholder" = "MM/AA";
+"expiration.error.empty" = "Completa este campo.";
+"expiration.error.incomplete" = "Ingresa la fecha completa.";
+"expiration.error.invalid" = "Ingresa una fecha válida.";
+
+/* MARK: - Security Code (CVV) */
+"cvv.label" = "Código de seguridad";
+"cvv.placeholder.default" = "Ej.: 123";
+"cvv.placeholder.amex" = "Ej.: 1234";
+"cvv.error.empty" = "Completa este campo.";
+"cvv.error.incomplete" = "Ingresa el código completo.";
+"cvv.optional" = "Dato opcional.";
+"cvv.tooltip.static" = "Es un número de %ld dígitos que está %@ de tu tarjeta.";
+"cvv.tooltip.location.back" = "en el dorso";
+"cvv.tooltip.location.front" = "en el frente";
+"cvv.tooltip.dynamic.default" = "Es un número de 3 dígitos que encuentras en la app de tu banco o billetera.";
+"cvv.tooltip.dynamic.amex" = "Es un número de 4 dígitos que encuentras en la app de tu banco o billetera.";
+"cvv.tooltip.unknown.default" = "Es un número de 3 dígitos que está en el dorso de tu tarjeta.";
+"cvv.tooltip.unknown.amex" = "Es un número de 4 dígitos. Lo encuentras al frente de tu tarjeta o en la app de tu banco o billetera.";
+
+/* MARK: - Issuer (Multiple Issuers) */
+"issuer.label" = "Entidad emisora";
+"issuer.placeholder" = "Selecciona una opción.";
+"issuer.error.empty" = "Selecciona una opción.";
+
+/* MARK: - Document */
+"document.label" = "Documento del titular";
+"document.type" = "DNI";
+"document.placeholder" = "99999999";
+"document.error.empty" = "Completa este campo.";
+"document.error.incomplete" = "Ingresa el documento completo.";
+"document.error.invalid" = "Ingresa un documento válido.";
+"document.error.funding" = "Solo podrás ingresar dinero con tarjetas a tu nombre.";
+
+/* MARK: - Installments */
+"installments.title" = "Elige las cuotas";
+"installments.show_more" = "Mostrar más opciones";
+"installments.show_less" = "Mostrar menos opciones";
+"installments.interest_free" = "Sin interés";
+
+/* MARK: - Common */
+"common.cancel" = "Cancelar";
+"common.confirm" = "Confirmar";
+"common.continue" = "Continuar";
+"common.back" = "Volver";
+"common.close" = "Cerrar";
+"common.error" = "Error";
+"common.retry" = "Reintentar";
+"common.loading" = "Cargando...";
+"common.accessibility.textfield.moreInfo" = "Más información";
+"common.total" = "Total";
+"common.currency" = "S/";
+"common.credit" = "Crédito";
+"common.debit" = "Débito";
+"common.prepaid" = "Prepago";
+
+/* MARK: - Errors */
+"error.generic" = "Algo salió mal. Por favor, intenta de nuevo.";
+"error.network" = "Error de conexión. Verifica tu conexión a internet.";

--- a/Sources/MPFoundation/Resources/es-UY.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-UY.lproj/Localizable.strings
@@ -1,0 +1,93 @@
+/*
+  Localizable.strings (Spanish - Uruguay)
+  MercadoPagoSDK
+
+  Extraído de: MLU (Voseado).tokens.json
+*/
+
+/* MARK: - Form Title & Buttons */
+"form.title" = "Ingresá tu tarjeta";
+"form.button" = "Guardar tarjeta";
+
+/* MARK: - Card Number */
+"card_number.label" = "Número de tarjeta";
+"card_number.placeholder" = "1234 1234 1234 1234";
+"card_number.error.empty" = "Completá este campo.";
+"card_number.error.incomplete" = "Ingresá el número completo.";
+"card_number.error.invalid" = "Ingresalo como aparece en la tarjeta.";
+"card_number.error.credit_limit" = "Ingresá una tarjeta con límite suficiente para pagar el monto.";
+"card_number.error.debit_balance" = "Ingresá una tarjeta con saldo suficiente para pagar el monto.";
+"card_number.error.seller_exclusion" = "La tienda no acepta tarjetas %@.";
+"card_number.error.credit_only" = "La tienda solo acepta tarjetas de crédito.";
+"card_number.error.debit_only" = "La tienda solo acepta tarjetas de débito.";
+"card_number.error.type_not_allowed" = "La tienda no acepta %@.";
+
+/* MARK: - Card Holder */
+"card_holder.label" = "Nombre del titular";
+"card_holder.placeholder" = "Ej.: María López";
+"card_holder.error.empty" = "Completá este campo.";
+"card_holder.error.incomplete" = "Ingresá el nombre tal como aparece en la tarjeta.";
+"card_holder.error.invalid_format" = "Ingresá solo letras y números.";
+"card_holder.helper.text" = "Como aparece en la tarjeta.";
+
+/* MARK: - Expiration Date */
+"expiration.label" = "Vencimiento";
+"expiration.placeholder" = "MM/AA";
+"expiration.error.empty" = "Completá este campo.";
+"expiration.error.incomplete" = "Ingresá la fecha completa.";
+"expiration.error.invalid" = "Ingresá una fecha válida.";
+
+/* MARK: - Security Code (CVV) */
+"cvv.label" = "Código de seguridad";
+"cvv.placeholder.default" = "Ej.: 123";
+"cvv.placeholder.amex" = "Ej.: 1234";
+"cvv.error.empty" = "Completá este campo.";
+"cvv.error.incomplete" = "Ingresá el código completo.";
+"cvv.optional" = "Dato opcional.";
+"cvv.tooltip.static" = "Es un número de %ld dígitos que está %@ de tu tarjeta.";
+"cvv.tooltip.location.back" = "en el dorso";
+"cvv.tooltip.location.front" = "en el frente";
+"cvv.tooltip.dynamic.default" = "Es un número de 3 dígitos que encontrás en la app de tu banco o billetera.";
+"cvv.tooltip.dynamic.amex" = "Es un número de 4 dígitos que encontrás en la app de tu banco o billetera.";
+"cvv.tooltip.unknown.default" = "Es un número de 3 dígitos que está en el dorso de tu tarjeta.";
+"cvv.tooltip.unknown.amex" = "Es un número de 4 dígitos. Lo encontrás al frente de tu tarjeta o en la app de tu banco o billetera.";
+
+/* MARK: - Issuer (Multiple Issuers) */
+"issuer.label" = "Entidad emisora";
+"issuer.placeholder" = "Seleccioná una opción.";
+"issuer.error.empty" = "Seleccioná una opción.";
+
+/* MARK: - Document */
+"document.label" = "Documento del titular";
+"document.type" = "CI";
+"document.placeholder" = "9.999.999-9";
+"document.error.empty" = "Completá este campo.";
+"document.error.incomplete" = "Ingresá el documento completo.";
+"document.error.invalid" = "Ingresá un documento válido.";
+"document.error.funding" = "Solo podrás ingresar dinero con tarjetas a tu nombre.";
+
+/* MARK: - Installments */
+"installments.title" = "Elegí las cuotas";
+"installments.show_more" = "Mostrar más opciones";
+"installments.show_less" = "Mostrar menos opciones";
+"installments.interest_free" = "Sin interés";
+
+/* MARK: - Common */
+"common.cancel" = "Cancelar";
+"common.confirm" = "Confirmar";
+"common.continue" = "Continuar";
+"common.back" = "Volver";
+"common.close" = "Cerrar";
+"common.error" = "Error";
+"common.retry" = "Reintentar";
+"common.loading" = "Cargando...";
+"common.accessibility.textfield.moreInfo" = "Más información";
+"common.total" = "Total";
+"common.currency" = "$";
+"common.credit" = "Crédito";
+"common.debit" = "Débito";
+"common.prepaid" = "Prepaga";
+
+/* MARK: - Errors */
+"error.generic" = "Algo salió mal. Por favor, intentá de nuevo.";
+"error.network" = "Error de conexión. Verificá tu conexión a internet.";

--- a/Sources/MPFoundation/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/pt-BR.lproj/Localizable.strings
@@ -5,11 +5,11 @@
   Extraído de: MLB.tokens.json
 */
 
-// MARK: - Form Title & Buttons
+/* MARK: - Form Title & Buttons */
 "form.title" = "Preencha os dados do cartão";
 "form.button" = "Salvar cartão";
 
-// MARK: - Card Number
+/* MARK: - Card Number */
 "card_number.label" = "Número do cartão";
 "card_number.placeholder" = "1234 1234 1234 1234";
 "card_number.error.empty" = "Preencha este campo.";
@@ -22,7 +22,7 @@
 "card_number.error.debit_only" = "A loja só aceita cartões de débito.";
 "card_number.error.type_not_allowed" = "A loja não aceita %@.";
 
-// MARK: - Card Holder
+/* MARK: - Card Holder */
 "card_holder.label" = "Nome do titular";
 "card_holder.placeholder" = "Ex.: Maria dos Santos";
 "card_holder.error.empty" = "Preencha este campo.";
@@ -30,14 +30,14 @@
 "card_holder.error.invalid_format" = "Digite apenas letras e números.";
 "card_holder.helper.text" = "Conforme aparece no cartão.";
 
-// MARK: - Expiration Date
+/* MARK: - Expiration Date */
 "expiration.label" = "Vencimento";
 "expiration.placeholder" = "MM/AA";
 "expiration.error.empty" = "Preencha este campo.";
 "expiration.error.incomplete" = "Insira a data completa.";
 "expiration.error.invalid" = "Insira uma data válida.";
 
-// MARK: - Security Code (CVV)
+/* MARK: - Security Code (CVV) */
 "cvv.label" = "Código de segurança";
 "cvv.placeholder.default" = "Ex.: 123";
 "cvv.placeholder.amex" = "Ex.: 1234";
@@ -52,12 +52,12 @@
 "cvv.tooltip.unknown.default" = "É um número de 3 dígitos que está atrás do seu cartão.";
 "cvv.tooltip.unknown.amex" = "É um número de 4 dígitos. Você o encontra na parte da frente do seu cartão ou no app do seu banco ou carteira digital.";
 
-// MARK: - Issuer (Multiple Issuers)
+/* MARK: - Issuer (Multiple Issuers) */
 "issuer.label" = "Instituição emissora";
 "issuer.placeholder" = "Selecione uma opção.";
 "issuer.error.empty" = "Selecione uma opção.";
 
-// MARK: - Document
+/* MARK: - Document */
 "document.label" = "Documento do titular";
 "document.type" = "CPF";
 "document.placeholder" = "999.999.999-99";
@@ -66,13 +66,13 @@
 "document.error.invalid" = "Insira um documento válido.";
 "document.error.funding" = "Você só poderá depositar dinheiro com cartões no seu nome.";
 
-// MARK: - Installments
+/* MARK: - Installments */
 "installments.title" = "Escolha o parcelamento";
 "installments.show_more" = "Mostrar mais opções";
 "installments.show_less" = "Mostrar menos opções";
 "installments.interest_free" = "Sem acréscimo";
 
-// MARK: - Common
+/* MARK: - Common */
 "common.cancel" = "Cancelar";
 "common.confirm" = "Confirmar";
 "common.continue" = "Continuar";
@@ -88,6 +88,6 @@
 "common.debit" = "Débito";
 "common.prepaid" = "Pré-pago";
 
-// MARK: - Errors
+/* MARK: - Errors */
 "error.generic" = "Algo deu errado. Por favor, tente novamente.";
 "error.network" = "Erro de conexão. Verifique sua conexão com a internet.";


### PR DESCRIPTION
## Summary
- Fix comment syntax in `.strings` files (`//` → `/* */`) for es-AR, es-MX, pt-BR
- Fix missing semicolon in `common.currency` key (es-AR)
- Add new locale translations: es-CL, es-CO, es-PE, es-UY

## Test plan
- [ ] Build sem erros
- [ ] Testes unitários passando
- [ ] Verificar que strings são carregadas corretamente nos novos locales