### PR TITLE
[CHOBK-3846] (Fix): Fix MPHeader animation behavior

### DIFF
--- a/Sources/MPComponents/BaseElements/Header/MPHeader.swift
+++ b/Sources/MPComponents/BaseElements/Header/MPHeader.swift
@@ -12,8 +12,8 @@ import UIKit
 /// A collapsible header component that automatically handles back navigation and scroll animations.
 ///
 /// The header consists of two parts:
-/// - **Main Header**: A fixed top bar with back button, title (appears when collapsed), and trailing actions
-/// - **Sub Header**: A large title that collapses as the user scrolls
+/// - **Main Header**: A fixed top bar with back button and trailing actions
+/// - **Animated Title**: A large title that physically moves from below the bar to inline as the user scrolls
 ///
 /// ## Usage
 ///
@@ -53,16 +53,26 @@ package struct MPHeader<Content: View, TrailingActions: View, Footer: View>: Vie
     // MARK: - State
 
     @State private var scrollOffset: CGFloat = 0
-    @State private var headerHeight: CGFloat = 30
-    @State private var subHeaderHeight: CGFloat = 20
+    @State private var headerHeight: CGFloat = 0
+    @State private var subHeaderHeight: CGFloat = 0
     @State private var contentHeight: CGFloat = 0
     @State private var scrollViewHeight: CGFloat = 0
-    /// Natural footer height — always measured via invisible overlay regardless of enabled state.
     @State private var footerMeasuredHeight: CGFloat = 0
-    /// Actual rendered footer height — 0 when footer is disabled.
     @State private var actualFooterHeight: CGFloat = 0
 
     // MARK: - Computed
