### PR TITLE
[CHOBK-3823] (Refactor): Add retry logic for retriable errors

### DIFF
--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
@@ -37,9 +37,15 @@ final class CardFormBrickViewModel: ObservableObject {
     func load() async throws(MercadoPagoCheckoutError) {
         guard case .loading = self.screenState else { return }
         let config = self.extractCardFormConfig()
-        let result = try await self.initializeUseCase.execute(config: config)
-        let viewModel = CardFormViewModel(configuration: self.configuration, initResult: result)
-        self.screenState = .ready(result, viewModel)
+        do {
+            let result = try await withRetry { try await self.initializeUseCase.execute(config: config) }
+            let viewModel = CardFormViewModel(configuration: self.configuration, initResult: result)
+            self.screenState = .ready(result, viewModel)
+        } catch let error as MercadoPagoCheckoutError {
+            throw error
+        } catch {
+            throw MercadoPagoCheckoutError(code: .unknown, localizedDescription: error.localizedDescription, location: .initialization)
+        }
     }
 
     // MARK: - Private

--- a/Sources/MercadoPagoCheckout/Utils/RetryUtils.swift
+++ b/Sources/MercadoPagoCheckout/Utils/RetryUtils.swift
@@ -7,14 +7,17 @@
 
 import Foundation
 
-/// Executes the given `operation` up to `maxAttempts` times, retrying on any thrown error.
+/// Executes the given `operation` up to `maxAttempts` times, retrying on eligible errors.
 /// Throws the last error if all attempts fail.
 ///
 /// - Parameters:
 ///   - maxAttempts: Maximum number of attempts. Defaults to 2.
+///   - isRetryable: Predicate that decides whether a given error should be retried.
+///     `CancellationError` is never retried regardless of this predicate.
 ///   - operation: The async throwing closure to execute.
 func withRetry<T>(
     maxAttempts: Int = 2,
+    isRetryable: @Sendable (Error) -> Bool = { _ in true },
     isolation _: isolated (any Actor)? = #isolation,
     operation: () async throws -> T
 ) async throws -> T {
@@ -25,7 +28,11 @@ func withRetry<T>(
         } catch is CancellationError {
             throw CancellationError()
         } catch {
-            lastError = error
+            if isRetryable(error) {
+                lastError = error
+            } else {
+                throw error
+            }
         }
     }
     throw lastError ?? CancellationError()

--- a/Sources/MercadoPagoCheckout/Utils/RetryUtils.swift
+++ b/Sources/MercadoPagoCheckout/Utils/RetryUtils.swift
@@ -21,6 +21,7 @@ func withRetry<T>(
     isolation _: isolated (any Actor)? = #isolation,
     operation: () async throws -> T
 ) async throws -> T {
+    try Task.checkCancellation()
     var lastError: Error?
     for _ in 0 ..< maxAttempts {
         do {

--- a/Sources/MercadoPagoCheckout/Utils/RetryUtils.swift
+++ b/Sources/MercadoPagoCheckout/Utils/RetryUtils.swift
@@ -18,11 +18,12 @@ func withRetry<T>(
     isolation _: isolated (any Actor)? = #isolation,
     operation: () async throws -> T
 ) async throws -> T {
-    try Task.checkCancellation()
     var lastError: Error?
     for _ in 0 ..< maxAttempts {
         do {
             return try await operation()
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             lastError = error
         }

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -197,12 +197,14 @@ final class CardFormViewModel: ObservableObject {
         let acceptedPaymentTypeIds = self.configuration.paymentMethod.acceptedPaymentTypeIds
         let acceptedPaymentMethodIds = self.configuration.paymentMethod.acceptedPaymentMethodIds
         do {
-            let data = try await service.fetchBinData(
-                bin: bin,
-                amount: amount,
-                acceptedPaymentTypeIds: acceptedPaymentTypeIds,
-                acceptedPaymentMethodIds: acceptedPaymentMethodIds
-            )
+            let data = try await withRetry {
+                try await self.service.fetchBinData(
+                    bin: bin,
+                    amount: amount,
+                    acceptedPaymentTypeIds: acceptedPaymentTypeIds,
+                    acceptedPaymentMethodIds: acceptedPaymentMethodIds
+                )
+            }
             guard !Task.isCancelled else { return }
             self.binData = data
         } catch let error as CardAcceptanceError {

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -197,7 +197,7 @@ final class CardFormViewModel: ObservableObject {
         let acceptedPaymentTypeIds = self.configuration.paymentMethod.acceptedPaymentTypeIds
         let acceptedPaymentMethodIds = self.configuration.paymentMethod.acceptedPaymentMethodIds
         do {
-            let data = try await withRetry {
+            let data = try await withRetry(isRetryable: { !($0 is CardAcceptanceError) }) {
                 try await self.service.fetchBinData(
                     bin: bin,
                     amount: amount,

--- a/Tests/MercadoPagoCheckoutTests/Mocks/MockCardFormInitializationRepository.swift
+++ b/Tests/MercadoPagoCheckoutTests/Mocks/MockCardFormInitializationRepository.swift
@@ -12,8 +12,15 @@ import Foundation
 final class MockCardFormInitializationRepository: CardFormInitializationRepository {
     nonisolated(unsafe) var mockData: CardFormInitializationInput?
     nonisolated(unsafe) var shouldThrow = false
+    nonisolated(unsafe) var fetchCallCount = 0
+    nonisolated(unsafe) var sequentialResults: [Result<CardFormInitializationInput, Error>] = []
 
     func fetchInitialization() async throws -> CardFormInitializationInput {
+        self.fetchCallCount += 1
+        if !self.sequentialResults.isEmpty {
+            let result = self.sequentialResults.removeFirst()
+            return try result.get()
+        }
         if self.shouldThrow { throw NSError(domain: "test", code: -1) }
         return self.mockData ?? Self.makeDefault()
     }

--- a/Tests/MercadoPagoCheckoutTests/Mocks/MockCheckoutService.swift
+++ b/Tests/MercadoPagoCheckoutTests/Mocks/MockCheckoutService.swift
@@ -18,6 +18,8 @@ final actor MockCheckoutService: CheckoutServiceProtocol {
     private var issuersResult: Result<[Issuer], Error>?
     private var installmentsResult: Result<[Installment], Error>?
     private var fetchBinDataResult: Result<CardBinData, Error>?
+    private var fetchBinDataResults: [Result<CardBinData, Error>] = []
+    private(set) var fetchBinDataCallCount = 0
     private var createCardTokenResult: Result<CardToken, Error>?
     private(set) var capturedCardParams: CardParams?
 
@@ -43,6 +45,10 @@ final actor MockCheckoutService: CheckoutServiceProtocol {
 
     func setFetchBinDataResult(_ result: Result<CardBinData, Error>) {
         self.fetchBinDataResult = result
+    }
+
+    func setSequentialFetchBinDataResults(_ results: Result<CardBinData, Error>...) {
+        self.fetchBinDataResults = Array(results)
     }
 
     func setCreateCardTokenResult(_ result: Result<CardToken, Error>) {
@@ -110,6 +116,13 @@ final actor MockCheckoutService: CheckoutServiceProtocol {
         acceptedPaymentTypeIds _: [String],
         acceptedPaymentMethodIds _: [String]
     ) async throws -> CardBinData {
+        self.fetchBinDataCallCount += 1
+        if !self.fetchBinDataResults.isEmpty {
+            let result = self.fetchBinDataResults.count > 1
+                ? self.fetchBinDataResults.removeFirst()
+                : self.fetchBinDataResults[0]
+            return try result.get()
+        }
         guard let result = fetchBinDataResult else { throw MockError.resultNotSet }
         return try result.get()
     }

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormBrickViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormBrickViewModelTests.swift
@@ -1,0 +1,79 @@
+//
+//  CardFormBrickViewModelTests.swift
+//  MercadoPagoSDK
+//
+
+import Foundation
+@testable import MercadoPagoCheckout
+import XCTest
+
+@MainActor
+final class CardFormBrickViewModelTests: XCTestCase {
+    // MARK: - Types
+
+    typealias SUT = (
+        viewModel: CardFormBrickViewModel,
+        repository: MockCardFormInitializationRepository
+    )
+
+    // MARK: - Helpers
+
+    private func makeSUT() -> SUT {
+        let repository = MockCardFormInitializationRepository()
+        let useCase = InitializeCardFormUseCase(repository: repository)
+        let configuration = MercadoPagoCheckout.CheckoutConfiguration(
+            type: .cardForm(cardFormConfiguration: .init()),
+            paymentMethod: [.card(allowedTypes: [.credit, .debit, .prepaid])]
+        )
+        let viewModel = CardFormBrickViewModel(configuration: configuration, initializeUseCase: useCase)
+        return (viewModel, repository)
+    }
+
+    // MARK: - load() retry
+
+    func test_load_whenFirstAttemptSucceeds_shouldCallRepositoryOnce() async throws {
+        // Arrange
+        let sut = self.makeSUT()
+
+        // Act
+        try await sut.viewModel.load()
+
+        // Assert
+        XCTAssertEqual(sut.repository.fetchCallCount, 1)
+        if case .ready = sut.viewModel.screenState {} else {
+            XCTFail("Expected screenState .ready")
+        }
+    }
+
+    func test_load_whenFirstAttemptFails_shouldRetryAndSucceed() async throws {
+        // Arrange
+        let sut = self.makeSUT()
+        sut.repository.sequentialResults = [
+            .failure(NSError(domain: "network", code: -1)),
+            .success(MockCardFormInitializationRepository.makeDefault())
+        ]
+
+        // Act
+        try await sut.viewModel.load()
+
+        // Assert
+        XCTAssertEqual(sut.repository.fetchCallCount, 2)
+        if case .ready = sut.viewModel.screenState {} else {
+            XCTFail("Expected screenState .ready after retry")
+        }
+    }
+
+    func test_load_whenAllAttemptsFail_shouldThrowErrorAfter2Calls() async {
+        // Arrange
+        let sut = self.makeSUT()
+        sut.repository.shouldThrow = true
+
+        // Act & Assert
+        do {
+            try await sut.viewModel.load()
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual(sut.repository.fetchCallCount, 2)
+        }
+    }
+}

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
@@ -372,6 +372,79 @@ final class CardFormViewModelTests: XCTestCase {
         XCTAssertEqual(sut.viewModel.binData, CardBinDataStub.visa)
     }
 
+    // MARK: - fetchBinData retry
+
+    func test_onCardNumberChange_whenFirstBinFetchSucceeds_shouldCallServiceOnce() async {
+        // Arrange
+        let sut = self.makeSUT()
+        await sut.service.setFetchBinDataResult(.success(CardBinDataStub.visa))
+
+        // Act
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binData)
+
+        // Assert
+        let callCount = await sut.service.fetchBinDataCallCount
+        XCTAssertEqual(sut.viewModel.binData, CardBinDataStub.visa)
+        XCTAssertEqual(callCount, 1)
+    }
+
+    func test_onCardNumberChange_whenFirstBinFetchFails_shouldRetryAndSetBinData() async {
+        // Arrange
+        let sut = self.makeSUT()
+        let networkError = MercadoPagoCheckoutError(code: .networkConnectionFailed, localizedDescription: "timeout", location: .paymentMethods)
+        await sut.service.setSequentialFetchBinDataResults(
+            .failure(networkError),
+            .success(CardBinDataStub.visa)
+        )
+
+        // Act
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binData)
+
+        // Assert
+        let callCount = await sut.service.fetchBinDataCallCount
+        XCTAssertEqual(sut.viewModel.binData, CardBinDataStub.visa)
+        XCTAssertEqual(callCount, 2)
+    }
+
+    func test_onCardNumberChange_whenAllBinFetchesFail_shouldSetBinNetworkErrorAfter2Calls() async {
+        // Arrange
+        let sut = self.makeSUT()
+        let networkError = MercadoPagoCheckoutError(code: .networkConnectionFailed, localizedDescription: "timeout", location: .paymentMethods)
+        await sut.service.setSequentialFetchBinDataResults(
+            .failure(networkError),
+            .failure(networkError)
+        )
+
+        // Act
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binNetworkError)
+
+        // Assert
+        let callCount = await sut.service.fetchBinDataCallCount
+        XCTAssertNotNil(sut.viewModel.binNetworkError)
+        XCTAssertNil(sut.viewModel.binData)
+        XCTAssertEqual(callCount, 2)
+    }
+
+    func test_onCardNumberChange_whenCardAcceptanceError_shouldNotRetry() async {
+        // Arrange
+        let sut = self.makeSUT()
+        await sut.service.setSequentialFetchBinDataResults(
+            .failure(CardAcceptanceError.paymentMethodNotAllowed("visa"))
+        )
+
+        // Act
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$cardAcceptanceError)
+
+        // Assert
+        let callCount = await sut.service.fetchBinDataCallCount
+        XCTAssertNotNil(sut.viewModel.cardAcceptanceError)
+        XCTAssertEqual(callCount, 1)
+    }
+
     // MARK: - retryBinFetch
 
     func test_init_showSnackbarShouldBeFalse() {


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
https://mercadolibre.atlassian.net/browse/CHOBK-3823

## Description
- Introduced `withRetry` utility function in `MercadoPagoCheckout/Utils/RetryUtils.swift` for executing async throwing operations with configurable retry attempts
- Added `isRetryable` predicate parameter to control which errors trigger a retry; `CancellationError` is never retried regardless
- Added explicit task cancellation check between retry attempts to prevent retrying after cooperative cancellation
- Applied retry logic to retriable network errors in the checkout flow (BIN data fetch, card form initialization)
- Added unit tests covering retry behavior, cancellation propagation, and non-retriable error fast-fail

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [x] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [ ] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<img width="629" height="135" alt="Captura de Tela 2026-03-30 às 15 15 12" src="https://github.com/user-attachments/assets/b65de289-29ed-4fe3-9ae4-c29e65188f49" />
<img width="628" height="58" alt="Captura de Tela 2026-03-30 às 15 32 35" src="https://github.com/user-attachments/assets/16120197-5483-4c0d-8cc6-b273ac0601c7" />
