### PR TITLE
[CHOBK-3812] (Fix): Fix validation for payment not found error

### DIFF
--- a/Sources/MercadoPagoCheckout/Domain/CardAcceptanceError.swift
+++ b/Sources/MercadoPagoCheckout/Domain/CardAcceptanceError.swift
@@ -6,4 +6,5 @@
 package enum CardAcceptanceError: Error, Equatable {
     case paymentMethodNotAllowed(String)
     case paymentTypeNotAllowed(MercadoPagoCheckout.CardType?)
+    case paymentMethodNotFound
 }

--- a/Sources/MercadoPagoCheckout/Model/Internal/MercadoPagoCheckoutError+Network.swift
+++ b/Sources/MercadoPagoCheckout/Model/Internal/MercadoPagoCheckoutError+Network.swift
@@ -91,3 +91,12 @@ extension MercadoPagoCheckoutError {
         }
     }
 }
+
+// MARK: - MercadoPagoCheckoutError + PaymentMethodNotFound
+
+extension MercadoPagoCheckoutError {
+    var isPaymentMethodNotFound: Bool {
+        errorUserInfo["error_code"] as? String == "not_found"
+            || errorUserInfo["message"] as? String == "Payment methods not found"
+    }
+}

--- a/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
+++ b/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
@@ -76,13 +76,7 @@ package struct CardNumberRule: CardFormRuleType {
         guard !digits.isEmpty else { return nil }
         if let externalError { return self.validateExternalError(externalError) }
         guard digits.count >= self.min else { return nil }
-        if self.isAllRepeatedDigits(digits) { return self.validation.errorInvalid }
         return nil
-    }
-
-    private func isAllRepeatedDigits(_ digits: String) -> Bool {
-        guard let first = digits.first else { return false }
-        return digits.dropFirst().allSatisfy { $0 == first }
     }
 
     private func validateExternalError(_ error: CardAcceptanceError) -> String? {
@@ -94,6 +88,8 @@ package struct CardNumberRule: CardFormRuleType {
                 return self.validation.errorInvalid
             }
             return String(format: self.validation.errorTypeNotAllowed, self.cardTypeDisplayName(cardType))
+        case .paymentMethodNotFound:
+            return self.validation.errorInvalid
         }
     }
 

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -68,11 +68,7 @@ final class CardFormViewModel: ObservableObject {
     private var isRetriableBinError: Bool {
         return self.binNetworkError?.code == .networkConnectionFailed
             || self.binNetworkError?.code == .networkTimeout
-            || self.binNetworkError?.code == .serviceError && !self.isPaymentMethodNotFound
-    }
-
-    private var isPaymentMethodNotFound: Bool {
-        self.binNetworkError?.errorUserInfo["message"] as? String == "Payment methods not found"
+            || self.binNetworkError?.code == .serviceError && !(self.binNetworkError?.isPaymentMethodNotFound ?? false)
     }
 
     // MARK: - Constants
@@ -208,7 +204,11 @@ final class CardFormViewModel: ObservableObject {
         } catch let error as MercadoPagoCheckoutError {
             guard !Task.isCancelled else { return }
             self.binData = nil
-            self.binNetworkError = error
+            if error.errorUserInfo["message"] as? String == "Payment methods not found" {
+                self.cardAcceptanceError = .paymentMethodNotFound
+            } else {
+                self.binNetworkError = error
+            }
         } catch {
             guard !Task.isCancelled else { return }
             self.binData = nil

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -204,7 +204,7 @@ final class CardFormViewModel: ObservableObject {
         } catch let error as MercadoPagoCheckoutError {
             guard !Task.isCancelled else { return }
             self.binData = nil
-            if error.errorUserInfo["message"] as? String == "Payment methods not found" {
+            if error.isPaymentMethodNotFound {
                 self.cardAcceptanceError = .paymentMethodNotFound
             } else {
                 self.binNetworkError = error

--- a/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
+++ b/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
@@ -96,6 +96,7 @@ struct CardFormData {
             switch acceptanceError {
             case let .paymentMethodNotAllowed(brand): return .cardBrandNotAccepted(brand: brand)
             case let .paymentTypeNotAllowed(cardType): return .cardTypeNotAccepted(cardType: cardType)
+            case .paymentMethodNotFound: return .invalid
             }
         }
         return _cardNumber.errorMessages.contains(MPStrings.CardForm.CardNumber.errorIncomplete) ? .incomplete : .invalid


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
https://mercadolibre.atlassian.net/browse/CHOBK-3812

## Description
- Added `paymentMethodNotFound` case to `CardAcceptanceError` enum for handling payment method not found errors
- Added `isPaymentMethodNotFound` computed property to `MercadoPagoCheckoutError` that checks for `error_code == "not_found"` or `message == "Payment methods not found"` in the error's `userInfo`
- `CardFormRules`: maps `.paymentMethodNotFound` external error to `errorInvalid` on the card number field, so the field correctly shows an error when the payment method is not found
- `CardFormViewModel`: refactored `isPaymentMethodNotFound` logic to use the new error extension property; fixed retry logic to correctly exclude payment-not-found errors from retryable service errors
- Removed all-repeated-digits validation from `CardNumberRule` (was incorrectly blocking valid card numbers)

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [x] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>