### PR TITLE
[CHOBK-3836] (Fix): Fix payment method exclusion wording

### DIFF
--- a/Sources/MPFoundation/Resources/es-AR.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-AR.lproj/Localizable.strings
@@ -84,9 +84,9 @@
 "common.accessibility.textfield.moreInfo" = "Más información";
 "common.total" = "Total";
 "common.currency" = "$";
-"common.credit" = "Crédito";
-"common.debit" = "Débito";
-"common.prepaid" = "Prepaga";
+"common.credit" = "Tarjeta de Crédito";
+"common.debit" = "Tarjeta de Débito";
+"common.prepaid" = "Tarjeta Prepaga";
 
 /* MARK: - Errors */
 "error.generic" = "Algo salió mal. Por favor, intentá de nuevo.";

--- a/Sources/MPFoundation/Resources/es-CL.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-CL.lproj/Localizable.strings
@@ -84,9 +84,9 @@
 "common.accessibility.textfield.moreInfo" = "Más información";
 "common.total" = "Total";
 "common.currency" = "$";
-"common.credit" = "Crédito";
-"common.debit" = "Débito";
-"common.prepaid" = "Prepago";
+"common.credit" = "Tarjeta de Crédito";
+"common.debit" = "Tarjeta de Débito";
+"common.prepaid" = "Tarjeta Prepago";
 
 /* MARK: - Errors */
 "error.generic" = "Algo salió mal. Por favor, intenta de nuevo.";

--- a/Sources/MPFoundation/Resources/es-CO.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-CO.lproj/Localizable.strings
@@ -84,9 +84,9 @@
 "common.accessibility.textfield.moreInfo" = "Más información";
 "common.total" = "Total";
 "common.currency" = "$";
-"common.credit" = "Crédito";
-"common.debit" = "Débito";
-"common.prepaid" = "Prepago";
+"common.credit" = "Tarjeta de Crédito";
+"common.debit" = "Tarjeta de Débito";
+"common.prepaid" = "Tarjeta Prepago";
 
 /* MARK: - Errors */
 "error.generic" = "Algo salió mal. Por favor, intenta de nuevo.";

--- a/Sources/MPFoundation/Resources/es-MX.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-MX.lproj/Localizable.strings
@@ -84,9 +84,9 @@
 "common.accessibility.textfield.moreInfo" = "Más información";
 "common.total" = "Total";
 "common.currency" = "$";
-"common.credit" = "Crédito";
-"common.debit" = "Débito";
-"common.prepaid" = "Prepagada";
+"common.credit" = "Tarjeta de Crédito";
+"common.debit" = "Tarjeta de Débito";
+"common.prepaid" = "Tarjeta Prepagada";
 
 /* MARK: - Errors */
 "error.generic" = "Algo salió mal. Por favor, intenta de nuevo.";

--- a/Sources/MPFoundation/Resources/es-PE.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-PE.lproj/Localizable.strings
@@ -84,9 +84,9 @@
 "common.accessibility.textfield.moreInfo" = "Más información";
 "common.total" = "Total";
 "common.currency" = "S/";
-"common.credit" = "Crédito";
-"common.debit" = "Débito";
-"common.prepaid" = "Prepago";
+"common.credit" = "Tarjeta de Crédito";
+"common.debit" = "Tarjeta de Débito";
+"common.prepaid" = "Tarjeta Prepago";
 
 /* MARK: - Errors */
 "error.generic" = "Algo salió mal. Por favor, intenta de nuevo.";

--- a/Sources/MPFoundation/Resources/es-UY.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-UY.lproj/Localizable.strings
@@ -84,9 +84,9 @@
 "common.accessibility.textfield.moreInfo" = "Más información";
 "common.total" = "Total";
 "common.currency" = "$";
-"common.credit" = "Crédito";
-"common.debit" = "Débito";
-"common.prepaid" = "Prepaga";
+"common.credit" = "Tarjeta de Crédito";
+"common.debit" = "Tarjeta de Débito";
+"common.prepaid" = "Tarjeta Prepaga";
 
 /* MARK: - Errors */
 "error.generic" = "Algo salió mal. Por favor, intentá de nuevo.";

--- a/Sources/MPFoundation/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/pt-BR.lproj/Localizable.strings
@@ -84,9 +84,9 @@
 "common.accessibility.textfield.moreInfo" = "Mais informações";
 "common.total" = "Total";
 "common.currency" = "R$";
-"common.credit" = "Crédito";
-"common.debit" = "Débito";
-"common.prepaid" = "Pré-pago";
+"common.credit" = "Cartão de Crédito";
+"common.debit" = "Cartão de Débito";
+"common.prepaid" = "Cartão Pré-pago";
 
 /* MARK: - Errors */
 "error.generic" = "Algo deu errado. Por favor, tente novamente.";

--- a/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
+++ b/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
@@ -88,7 +88,7 @@ package struct CardNumberRule: CardFormRuleType {
             guard let cardType else {
                 return self.validation.errorInvalid
             }
-            return String(format: self.validation.errorTypeNotAllowed, self.cardTypeDisplayName(cardType))
+            return String(format: self.validation.errorTypeNotAllowed, self.cardTypeDisplayName(cardType).lowercased())
         case .paymentMethodNotFound:
             return self.validation.errorInvalid
         }


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
https://mercadolibre.atlassian.net/browse/CHOBK-3836

## Description
- Updated card type display names in all locales (`es-AR`, `es-CL`, `es-CO`, `es-MX`, `es-PE`, `es-UY`, `pt-BR`): `Crédito` → `Tarjeta de Crédito`, `Débito` → `Tarjeta de Débito`, `Prepaga` → `Tarjeta Prepaga` for improved clarity in exclusion error messages
- `CardFormRules`: applied `.lowercased()` to card type display name in `errorTypeNotAllowed` format string, ensuring correct grammar when the type name is interpolated mid-sentence

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-31 at 15 24 53" src="https://github.com/user-attachments/assets/08c7eb41-4b61-47ba-a91d-099a009bedb5" />
