### PR TITLE
[CHOBK-3776] (Fix): Fix document min length not persisting on init

### DIFF
--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -35,13 +35,19 @@ struct CardFormScreen: View {
         onSuccess: @escaping (MPPaymentData) -> Void = { _ in },
         onFailure: @escaping (MercadoPagoCheckoutError) -> Void = { _ in }
     ) {
-        self.initResult = initResult
-        self._cardForm = State(initialValue: CardFormData(fields: initResult.fields))
-        self._viewModel = ObservedObject(wrappedValue: viewModel)
         self.onBack = onBack
         self.onSuccess = onSuccess
         self.onFailure = onFailure
         self.transactionAmount = transactionAmount
+        self.initResult = initResult
+
+        self._viewModel = ObservedObject(wrappedValue: viewModel)
+
+        var formData = CardFormData(fields: initResult.fields)
+        if let firstType = viewModel.selectTypeDocument {
+            formData.setDocumentLength(firstType.minLenght, firstType.maxLenght)
+        }
+        self._cardForm = State(initialValue: formData)
     }
 
     var body: some View {


### PR DESCRIPTION
## O que foi feito
- Corrigido bug onde `DocumentRule.minLength` não era persistido na inicialização da tela
- Root cause: `@State` mutado via `self.cardForm` no `init` da View opera numa cópia temporária — o SwiftUI só usa o valor passado no `State(initialValue:)`
- Fix: aplicar `setDocumentLength` no `CardFormData` **antes** de passá-lo para `State(initialValue:)`
- Removidos prints de debug no `DocumentRule`
- Validação de documento agora usa range check `(min...max).contains(count)`

## Como testar
- [ ] Build sem erros
- [ ] Testes unitários passando
- [ ] Ao abrir o card form, validação de documento respeita o `minLength` da API desde o início