+
+    /// 0 when large title fully visible, 1 when fully scrolled off.
+    private var collapseProgress: CGFloat {
+        guard self.subHeaderHeight > 0 else { return 0 }
+        return max(0, min(-self.scrollOffset / self.subHeaderHeight, 1))
+    }
+
+    /// Opacity for the inline title: fades in only after the large title has nearly scrolled off.
+    private var inlineTitleOpacity: CGFloat {
+        let threshold: CGFloat = 0.75
+        return max(0, min((self.collapseProgress - threshold) / (1 - threshold), 1))
+    }
 
     private var isScrollable: Bool {
         self.scrollViewHeight > 0 && self.contentHeight > self.scrollViewHeight
@@ -73,9 +83,10 @@ package struct MPHeader<Content: View, TrailingActions: View, Footer: View>: Vie
     /// Creates a new header with the specified configuration.
     ///
     /// - Parameters:
-    ///   - title: The title to display in both the main header and sub-header
+    ///   - title: The title to display in the header
     ///   - onBack: Action to perform when the back button is tapped
     ///   - trailingActions: Optional views to display on the trailing edge
+    ///   - footer: Optional footer view pinned to the bottom
     ///   - content: The scrollable content to display below the header
     package init(
         title: String,
@@ -95,14 +106,40 @@ package struct MPHeader<Content: View, TrailingActions: View, Footer: View>: Vie
 
     package var body: some View {
         ZStack(alignment: .top) {
-            self.scrollViewContent
+            self.scrollArea
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-            self.headerContent
+            self.mainHeaderBar
                 .frame(maxWidth: .infinity, alignment: .top)
+                .background(self.theme.colors.background.primary.edgesIgnoringSafeArea(.top))
                 .zIndex(1)
+
+            // Measures sub-header height OUTSIDE the ScrollView so preference propagation
+            // is direct and reliable. Zero-height in layout; overlay extends downward.
+            Color.clear
+                .frame(maxWidth: .infinity, maxHeight: 0)
+                .overlay(
+                    Text(self.title)
+                        .textStyle(.headingHuge())
+                        .lineLimit(2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, self.theme.spacings.xtiny)
+                        .padding(.vertical, self.theme.spacings.xmicro)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .background(
+                            GeometryReader { geo in
+                                Color.clear.preference(
+                                    key: SubHeaderHeightKey.self,
+                                    value: geo.size.height
+                                )
+                            }
+                        )
+                        .allowsHitTesting(false)
+                        .opacity(0),
+                    alignment: .topLeading
+                )
         }
-        // Invisible overlay always renders footer at full height to measure it
+        // Invisible overlay measures footer at full height
         .overlay(
             self.footer
                 .disabled(false)
@@ -115,6 +152,7 @@ package struct MPHeader<Content: View, TrailingActions: View, Footer: View>: Vie
                 ),
             alignment: .bottom
         )
+        .background(self.theme.colors.background.primary.edgesIgnoringSafeArea(.all))
         .onPreferenceChange(MainHeaderHeightKey.self) { self.headerHeight = $0 }
         .onPreferenceChange(SubHeaderHeightKey.self) { self.subHeaderHeight = $0 }
         .onPreferenceChange(ScrollViewHeightKey.self) { self.scrollViewHeight = $0 }
@@ -123,32 +161,53 @@ package struct MPHeader<Content: View, TrailingActions: View, Footer: View>: Vie
         .navigationBarHidden(true)
     }
 
-    // MARK: - Scroll View Content
+    // MARK: - Main Header Bar
+
+    /// Renders the main header bar via the injected style (back button + trailing actions).
+    /// Uses fixedSize to ensure it takes only its natural height regardless of proposed size.
+    private var mainHeaderBar: some View {
+        let configuration = MPHeaderStyleConfiguration(
+            title: self.title,
+            onBack: self.onBack,
+            trailingActions: self.trailingActionsConfiguration,
+            scrollOffset: self.scrollOffset,
+            inlineTitleOpacity: self.inlineTitleOpacity
+        )
+        return AnyView(self.style.resolve(configuration: configuration))
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    // MARK: - Overlay Title
+
+    // MARK: - Scroll Area
 
     @ViewBuilder
-    private var scrollViewContent: some View {
+    private var scrollArea: some View {
         if #available(iOS 14.0, *) {
-            self.scrollViewContentWithAutoScroll
+            self.scrollAreaWithAutoScroll
         } else {
-            self.scrollViewContentBase
+            self.scrollAreaBase
         }
     }
 
     @available(iOS 14.0, *)
-    private var scrollViewContentWithAutoScroll: some View {
+    private var scrollAreaWithAutoScroll: some View {
         ScrollViewReader { proxy in
             ScrollViewWithOffset(
                 offset: self.$scrollOffset,
                 contentHeight: self.$contentHeight
             ) {
                 VStack(spacing: 0) {
-                    Color.clear
-                        .frame(height: self.headerInset())
-                        .padding(.bottom, self.theme.spacings.xsmall)
+                    // Space reserved for the floating header bar
+                    Color.clear.frame(height: self.headerHeight)
+                    // Invisible spacer that measures sub-header height for animation math
+                    self.subHeaderSpacer
+                    Color.clear.frame(height: self.theme.spacings.xsmall)
                     self.content
-                    // Reserves footer height + bottom spacing so last field is always
-                    // scrollable above the footer overlay with breathing room.
-                    Color.clear.frame(height: self.footerMeasuredHeight + self.theme.spacings.xsmall).id("footerPadding")
+                    // Reserves space so last item scrolls above the footer with breathing room
+                    Color.clear
+                        .frame(height: self.footerMeasuredHeight + self.theme.spacings.xsmall)
+                        .id("footerPadding")
                 }
             }
             .background(
@@ -175,15 +234,15 @@ package struct MPHeader<Content: View, TrailingActions: View, Footer: View>: Vie
         }
     }
 
-    private var scrollViewContentBase: some View {
+    private var scrollAreaBase: some View {
         ScrollViewWithOffset(
             offset: self.$scrollOffset,
             contentHeight: self.$contentHeight
         ) {
             VStack(spacing: 0) {
-                Color.clear
-                    .frame(height: self.headerInset())
-                    .padding(.bottom, self.theme.spacings.xsmall)
+                Color.clear.frame(height: self.headerHeight)
+                self.subHeaderSpacer
+                Color.clear.frame(height: self.theme.spacings.xsmall)
                 self.content
                 Color.clear.frame(height: self.footerMeasuredHeight + self.theme.spacings.xsmall)
             }
@@ -199,41 +258,20 @@ package struct MPHeader<Content: View, TrailingActions: View, Footer: View>: Vie
         )
     }
 
-    // MARK: - Header Content
+    // MARK: - Sub-header Spacer
 
-    private var headerContent: some View {
-        let configuration = MPHeaderStyleConfiguration(
-            title: title,
-            onBack: onBack,
-            trailingActions: trailingActionsConfiguration,
-            collapseProgress: collapseProgress,
-            subHeaderHeight: subHeaderHeight,
-            subHeaderVisibleHeight: subHeaderVisibleHeight,
-            scrollOffset: scrollOffset
-        )
-
-        return AnyView(
-            self.style.resolve(configuration: configuration)
-        )
+    /// Large title that scrolls with the content. When it scrolls off, the inline
+    /// title in the header bar fades in.
+    private var subHeaderSpacer: some View {
+        Text(self.title)
+            .textStyle(.headingHuge())
+            .lineLimit(2)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, self.theme.spacings.xtiny)
+            .padding(.vertical, self.theme.spacings.xmicro)
     }
 
     // MARK: - Computed Properties
-
-    /// Progress of the collapse animation (0 = fully expanded, 1 = fully collapsed)
-    private var collapseProgress: CGFloat {
-        guard self.subHeaderHeight > 0 else { return 0 }
-        return max(0, min((0 - self.scrollOffset) / self.subHeaderHeight, 1))
-    }
-
-    /// Visible height of the sub-header (decreases as user scrolls)
-    private var subHeaderVisibleHeight: CGFloat {
-        self.subHeaderHeight * (1 - self.collapseProgress)
-    }
-
-    private func headerInset() -> CGFloat {
-        let totalInset = self.headerHeight + self.subHeaderVisibleHeight
-        return max(totalInset, 40)
-    }
 
     private var trailingActionsConfiguration: MPHeaderStyleConfiguration.TrailingActions? {
         guard TrailingActions.self != EmptyView.self else { return nil }
@@ -278,27 +316,23 @@ private struct ScrollViewWithOffset<Content: View>: View {
         ScrollView {
             self.content
                 .background(
-                    GeometryReader { geo in
-                        Color.clear
-                            .preference(
-                                key: ScrollOffsetKey.self,
-                                value: geo.frame(in: .named("MPScroll")).origin
-                            )
-                    }
+                    ScrollMetricsReader(
+                        contentHeight: self.$contentHeight,
+                        scrollOffset: self.$offset
+                    )
                 )
-                .background(ScrollContentSizeReader(contentHeight: self.$contentHeight))
-        }
-        .coordinateSpace(name: "MPScroll")
-        .onPreferenceChange(ScrollOffsetKey.self) { value in
-            self.offset = value.y
         }
     }
 }
 
-// MARK: - UIScrollView Content Size Reader
+// MARK: - UIScrollView Metrics Reader (KVO-based, reliable on all iOS versions)
 
-private struct ScrollContentSizeReader: UIViewRepresentable {
+/// Walks up the UIView hierarchy to find the parent UIScrollView, then uses KVO to
+/// observe contentOffset and layoutSubviews to observe contentSize. This is more
+/// reliable than the GeometryReader+PreferenceKey approach for scroll tracking.
+private struct ScrollMetricsReader: UIViewRepresentable {
     @Binding var contentHeight: CGFloat
+    @Binding var scrollOffset: CGFloat
 
     func makeUIView(context _: Context) -> InnerView {
         let view = InnerView()
@@ -308,22 +342,43 @@ private struct ScrollContentSizeReader: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: InnerView, context _: Context) {
-        uiView.onHeightChange = { height in
-            if height > 0, abs(height - self.contentHeight) > 0.5 {
+        uiView.onHeightChange = { [weak uiView] height in
+            guard let uiView else { return }
+            if height > 0, abs(height - uiView.lastReportedHeight) > 0.5 {
+                uiView.lastReportedHeight = height
                 self.contentHeight = height
             }
+        }
+        uiView.onOffsetChange = { offset in
+            self.scrollOffset = offset
         }
     }
 
     final class InnerView: UIView {
         var onHeightChange: ((CGFloat) -> Void)?
+        var onOffsetChange: ((CGFloat) -> Void)?
+        var lastReportedHeight: CGFloat = 0
+        private var observation: NSKeyValueObservation?
 
         override func layoutSubviews() {
             super.layoutSubviews()
+            guard self.observation == nil else { return }
             var current: UIView? = self
             while let parent = current?.superview {
                 if let scrollView = parent as? UIScrollView {
+                    // Report initial content size
                     self.onHeightChange?(scrollView.contentSize.height)
+                    // Observe contentOffset via KVO — fires on every scroll frame
+                    self.observation = scrollView.observe(
+                        \.contentOffset,
+                        options: [.new]
+                    ) { [weak self] sv, _ in
+                        DispatchQueue.main.async {
+                            self?.onHeightChange?(sv.contentSize.height)
+                            // Negate so scrolling down → negative offset (matching convention)
+                            self?.onOffsetChange?(-sv.contentOffset.y)
+                        }
+                    }
                     return
                 }
                 current = parent
@@ -334,9 +389,11 @@ private struct ScrollContentSizeReader: UIViewRepresentable {
 
 // MARK: - Preference Keys
 
-private struct ScrollOffsetKey: PreferenceKey {
-    static let defaultValue: CGPoint = .zero
-    static func reduce(value _: inout CGPoint, nextValue _: () -> CGPoint) {}
+private struct SubHeaderHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
 }
 
 private struct FooterHeightKey: PreferenceKey {

--- a/Sources/MPComponents/BaseElements/Header/MPHeaderStyle.swift
+++ b/Sources/MPComponents/BaseElements/Header/MPHeaderStyle.swift
@@ -12,6 +12,8 @@ import SwiftUI
 package protocol MPHeaderStyle: StyleProtocol, Identifiable where Configuration == MPHeaderStyleConfiguration {}
 
 /// Default visual style for `MPHeader` using theme tokens.
+/// Renders only the main header bar (back button + trailing actions).
+/// The animated title is handled by `MPHeader` directly.
 package struct MPDefaultHeaderStyle: MPHeaderStyle {
     package var id: UUID = .init()
 
@@ -21,15 +23,6 @@ package struct MPDefaultHeaderStyle: MPHeaderStyle {
 
     @MainActor
     package func makeBody(configuration: MPHeaderStyleConfiguration) -> some View {
-        VStack(spacing: 0) {
-            self.mainHeader(configuration)
-            self.subHeader(configuration)
-        }
-        .background(self.theme.colors.background.primary.edgesIgnoringSafeArea(.top))
-    }
-
-    @MainActor
-    private func mainHeader(_ configuration: MPHeaderStyleConfiguration) -> some View {
         HStack(spacing: self.theme.spacings.xmicro) {
             Button(action: configuration.onBack) {
                 Image(systemName: Logos.arrowLeft)
@@ -41,7 +34,7 @@ package struct MPDefaultHeaderStyle: MPHeaderStyle {
             Text(configuration.title)
                 .textStyle(.headingMedium())
                 .lineLimit(1)
-                .opacity(configuration.collapseProgress)
+                .opacity(Double(configuration.inlineTitleOpacity))
                 .frame(maxWidth: .infinity)
 
             if let trailing = configuration.trailingActions {
@@ -61,38 +54,9 @@ package struct MPDefaultHeaderStyle: MPHeaderStyle {
                 )
             }
         )
-        .animation(
-            .easeInOut(duration: 0.2), value: configuration.collapseProgress
-        )
     }
 
-    @MainActor
-    private func subHeader(_ configuration: MPHeaderStyleConfiguration) -> some View {
-        Text(configuration.title)
-            .textStyle(.headingHuge())
-            .lineLimit(2)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, self.theme.spacings.xtiny)
-            .padding(
-                .vertical,
-                configuration.subHeaderVisibleHeight > 24 ?
-                    self.theme.spacings.xmicro : 0
-            )
-            .background(
-                GeometryReader { geo in
-                    Color.clear.preference(
-                        key: SubHeaderHeightKey.self,
-                        value: geo.size.height
-                    )
-                }
-            )
-            .frame(height: configuration.subHeaderVisibleHeight, alignment: .top)
-            .opacity(1 - configuration.collapseProgress)
-            .offset(y: -(configuration.subHeaderHeight - configuration.subHeaderVisibleHeight))
-            .clipped()
-    }
-
-    // MARK: - Background with Blur
+    // MARK: - Background
 
     @ViewBuilder
     private func headerBackgroundView(
@@ -100,40 +64,17 @@ package struct MPDefaultHeaderStyle: MPHeaderStyle {
     ) -> some View {
         let epsilon: CGFloat = 0.00001
 
-        ZStack {
-            if configuration.scrollOffset < -epsilon {
-                self.theme.colors.background.primary.opacity(0.98)
-            } else {
-                Color.clear
-            }
+        if configuration.scrollOffset < -epsilon {
+            self.theme.colors.background.primary.opacity(0.98)
+        } else {
+            Color.clear
         }
     }
 }
 
-// MARK: - Visual Effect Blur
-
-private struct VisualEffectBlur: UIViewRepresentable {
-    var blurStyle: UIBlurEffect.Style
-
-    func makeUIView(context _: Context) -> UIVisualEffectView {
-        return UIVisualEffectView(effect: UIBlurEffect(style: self.blurStyle))
-    }
-
-    func updateUIView(_ uiView: UIVisualEffectView, context _: Context) {
-        uiView.effect = UIBlurEffect(style: self.blurStyle)
-    }
-}
-
-// MARK: - PreferenceKeys for Header Measurements
+// MARK: - PreferenceKey for Header Height
 
 package struct MainHeaderHeightKey: PreferenceKey {
-    package static let defaultValue: CGFloat = 0
-    package static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
-    }
-}
-
-package struct SubHeaderHeightKey: PreferenceKey {
     package static let defaultValue: CGFloat = 0
     package static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = max(value, nextValue())

--- a/Sources/MPComponents/BaseElements/Header/MPHeaderStyleConfiguration.swift
+++ b/Sources/MPComponents/BaseElements/Header/MPHeaderStyleConfiguration.swift
@@ -9,54 +9,44 @@ import SwiftUI
 
 /// Configuration passed to `MPHeaderStyle` for rendering.
 package struct MPHeaderStyleConfiguration {
-    
     // MARK: - Subviews
-    
+
     package struct TrailingActions: View {
         package let body: AnyView
     }
-    
+
     // MARK: - Properties
-    
-    /// Header title displayed in both main and sub-header contexts.
+
+    /// Header title.
     package let title: String
-    
+
     /// Action invoked when the back button is pressed.
     package let onBack: () -> Void
-    
-    /// Optional trailing actions supplied by the parent view.
+
+    /// Optional trailing actions on the right side.
     package let trailingActions: TrailingActions?
-    
-    /// Progress of collapse animation (0 = expanded, 1 = collapsed)
-    package let collapseProgress: CGFloat
-    
-    /// Full height of sub-header (for measuring)
-    package let subHeaderHeight: CGFloat
-    
-    /// Visible height of sub-header (after collapse calculation)
-    package let subHeaderVisibleHeight: CGFloat
-    
-    /// Current scroll offset (negative when scrolled down)
+
+    /// Current scroll offset (negative when scrolled down). Used for background styling.
     package let scrollOffset: CGFloat
-    
+
+    /// Opacity for the inline title next to the back button (0 = hidden, 1 = fully visible).
+    /// Increases as the large title in scroll content disappears.
+    package let inlineTitleOpacity: CGFloat
+
     // MARK: - Initialization
-    
+
     @MainActor
     package init(
         title: String,
         onBack: @escaping () -> Void,
         trailingActions: TrailingActions? = nil,
-        collapseProgress: CGFloat,
-        subHeaderHeight: CGFloat,
-        subHeaderVisibleHeight: CGFloat,
-        scrollOffset: CGFloat
+        scrollOffset: CGFloat,
+        inlineTitleOpacity: CGFloat = 0
     ) {
         self.title = title
         self.onBack = onBack
         self.trailingActions = trailingActions
-        self.collapseProgress = collapseProgress
-        self.subHeaderHeight = subHeaderHeight
-        self.subHeaderVisibleHeight = subHeaderVisibleHeight
         self.scrollOffset = scrollOffset
+        self.inlineTitleOpacity = inlineTitleOpacity
     }
 }


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
https://mercadolibre.atlassian.net/browse/CHOBK-3846

## Description
- Reworked the large title animation: it now physically scrolls with the content as a `subHeaderSpacer`, and the inline title in the header bar fades in only after 75% of scroll progress (`inlineTitleOpacity`) — removing the previous clipping/offset approach
- Replaced `GeometryReader + PreferenceKey` scroll tracking with a KVO-based `ScrollMetricsReader` (UIViewRepresentable) that observes `contentOffset` directly, improving reliability across all iOS 13+ versions
- Simplified `MPHeaderStyleConfiguration`: removed `collapseProgress`, `subHeaderHeight`, and `subHeaderVisibleHeight`; replaced with a single `inlineTitleOpacity` CGFloat
- Moved sub-header height measurement out of the `ScrollView` (using an invisible zero-height overlay) so preference propagation is direct and reliable
- Removed `VisualEffectBlur` struct and simplified background overlay logic
- `SubHeaderHeightKey` moved from package-level in `MPHeaderStyle` to a private key inside `MPHeader`

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
![Simulator Screen Recording - iPhone 17 - 2026-04-02 at 14 29 03](https://github.com/user-attachments/assets/82cf739c-16c1-4e6b-a3e6-908a956717e8)
