### PR TITLE
[CHOBK-3800] (Fix): Fix CardFormBrick state lost on background transition

### DIFF
--- a/Sources/MPFoundation/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/pt-BR.lproj/Localizable.strings
@@ -24,7 +24,7 @@
 
 /* MARK: - Card Holder */
 "card_holder.label" = "Nome do titular";
-"card_holder.placeholder" = "Ex.: Maria dos Santos";
+"card_holder.placeholder" = "Ex.: Maria Lopes";
 "card_holder.error.empty" = "Preencha este campo.";
 "card_holder.error.incomplete" = "Insira conforme está no cartão.";
 "card_holder.error.invalid_format" = "Digite apenas letras e números.";

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -57,8 +57,8 @@ struct CardFormBrick: View {
                             MPProgressIndicator()
                                 .size(.xlarge)
                         }
-                    case let .ready(initResult):
-                        self.cardFormScreen(initResult: initResult)
+                    case let .ready(initResult, cardFormViewModel):
+                        self.cardFormScreen(initResult: initResult, viewModel: cardFormViewModel)
                     }
                     self.navigationLinks()
                 }
@@ -81,11 +81,11 @@ struct CardFormBrick: View {
         }
     }
 
-    private func cardFormScreen(initResult: CardFormInitializationOutput) -> some View {
+    private func cardFormScreen(initResult: CardFormInitializationOutput, viewModel: CardFormViewModel) -> some View {
         CardFormScreen(
             initResult: initResult,
             transactionAmount: self.transactionAmount,
-            viewModel: CardFormViewModel(configuration: self.configuration, initResult: initResult),
+            viewModel: viewModel,
             onBack: { context in self.cancelCheckout(context: .cardForm(context)) },
             onSuccess: { paymentData in
                 self.paymentData = paymentData

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 final class CardFormBrickViewModel: ObservableObject {
     enum ScreenState {
         case loading
-        case ready(CardFormInitializationOutput)
+        case ready(CardFormInitializationOutput, CardFormViewModel)
     }
 
     // MARK: - Published State
@@ -35,9 +35,11 @@ final class CardFormBrickViewModel: ObservableObject {
     // MARK: - Initialization
 
     func load() async throws(MercadoPagoCheckoutError) {
+        guard case .loading = self.screenState else { return }
         let config = self.extractCardFormConfig()
         let result = try await self.initializeUseCase.execute(config: config)
-        self.screenState = .ready(result)
+        let viewModel = CardFormViewModel(configuration: self.configuration, initResult: result)
+        self.screenState = .ready(result, viewModel)
     }
 
     // MARK: - Private


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
https://mercadolibre.atlassian.net/browse/CHOBK-3800

## Description
- Fixed `CardFormBrickViewModel.ScreenState.ready` to store the `CardFormViewModel` alongside `CardFormInitializationOutput`, preventing it from being recreated on view re-renders
- Added a guard in `CardFormBrickViewModel.load()` to skip re-initialization if the state is already `.ready`, preserving form state when the app returns from background
- Updated `CardFormBrick` to extract and pass the stored `CardFormViewModel` from state instead of instantiating a new one each time
- Fixed pt-BR placeholder for card holder name field

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>