### PR TITLE
[CHOBK-3787] (Fix): Fix background color during CardFormBrick loading state

### DIFF
--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -25,6 +25,7 @@ struct CardFormBrick: View {
     private let onResult: (MercadoPagoCheckoutResult) -> Void
 
     @Environment(\.presentationMode) var presentationMode
+    @Environment(\.checkoutTheme) private var theme: MPTheme
 
     init(
         configuration: MercadoPagoCheckout.CheckoutConfiguration,
@@ -50,9 +51,12 @@ struct CardFormBrick: View {
                 ZStack {
                     switch self.brickViewModel.screenState {
                     case .loading:
-                        MPProgressIndicator()
-                            .size(.xlarge)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        ZStack {
+                            self.theme.colors.background.primary
+                                .edgesIgnoringSafeArea(.all)
+                            MPProgressIndicator()
+                                .size(.xlarge)
+                        }
                     case let .ready(initResult):
                         self.cardFormScreen(initResult: initResult)
                     }


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
https://mercadolibre.atlassian.net/browse/CHOBK-3787

## Description
- Fixed background color not being applied during `CardFormBrick` loading state
- Wrapped `MPProgressIndicator` in a `ZStack` that applies `theme.colors.background.primary` with `edgesIgnoringSafeArea(.all)`, ensuring the theme background is visible while the form initializes
- Added `@Environment(\.checkoutTheme)` to `CardFormBrick` to access the current theme during the loading state

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>