### PR TITLE
[CHOBK-3793] (Fix): Update keyboard type for identification fields

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -419,7 +419,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Sources/Preview Content\"";
-				DEVELOPMENT_TEAM = N34W3XSZ62;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -433,7 +432,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.mercadopago.sdk.ios.Example.danielle;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mercadopago.sdk.ios.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -453,7 +452,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Sources/Preview Content\"";
-				DEVELOPMENT_TEAM = N34W3XSZ62;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -467,7 +465,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.mercadopago.sdk.ios.Example.danielle;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mercadopago.sdk.ios.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -419,6 +419,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Sources/Preview Content\"";
+				DEVELOPMENT_TEAM = N34W3XSZ62;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -432,7 +433,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.mercadopago.sdk.ios.Example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mercadopago.sdk.ios.Example.danielle;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -452,6 +453,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Sources/Preview Content\"";
+				DEVELOPMENT_TEAM = N34W3XSZ62;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -465,7 +467,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.mercadopago.sdk.ios.Example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mercadopago.sdk.ios.Example.danielle;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/Sources/MercadoPagoCheckout/Utils/CardFormFormatting.swift
+++ b/Sources/MercadoPagoCheckout/Utils/CardFormFormatting.swift
@@ -94,33 +94,54 @@ package struct ExpirationDateFormatter: TextFormatting {
 // MARK: - Document Formatter
 
 /// A formatter that applies a mask pattern to document numbers.
-/// Uses '#' for digit positions and any other character as a literal.
-/// When the format is empty, the input is returned unchanged.
+/// Mask placeholders:
+///   - `#` — digit-only position
+///   - `A` — alphanumeric position (letters and digits)
+///   - Any other character — literal separator
+/// When the format is empty, the input is returned unchanged (filtered by type).
 package struct DocumentFormatter: TextFormatting {
     private let maskFormat: String
     private let maxLength: Int
+    private let isNumericType: Bool
 
-    package init(mask: String = "", maxLength: Int = 20) {
+    package init(mask: String = "", maxLength: Int = 20, isNumericType: Bool = true) {
         self.maskFormat = mask
         self.maxLength = maxLength
+        self.isNumericType = isNumericType
     }
 
     package func formatOnChange(_ text: String) -> String {
-        guard !self.maskFormat.isEmpty else {
-            return String(text.prefix(self.maxLength))
+        let cleaned: String
+        if self.isNumericType {
+            cleaned = String(text.filter(\.isNumber).prefix(self.maxLength))
+        } else {
+            cleaned = String(text.filter { $0.isLetter || $0.isNumber }.prefix(self.maxLength))
         }
-        let digits = String(
-            text.components(separatedBy: CharacterSet.decimalDigits.inverted).joined().prefix(self.maxLength)
-        )
-        var result = ""
-        var index = digits.startIndex
 
-        for char in self.maskFormat where index < digits.endIndex {
-            if char == "#" {
-                result.append(digits[index])
-                index = digits.index(after: index)
-            } else {
-                result.append(char)
+        guard !self.maskFormat.isEmpty else {
+            return cleaned
+        }
+
+        var result = ""
+        var index = cleaned.startIndex
+
+        for maskChar in self.maskFormat where index < cleaned.endIndex {
+            switch maskChar {
+            case "#":
+                // Digit-only position: skip any non-digit chars in the cleaned input
+                while index < cleaned.endIndex, !cleaned[index].isNumber {
+                    index = cleaned.index(after: index)
+                }
+                if index < cleaned.endIndex {
+                    result.append(cleaned[index])
+                    index = cleaned.index(after: index)
+                }
+            case "A":
+                // Alphanumeric position: accept any letter or digit
+                result.append(cleaned[index])
+                index = cleaned.index(after: index)
+            default:
+                result.append(maskChar)
             }
         }
 

--- a/Sources/MercadoPagoCheckout/Utils/Extensions/IdentificationType+Checkout.swift
+++ b/Sources/MercadoPagoCheckout/Utils/Extensions/IdentificationType+Checkout.swift
@@ -9,28 +9,27 @@ import CoreMethods
 import SwiftUI
 
 extension IdentificationType {
-
     func getPlaceholder() -> String {
         switch id {
-        case "CPF":  return "999.999.999-99"
+        case "CPF": return "999.999.999-99"
         case "CNPJ": return "99.999.999/9999-99"
-        default:     return ""
+        default: return ""
         }
     }
 
     func getFormat() -> String {
         switch id {
-        case "CPF":  return "###.###.###-##"
-        case "CNPJ": return "##.###.###/####-##"
-        default:     return ""
+        case "CPF": return "###.###.###-##"
+        case "CNPJ": return type == "string" ? "AA.AAA.AAA/AAAA-##" : "##.###.###/####-##"
+        default: return ""
         }
     }
-    
+
     func getKeyboardType() -> UIKeyboardType {
         switch type {
-        case "number":  return .numberPad
-        case "numeric": return .default
-        default:     return .default
+        case "number": return .numberPad
+        case "string": return .default
+        default: return .default
         }
     }
 }

--- a/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
+++ b/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
@@ -13,6 +13,7 @@ package enum CardValidationRequirement {
     case cardNumberExternalError(CardAcceptanceError?)
     case securityCodeLength(Int)
     case documentLength(min: Int, max: Int)
+    case documentType(isNumeric: Bool)
 }
 
 package protocol CardFormRuleType {
@@ -197,23 +198,31 @@ package struct DocumentRule: CardFormRuleType {
     private let validation: CardFormTexts.DocumentField.Validation
     private var maxLength = 20
     private var minLength = 1
+    private var isNumericType = true
 
     init(validation: CardFormTexts.DocumentField.Validation) {
         self.validation = validation
     }
 
     package mutating func apply(_ requirement: CardValidationRequirement) {
-        if case let .documentLength(minLen, maxLen) = requirement {
+        switch requirement {
+        case let .documentLength(minLen, maxLen):
             self.minLength = minLen
             self.maxLength = maxLen
+        case let .documentType(isNumeric):
+            self.isNumericType = isNumeric
+        default:
+            break
         }
     }
 
     package func validate(_ value: String) -> String? {
-        let digits = value.filter(\.isNumber)
-        if digits.isEmpty { return self.validation.errorEmpty }
-        if !(self.minLength ... self.maxLength).contains(digits.count) { return self.validation.errorIncomplete }
-        if digits.allSatisfy({ $0 == "0" }) { return self.validation.errorInvalid }
+        let chars = self.isNumericType
+            ? value.filter(\.isNumber)
+            : value.filter { $0.isLetter || $0.isNumber }
+        if chars.isEmpty { return self.validation.errorEmpty }
+        if !(self.minLength ... self.maxLength).contains(chars.count) { return self.validation.errorIncomplete }
+        if self.isNumericType, chars.allSatisfy({ $0 == "0" }) { return self.validation.errorInvalid }
         return nil
     }
 }

--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -47,6 +47,7 @@ struct CardFormScreen: View {
         var formData = CardFormData(fields: initResult.fields)
         if let firstType = viewModel.selectTypeDocument {
             formData.setDocumentLength(firstType.minLenght, firstType.maxLenght)
+            formData.setDocumentType(isNumeric: firstType.type != "string")
         }
         self._cardForm = State(initialValue: formData)
     }
@@ -247,5 +248,6 @@ struct CardFormScreen: View {
     private func updateIdentificationTypes(_ identificationType: IdentificationType?) {
         guard let identificationType else { return }
         self.cardForm.setDocumentLength(identificationType.minLenght, identificationType.maxLenght)
+        self.cardForm.setDocumentType(isNumeric: identificationType.type != "string")
     }
 }

--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -136,13 +136,13 @@ struct CardFormScreen: View {
                             label: self.initResult.fields.document.label,
                             placeholder: self.viewModel.selectTypeDocument?.getPlaceholder(),
                             errorMessage: self.cardForm.$documentHolder,
-                            keyboard: self.viewModel.documentKeyboardType,
+                            keyboard: self.viewModel.selectTypeDocument?.getKeyboardType() ?? .default,
                             formatter: self.viewModel.documentFormatter,
                             prefix: {
                                 self.dropdownDocument()
                             }
                         )
-                        .id(self.viewModel.documentKeyboardType)
+                        .id(self.viewModel.selectTypeDocument?.getKeyboardType() ?? .default)
                     }
                 }
                 .padding(.horizontal, self.theme.spacings.micro)

--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -136,12 +136,13 @@ struct CardFormScreen: View {
                             label: self.initResult.fields.document.label,
                             placeholder: self.viewModel.selectTypeDocument?.getPlaceholder(),
                             errorMessage: self.cardForm.$documentHolder,
-                            keyboard: self.viewModel.selectTypeDocument?.getKeyboardType() ?? .default,
+                            keyboard: self.viewModel.documentKeyboardType,
                             formatter: self.viewModel.documentFormatter,
                             prefix: {
                                 self.dropdownDocument()
                             }
                         )
+                        .id(self.viewModel.documentKeyboardType)
                     }
                 }
                 .padding(.horizontal, self.theme.spacings.micro)

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -20,7 +20,8 @@ final class CardFormViewModel: ObservableObject {
     @Published private(set) var cardNumberFormatter = CardNumberFormatter()
     let expirationDateFormatter = ExpirationDateFormatter()
     @Published private(set) var securityCodeFormatter = SecurityCodeFormatter()
-    private(set) var documentFormatter = DocumentFormatter()
+    @Published private(set) var documentFormatter = DocumentFormatter()
+    @Published private(set) var documentKeyboardType: UIKeyboardType = .default
 
     // MARK: - Published State
 
@@ -89,6 +90,14 @@ final class CardFormViewModel: ObservableObject {
         self.service = service
         self.identificationTypes = initResult.identificationTypes
         self.selectTypeDocument = initResult.identificationTypes.first
+
+        let firstType = initResult.identificationTypes.first
+        self.documentFormatter = DocumentFormatter(
+            mask: firstType?.getFormat() ?? String(),
+            maxLength: firstType?.maxLenght ?? 20,
+            isNumericType: firstType?.type != "string"
+        )
+        self.documentKeyboardType = firstType?.getKeyboardType() ?? .default
     }
 
     // MARK: - Formatter Updates
@@ -99,6 +108,7 @@ final class CardFormViewModel: ObservableObject {
             maxLength: self.selectTypeDocument?.maxLenght ?? 20,
             isNumericType: self.selectTypeDocument?.type != "string"
         )
+        self.documentKeyboardType = self.selectTypeDocument?.getKeyboardType() ?? .default
     }
 
     private func updateFormatters(for binData: CardBinData?) {

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -96,7 +96,8 @@ final class CardFormViewModel: ObservableObject {
     private func updateIdentificationType() {
         self.documentFormatter = DocumentFormatter(
             mask: self.selectTypeDocument?.getFormat() ?? String(),
-            maxLength: self.selectTypeDocument?.maxLenght ?? 20
+            maxLength: self.selectTypeDocument?.maxLenght ?? 20,
+            isNumericType: self.selectTypeDocument?.type != "string"
         )
     }
 
@@ -135,7 +136,7 @@ final class CardFormViewModel: ObservableObject {
         let shortYear = String(expirationParts.dropFirst().first ?? "")
         let century = Calendar.current.component(.year, from: Date()) / 100
         let year = "\(century)\(shortYear)"
-        let rawDocument = cardForm.documentHolder.filter(\.isNumber)
+        let rawDocument = cardForm.documentHolder.filter { $0.isLetter || $0.isNumber }
 
         return CardParams(
             cardNumber: rawCardNumber,
@@ -220,7 +221,7 @@ final class CardFormViewModel: ObservableObject {
             guard let selectTypeDocument else { return nil }
             return .init(
                 type: selectTypeDocument.type,
-                number: cardFormData.documentHolder.filter(\.isNumber)
+                number: cardFormData.documentHolder.filter { $0.isLetter || $0.isNumber }
             )
         }
 

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -21,7 +21,6 @@ final class CardFormViewModel: ObservableObject {
     let expirationDateFormatter = ExpirationDateFormatter()
     @Published private(set) var securityCodeFormatter = SecurityCodeFormatter()
     @Published private(set) var documentFormatter = DocumentFormatter()
-    @Published private(set) var documentKeyboardType: UIKeyboardType = .default
 
     // MARK: - Published State
 
@@ -97,7 +96,6 @@ final class CardFormViewModel: ObservableObject {
             maxLength: firstType?.maxLenght ?? 20,
             isNumericType: firstType?.type != "string"
         )
-        self.documentKeyboardType = firstType?.getKeyboardType() ?? .default
     }
 
     // MARK: - Formatter Updates
@@ -108,7 +106,6 @@ final class CardFormViewModel: ObservableObject {
             maxLength: self.selectTypeDocument?.maxLenght ?? 20,
             isNumericType: self.selectTypeDocument?.type != "string"
         )
-        self.documentKeyboardType = self.selectTypeDocument?.getKeyboardType() ?? .default
     }
 
     private func updateFormatters(for binData: CardBinData?) {

--- a/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
+++ b/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
@@ -51,6 +51,10 @@ struct CardFormData {
         _documentHolder.update(.documentLength(min: min, max: max))
     }
 
+    mutating func setDocumentType(isNumeric: Bool) {
+        _documentHolder.update(.documentType(isNumeric: isNumeric))
+    }
+
     mutating func setCardNumberLength(_ minLength: Int = 13, _ maxLength: Int = 16) {
         _cardNumber.update(.cardNumberRange(min: minLength, max: maxLength))
     }
@@ -123,7 +127,7 @@ struct CardFormData {
 
     private func documentHolderState() -> CardFormUserCancelledContext.FieldState.State {
         guard !_documentHolder.errorMessages.isEmpty else { return .valid }
-        if self.documentHolder.filter(\.isNumber).isEmpty { return .empty }
+        if self.documentHolder.filter({ $0.isLetter || $0.isNumber }).isEmpty { return .empty }
         if _documentHolder.errorMessages.contains(MPStrings.CardForm.Document.errorIncomplete) { return .incomplete }
         return .invalid
     }

--- a/Tests/MercadoPagoCheckoutTests/Extensions/IdentificationTypeCheckoutTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Extensions/IdentificationTypeCheckoutTests.swift
@@ -1,0 +1,37 @@
+//
+//  IdentificationTypeCheckoutTests.swift
+//  MercadoPagoSDK
+//
+
+@testable import CoreMethods
+@testable import MercadoPagoCheckout
+import UIKit
+import XCTest
+
+final class IdentificationTypeCheckoutTests: XCTestCase {
+    // MARK: - getKeyboardType
+
+    func test_getKeyboardType_whenNumberType_shouldReturnNumberPad() {
+        // Arrange
+        let type = IdentificationType(id: "CPF", name: "CPF", type: "number", minLenght: 11, maxLenght: 11)
+
+        // Act / Assert
+        XCTAssertEqual(type.getKeyboardType(), .numberPad)
+    }
+
+    func test_getKeyboardType_whenStringType_shouldReturnDefault() {
+        // Arrange
+        let type = IdentificationType(id: "CNPJ", name: "CNPJ", type: "string", minLenght: 14, maxLenght: 14)
+
+        // Act / Assert
+        XCTAssertEqual(type.getKeyboardType(), .default)
+    }
+
+    func test_getKeyboardType_whenUnknownType_shouldReturnDefault() {
+        // Arrange
+        let type = IdentificationType(id: "OTHER", name: "Other", type: "numeric", minLenght: 8, maxLenght: 10)
+
+        // Act / Assert
+        XCTAssertEqual(type.getKeyboardType(), .default)
+    }
+}

--- a/Tests/MercadoPagoCheckoutTests/Formatting/CardFormFormattingTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Formatting/CardFormFormattingTests.swift
@@ -104,3 +104,121 @@ final class CardFormFormattingTests: XCTestCase {
         XCTAssertEqual(digits.count, 17)
     }
 }
+
+// MARK: - DocumentFormatter (numeric type — default)
+
+final class DocumentFormatterNumericTests: XCTestCase {
+    func test_documentFormatter_numericType_withMask_shouldApplyMaskAndStripLetters() {
+        // Arrange — CPF mask
+        let formatter = DocumentFormatter(mask: "###.###.###-##", maxLength: 11, isNumericType: true)
+
+        // Act
+        let result = formatter.formatOnChange("12345678901")
+
+        // Assert
+        XCTAssertEqual(result, "123.456.789-01")
+    }
+
+    func test_documentFormatter_numericType_withMask_shouldIgnoreLettersInInput() {
+        // Arrange
+        let formatter = DocumentFormatter(mask: "###.###.###-##", maxLength: 11, isNumericType: true)
+
+        // Act — input contains letters that should be stripped
+        let result = formatter.formatOnChange("123ABC456789D01")
+
+        // Assert — only digits used
+        XCTAssertEqual(result, "123.456.789-01")
+    }
+
+    func test_documentFormatter_numericType_withoutMask_shouldReturnDigitsOnly() {
+        // Arrange
+        let formatter = DocumentFormatter(maxLength: 10, isNumericType: true)
+
+        // Act
+        let result = formatter.formatOnChange("abc123def456")
+
+        // Assert
+        XCTAssertEqual(result, "123456")
+    }
+
+    func test_documentFormatter_numericType_withoutMask_shouldRespectMaxLength() {
+        // Arrange
+        let formatter = DocumentFormatter(maxLength: 5, isNumericType: true)
+
+        // Act
+        let result = formatter.formatOnChange("123456789")
+
+        // Assert
+        XCTAssertEqual(result, "12345")
+    }
+}
+
+// MARK: - DocumentFormatter (string type — alphanumeric)
+
+final class DocumentFormatterStringTests: XCTestCase {
+    func test_documentFormatter_stringType_withAlphanumericMask_shouldAcceptLettersAndDigits() {
+        // Arrange — mask with A (alphanumeric) and # (digit-only) positions
+        let formatter = DocumentFormatter(mask: "AA.AAA.AAA/AAAA-##", maxLength: 14, isNumericType: false)
+
+        // Act
+        let result = formatter.formatOnChange("AB123456CDEF12")
+
+        // Assert
+        XCTAssertEqual(result, "AB.123.456/CDEF-12")
+    }
+
+    func test_documentFormatter_stringType_withAlphanumericMask_shouldStripSpecialChars() {
+        // Arrange
+        let formatter = DocumentFormatter(mask: "AA.AAA.AAA/AAAA-##", maxLength: 14, isNumericType: false)
+
+        // Act — input contains special characters that should be stripped
+        let result = formatter.formatOnChange("AB!123@456#CDEF$12")
+
+        // Assert — special chars removed, letters and digits preserved
+        XCTAssertEqual(result, "AB.123.456/CDEF-12")
+    }
+
+    func test_documentFormatter_stringType_digitPositionInMask_shouldSkipLetters() {
+        // Arrange — mask ends with ## (digit-only)
+        let formatter = DocumentFormatter(mask: "AA-##", maxLength: 4, isNumericType: false)
+
+        // Act — user types "AB" then "12" for the digit positions
+        let result = formatter.formatOnChange("AB12")
+
+        // Assert
+        XCTAssertEqual(result, "AB-12")
+    }
+
+    func test_documentFormatter_stringType_withoutMask_shouldReturnAlphanumericOnly() {
+        // Arrange
+        let formatter = DocumentFormatter(maxLength: 20, isNumericType: false)
+
+        // Act
+        let result = formatter.formatOnChange("AB!123@def#456")
+
+        // Assert — special chars removed
+        XCTAssertEqual(result, "AB123def456")
+    }
+
+    func test_documentFormatter_stringType_withoutMask_shouldRespectMaxLength() {
+        // Arrange
+        let formatter = DocumentFormatter(maxLength: 5, isNumericType: false)
+
+        // Act
+        let result = formatter.formatOnChange("ABCDEFGHIJ")
+
+        // Assert
+        XCTAssertEqual(result, "ABCDE")
+    }
+
+    func test_documentFormatter_stringType_whenEmpty_shouldReturnEmpty() {
+        // Arrange
+        let formatter = DocumentFormatter(mask: "AA.AAA", maxLength: 5, isNumericType: false)
+
+        // Act
+        let result = formatter.formatOnChange("")
+
+        // Assert
+        XCTAssertEqual(result, "")
+    }
+}

--- a/Tests/MercadoPagoCheckoutTests/Rules/CardFormRulesTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Rules/CardFormRulesTests.swift
@@ -574,4 +574,84 @@ final class CardFormRulesTests: XCTestCase {
         ruleWithLen.apply(.documentLength(min: 3, max: 3))
         XCTAssertEqual(ruleWithLen.validate("000"), "CUSTOM_INVALID")
     }
+
+    // MARK: - DocumentRule (string/alphanumeric type)
+
+    func test_documentRule_stringType_whenEmpty_shouldReturnEmptyError() {
+        // Arrange
+        var rule = DocumentRule(validation: Self.defaultDocumentValidation())
+        rule.apply(.documentType(isNumeric: false))
+
+        // Act
+        let result = rule.validate("")
+
+        // Assert
+        XCTAssertEqual(result, MPStrings.CardForm.Document.errorEmpty)
+    }
+
+    func test_documentRule_stringType_whenValidAlphanumeric_shouldReturnNil() {
+        // Arrange
+        var rule = DocumentRule(validation: Self.defaultDocumentValidation())
+        rule.apply(.documentType(isNumeric: false))
+        rule.apply(.documentLength(min: 5, max: 14))
+
+        // Act — "AB123" has 5 alphanumeric chars, within range
+        let result = rule.validate("AB.123")
+
+        // Assert
+        XCTAssertNil(result)
+    }
+
+    func test_documentRule_stringType_whenAllZeros_shouldReturnNil() {
+        // Arrange — all-zeros is only invalid for numeric type, not string type
+        var rule = DocumentRule(validation: Self.defaultDocumentValidation())
+        rule.apply(.documentType(isNumeric: false))
+        rule.apply(.documentLength(min: 3, max: 3))
+
+        // Act
+        let result = rule.validate("000")
+
+        // Assert
+        XCTAssertNil(result)
+    }
+
+    func test_documentRule_stringType_whenIncomplete_shouldReturnIncompleteError() {
+        // Arrange
+        var rule = DocumentRule(validation: Self.defaultDocumentValidation())
+        rule.apply(.documentType(isNumeric: false))
+        rule.apply(.documentLength(min: 5, max: 14))
+
+        // Act — "AB" has only 2 alphanumeric chars, below min
+        let result = rule.validate("AB")
+
+        // Assert
+        XCTAssertEqual(result, MPStrings.CardForm.Document.errorIncomplete)
+    }
+
+    func test_documentRule_stringType_whenOnlySpecialChars_shouldReturnEmptyError() {
+        // Arrange — special chars are stripped, leaving nothing — must return errorEmpty not errorIncomplete
+        var rule = DocumentRule(validation: Self.defaultDocumentValidation())
+        rule.apply(.documentType(isNumeric: false))
+
+        // Act
+        let result = rule.validate("!@#$%")
+
+        // Assert
+        XCTAssertEqual(result, MPStrings.CardForm.Document.errorEmpty)
+    }
+
+    func test_documentRule_whenTypeToggledFromNumericToString_allZerosShouldBecomeValid() {
+        // Arrange
+        var rule = DocumentRule(validation: Self.defaultDocumentValidation())
+        rule.apply(.documentLength(min: 3, max: 3))
+
+        // Act / Assert — numeric type: all zeros invalid
+        XCTAssertEqual(rule.validate("000"), MPStrings.CardForm.Document.errorInvalid)
+
+        // Act — switch to string type
+        rule.apply(.documentType(isNumeric: false))
+
+        // Assert — string type: all zeros valid
+        XCTAssertNil(rule.validate("000"))
+    }
 }

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
@@ -917,20 +917,20 @@ final class CardFormViewModelTests: XCTestCase {
         XCTAssertEqual(capturedValues, [false, true])
     }
 
-    // MARK: - documentKeyboardType
+    // MARK: - keyboard type (derived from selectTypeDocument)
 
-    func test_init_withNumericIdentificationType_shouldSetNumberPadKeyboard() {
+    func test_init_withNumericIdentificationType_shouldSelectNumericType() {
         // Arrange
         let numericType = IdentificationType(id: "CPF", name: "CPF", type: "number", minLenght: 11, maxLenght: 11)
 
         // Act
         let sut = self.makeSUT(identificationTypes: [numericType])
 
-        // Assert
-        XCTAssertEqual(sut.viewModel.documentKeyboardType, .numberPad)
+        // Assert — keyboard type is derived by the View via getKeyboardType()
+        XCTAssertEqual(sut.viewModel.selectTypeDocument?.getKeyboardType(), .numberPad)
     }
 
-    func test_init_withStringIdentificationType_shouldSetDefaultKeyboard() {
+    func test_init_withStringIdentificationType_shouldSelectStringType() {
         // Arrange
         let stringType = IdentificationType(id: "CNPJ", name: "CNPJ", type: "string", minLenght: 14, maxLenght: 14)
 
@@ -938,43 +938,41 @@ final class CardFormViewModelTests: XCTestCase {
         let sut = self.makeSUT(identificationTypes: [stringType])
 
         // Assert
-        XCTAssertEqual(sut.viewModel.documentKeyboardType, .default)
+        XCTAssertEqual(sut.viewModel.selectTypeDocument?.getKeyboardType(), .default)
     }
 
-    func test_init_withNoIdentificationTypes_shouldSetDefaultKeyboard() {
+    func test_init_withNoIdentificationTypes_shouldHaveNilSelectTypeDocument() {
         // Arrange / Act
         let sut = self.makeSUT()
 
-        // Assert
-        XCTAssertEqual(sut.viewModel.documentKeyboardType, .default)
+        // Assert — nil selectTypeDocument → View falls back to .default
+        XCTAssertNil(sut.viewModel.selectTypeDocument)
     }
 
-    func test_selectTypeDocument_whenChangedToStringType_shouldUpdateKeyboardToDefault() {
+    func test_selectTypeDocument_whenChangedToStringType_shouldReflectDefaultKeyboard() {
         // Arrange
         let numericType = IdentificationType(id: "CPF", name: "CPF", type: "number", minLenght: 11, maxLenght: 11)
         let stringType = IdentificationType(id: "CNPJ", name: "CNPJ", type: "string", minLenght: 14, maxLenght: 14)
         let sut = self.makeSUT(identificationTypes: [numericType, stringType])
-        XCTAssertEqual(sut.viewModel.documentKeyboardType, .numberPad)
 
         // Act
         sut.viewModel.selectTypeDocument = stringType
 
         // Assert
-        XCTAssertEqual(sut.viewModel.documentKeyboardType, .default)
+        XCTAssertEqual(sut.viewModel.selectTypeDocument?.getKeyboardType(), .default)
     }
 
-    func test_selectTypeDocument_whenChangedToNumericType_shouldUpdateKeyboardToNumberPad() {
+    func test_selectTypeDocument_whenChangedToNumericType_shouldReflectNumberPadKeyboard() {
         // Arrange
         let stringType = IdentificationType(id: "CNPJ", name: "CNPJ", type: "string", minLenght: 14, maxLenght: 14)
         let numericType = IdentificationType(id: "CPF", name: "CPF", type: "number", minLenght: 11, maxLenght: 11)
         let sut = self.makeSUT(identificationTypes: [stringType, numericType])
-        XCTAssertEqual(sut.viewModel.documentKeyboardType, .default)
 
         // Act
         sut.viewModel.selectTypeDocument = numericType
 
         // Assert
-        XCTAssertEqual(sut.viewModel.documentKeyboardType, .numberPad)
+        XCTAssertEqual(sut.viewModel.selectTypeDocument?.getKeyboardType(), .numberPad)
     }
 
     // MARK: - documentFormatter

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
@@ -916,4 +916,118 @@ final class CardFormViewModelTests: XCTestCase {
         // Assert — snackbar was reset then re-triggered
         XCTAssertEqual(capturedValues, [false, true])
     }
+
+    // MARK: - documentKeyboardType
+
+    func test_init_withNumericIdentificationType_shouldSetNumberPadKeyboard() {
+        // Arrange
+        let numericType = IdentificationType(id: "CPF", name: "CPF", type: "number", minLenght: 11, maxLenght: 11)
+
+        // Act
+        let sut = self.makeSUT(identificationTypes: [numericType])
+
+        // Assert
+        XCTAssertEqual(sut.viewModel.documentKeyboardType, .numberPad)
+    }
+
+    func test_init_withStringIdentificationType_shouldSetDefaultKeyboard() {
+        // Arrange
+        let stringType = IdentificationType(id: "CNPJ", name: "CNPJ", type: "string", minLenght: 14, maxLenght: 14)
+
+        // Act
+        let sut = self.makeSUT(identificationTypes: [stringType])
+
+        // Assert
+        XCTAssertEqual(sut.viewModel.documentKeyboardType, .default)
+    }
+
+    func test_init_withNoIdentificationTypes_shouldSetDefaultKeyboard() {
+        // Arrange / Act
+        let sut = self.makeSUT()
+
+        // Assert
+        XCTAssertEqual(sut.viewModel.documentKeyboardType, .default)
+    }
+
+    func test_selectTypeDocument_whenChangedToStringType_shouldUpdateKeyboardToDefault() {
+        // Arrange
+        let numericType = IdentificationType(id: "CPF", name: "CPF", type: "number", minLenght: 11, maxLenght: 11)
+        let stringType = IdentificationType(id: "CNPJ", name: "CNPJ", type: "string", minLenght: 14, maxLenght: 14)
+        let sut = self.makeSUT(identificationTypes: [numericType, stringType])
+        XCTAssertEqual(sut.viewModel.documentKeyboardType, .numberPad)
+
+        // Act
+        sut.viewModel.selectTypeDocument = stringType
+
+        // Assert
+        XCTAssertEqual(sut.viewModel.documentKeyboardType, .default)
+    }
+
+    func test_selectTypeDocument_whenChangedToNumericType_shouldUpdateKeyboardToNumberPad() {
+        // Arrange
+        let stringType = IdentificationType(id: "CNPJ", name: "CNPJ", type: "string", minLenght: 14, maxLenght: 14)
+        let numericType = IdentificationType(id: "CPF", name: "CPF", type: "number", minLenght: 11, maxLenght: 11)
+        let sut = self.makeSUT(identificationTypes: [stringType, numericType])
+        XCTAssertEqual(sut.viewModel.documentKeyboardType, .default)
+
+        // Act
+        sut.viewModel.selectTypeDocument = numericType
+
+        // Assert
+        XCTAssertEqual(sut.viewModel.documentKeyboardType, .numberPad)
+    }
+
+    // MARK: - documentFormatter
+
+    func test_init_withNumericIdentificationType_shouldInitializeFormatterWithNumericMask() {
+        // Arrange
+        let numericType = IdentificationType(id: "CPF", name: "CPF", type: "number", minLenght: 11, maxLenght: 11)
+
+        // Act
+        let sut = self.makeSUT(identificationTypes: [numericType])
+
+        // Assert — numeric formatter strips letters, applies CPF mask
+        let formatted = sut.viewModel.documentFormatter.formatOnChange("12345678901")
+        XCTAssertEqual(formatted, "123.456.789-01")
+    }
+
+    func test_init_withStringIdentificationType_shouldInitializeFormatterWithAlphanumericMask() {
+        // Arrange — CNPJ string type uses alphanumeric mask
+        let stringType = IdentificationType(id: "CNPJ", name: "CNPJ", type: "string", minLenght: 14, maxLenght: 14)
+
+        // Act
+        let sut = self.makeSUT(identificationTypes: [stringType])
+
+        // Assert — string formatter accepts letters, applies CNPJ alphanumeric mask
+        let formatted = sut.viewModel.documentFormatter.formatOnChange("AB123456CDEF12")
+        XCTAssertEqual(formatted, "AB.123.456/CDEF-12")
+    }
+
+    func test_selectTypeDocument_whenChangedToStringType_shouldUpdateFormatterToAlphanumeric() {
+        // Arrange — start with CPF (numeric)
+        let numericType = IdentificationType(id: "CPF", name: "CPF", type: "number", minLenght: 11, maxLenght: 11)
+        let stringType = IdentificationType(id: "CNPJ", name: "CNPJ", type: "string", minLenght: 14, maxLenght: 14)
+        let sut = self.makeSUT(identificationTypes: [numericType, stringType])
+
+        // Act
+        sut.viewModel.selectTypeDocument = stringType
+
+        // Assert — formatter now accepts letters
+        let formatted = sut.viewModel.documentFormatter.formatOnChange("AB123456CDEF12")
+        XCTAssertEqual(formatted, "AB.123.456/CDEF-12")
+    }
+
+    func test_selectTypeDocument_whenChangedToNumericType_shouldUpdateFormatterToDigitsOnly() {
+        // Arrange — start with CNPJ string type
+        let stringType = IdentificationType(id: "CNPJ", name: "CNPJ", type: "string", minLenght: 14, maxLenght: 14)
+        let numericType = IdentificationType(id: "CPF", name: "CPF", type: "number", minLenght: 11, maxLenght: 11)
+        let sut = self.makeSUT(identificationTypes: [stringType, numericType])
+
+        // Act
+        sut.viewModel.selectTypeDocument = numericType
+
+        // Assert — formatter now strips letters, applies CPF numeric mask
+        let formatted = sut.viewModel.documentFormatter.formatOnChange("12345678901")
+        XCTAssertEqual(formatted, "123.456.789-01")
+    }
 }


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
https://mercadolibre.atlassian.net/browse/CHOBK-3793

## Description
- Updated keyboard type for identification fields to accept alphanumeric input, aligning with the expected input for document types across different countries
- Extended `IdentificationType+Checkout` to expose the appropriate keyboard type per identification type
- Updated `CardFormRules` and `CardFormViewModel` to apply the correct keyboard type when an identification type is selected
- Updated `CardFormData` and `CardFormFormatting` to handle alphanumeric formatting for document fields
- Added unit tests for `IdentificationType+Checkout` extension, `CardFormRules`, `CardFormFormatting`, and `CardFormViewModel` covering the new keyboard type behavior

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [x] I have added tests that prove my solution is effective and works
- [ ] New and existing unit tests pass locally with my changes.
- [x] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>