### PR TITLE
(Fix): Fix close screen on init error

### DIFF
--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -69,14 +69,14 @@ struct CardFormBrick: View {
             do {
                 try await self.brickViewModel.load()
             } catch let error as MercadoPagoCheckoutError {
-                self.onResult(.error(error))
+                self.fail(error)
             } catch {
                 let checkoutError = MercadoPagoCheckoutError(
                     code: .unknown,
                     localizedDescription: error.localizedDescription,
                     location: .initialization
                 )
-                self.onResult(.error(checkoutError))
+                self.fail(checkoutError)
             }
         }
     }


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
N/A

## Description
- Fixed duplicate `onResult(.error(...))` callback call during `CardFormBrick` initialization failure — it was being called once in the `.mpTask` error handler and again inside `fail()`, which already calls `onResult` internally
- Removed redundant `onResult` calls from the `.mpTask` block so that `fail()` is the single source of truth for error handling on init (notifies result, dismisses screen, shows snackbar)
- Affected scenario: initialization errors such as failure to fetch identification types cause the checkout screen to correctly close and report the error exactly once

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
N/A — no UI changes