### PR TITLE
(Fix): Fix translations wordings

### DIFF
--- a/Sources/MPFoundation/Localization/MPStrings+CardForm.swift
+++ b/Sources/MPFoundation/Localization/MPStrings+CardForm.swift
@@ -188,8 +188,8 @@ extension MPStrings {
             ///   - length: Number of digits in the security code.
             ///   - location: Location on the card (`"front"` or `"back"`).
             package static func tooltipStatic(length: Int, location: String) -> String {
-                let locationKey = location == "front" ? "cvv.tooltip.location.front" : "cvv.tooltip.location.back"
-                return localized("cvv.tooltip.static", length, localized(locationKey))
+                let key = location == "front" ? "cvv.tooltip.static.front" : "cvv.tooltip.static.back"
+                return localized(key, length)
             }
 
             /// Tooltip for dynamic CVV (default cards)

--- a/Sources/MPFoundation/Resources/es-AR.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-AR.lproj/Localizable.strings
@@ -15,7 +15,7 @@
 "card_number.error.empty" = "Completá este campo.";
 "card_number.error.incomplete" = "Ingresá el número completo.";
 "card_number.error.invalid" = "Ingresá el número tal como aparece en la tarjeta.";
-"card_number.error.credit_limit" = "Ingresá una tarjeta con límite suficiente para pagar el monto.";
+"card_number.error.credit_limit" = "Verificá que la tarjeta tenga límite suficiente.";
 "card_number.error.debit_balance" = "Ingresá una tarjeta con saldo suficiente para pagar el monto.";
 "card_number.error.seller_exclusion" = "La tienda no acepta tarjetas %@.";
 "card_number.error.credit_only" = "La tienda solo acepta tarjetas de crédito.";
@@ -44,9 +44,8 @@
 "cvv.error.empty" = "Completá este campo.";
 "cvv.error.incomplete" = "Ingresá el código completo.";
 "cvv.optional" = "Dato opcional.";
-"cvv.tooltip.static" = "Es un número de %ld dígitos que está %@ de tu tarjeta.";
-"cvv.tooltip.location.back" = "en el dorso";
-"cvv.tooltip.location.front" = "en el frente";
+"cvv.tooltip.static.back" = "Es un número de %ld dígitos que está en el dorso de tu tarjeta o en la app de tu banco.";
+"cvv.tooltip.static.front" = "Es un número de %ld dígitos que está en el frente de tu tarjeta o en la app de tu banco.";
 "cvv.tooltip.dynamic.default" = "Es un número de 3 dígitos que encontrás en la app de tu banco o billetera.";
 "cvv.tooltip.dynamic.amex" = "Es un número de 4 dígitos que encontrás en la app de tu banco o billetera.";
 "cvv.tooltip.unknown.default" = "Es un número de 3 dígitos que está en el dorso de tu tarjeta.";
@@ -89,6 +88,6 @@
 "common.prepaid" = "Tarjeta Prepaga";
 
 /* MARK: - Errors */
-"error.generic" = "Algo salió mal. Por favor, intentá de nuevo.";
+"error.generic" = "Ocurrió un error. Por favor, inténtalo de nuevo.";
 "error.network" = "Error de conexión. Verificá tu conexión a internet.";
 

--- a/Sources/MPFoundation/Resources/es-CL.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-CL.lproj/Localizable.strings
@@ -15,7 +15,7 @@
 "card_number.error.empty" = "Completa este campo.";
 "card_number.error.incomplete" = "Ingresa el número completo.";
 "card_number.error.invalid" = "Ingresa el número tal como aparece en la tarjeta.";
-"card_number.error.credit_limit" = "Ingresa una tarjeta con límite suficiente para pagar el monto.";
+"card_number.error.credit_limit" = "Verifica que la tarjeta tenga límite suficiente.";
 "card_number.error.debit_balance" = "Ingresa una tarjeta con saldo suficiente para pagar el monto.";
 "card_number.error.seller_exclusion" = "La tienda no acepta tarjetas %@.";
 "card_number.error.credit_only" = "La tienda solo acepta tarjetas de crédito.";
@@ -44,9 +44,8 @@
 "cvv.error.empty" = "Completa este campo.";
 "cvv.error.incomplete" = "Ingresa el código completo.";
 "cvv.optional" = "Dato opcional.";
-"cvv.tooltip.static" = "Es un número de %ld dígitos que está %@ de tu tarjeta.";
-"cvv.tooltip.location.back" = "en el dorso";
-"cvv.tooltip.location.front" = "en el frente";
+"cvv.tooltip.static.back" = "Es un número de %ld dígitos que está en el dorso de tu tarjeta o en la app de tu banco.";
+"cvv.tooltip.static.front" = "Es un número de %ld dígitos que está en el frente de tu tarjeta o en la app de tu banco.";
 "cvv.tooltip.dynamic.default" = "Es un número de 3 dígitos que encuentras en la app de tu banco o billetera.";
 "cvv.tooltip.dynamic.amex" = "Es un número de 4 dígitos que encuentras en la app de tu banco o billetera.";
 "cvv.tooltip.unknown.default" = "Es un número de 3 dígitos que está en el dorso de tu tarjeta.";
@@ -89,5 +88,5 @@
 "common.prepaid" = "Tarjeta Prepago";
 
 /* MARK: - Errors */
-"error.generic" = "Algo salió mal. Por favor, intenta de nuevo.";
+"error.generic" = "Ocurrió un error. Por favor, intentá de nuevo.";
 "error.network" = "Error de conexión. Verifica tu conexión a internet.";

--- a/Sources/MPFoundation/Resources/es-CL.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-CL.lproj/Localizable.strings
@@ -88,5 +88,5 @@
 "common.prepaid" = "Tarjeta Prepago";
 
 /* MARK: - Errors */
-"error.generic" = "Ocurrió un error. Por favor, intentá de nuevo.";
+"error.generic" = "Ocurrió un error. Por favor, intenta de nuevo.";
 "error.network" = "Error de conexión. Verifica tu conexión a internet.";

--- a/Sources/MPFoundation/Resources/es-CO.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-CO.lproj/Localizable.strings
@@ -15,7 +15,7 @@
 "card_number.error.empty" = "Completa este campo.";
 "card_number.error.incomplete" = "Ingresa el número completo.";
 "card_number.error.invalid" = "Ingresa el número tal como aparece en la tarjeta.";
-"card_number.error.credit_limit" = "Ingresa una tarjeta con límite suficiente para pagar el monto.";
+"card_number.error.credit_limit" = "Verifica que la tarjeta tenga límite suficiente.";
 "card_number.error.debit_balance" = "Ingresa una tarjeta con saldo suficiente para pagar el monto.";
 "card_number.error.seller_exclusion" = "La tienda no acepta tarjetas %@.";
 "card_number.error.credit_only" = "La tienda solo acepta tarjetas de crédito.";
@@ -44,9 +44,8 @@
 "cvv.error.empty" = "Completa este campo.";
 "cvv.error.incomplete" = "Ingresa el código completo.";
 "cvv.optional" = "Dato opcional.";
-"cvv.tooltip.static" = "Es un número de %ld dígitos que está %@ de tu tarjeta.";
-"cvv.tooltip.location.back" = "en el dorso";
-"cvv.tooltip.location.front" = "en el frente";
+"cvv.tooltip.static.back" = "Es un número de %ld dígitos que está en el dorso de tu tarjeta o en la app de tu banco.";
+"cvv.tooltip.static.front" = "Es un número de %ld dígitos que está en el frente de tu tarjeta o en la app de tu banco.";
 "cvv.tooltip.dynamic.default" = "Es un número de 3 dígitos que encuentras en la app de tu banco o billetera.";
 "cvv.tooltip.dynamic.amex" = "Es un número de 4 dígitos que encuentras en la app de tu banco o billetera.";
 "cvv.tooltip.unknown.default" = "Es un número de 3 dígitos que está en el dorso de tu tarjeta.";
@@ -89,5 +88,5 @@
 "common.prepaid" = "Tarjeta Prepago";
 
 /* MARK: - Errors */
-"error.generic" = "Algo salió mal. Por favor, intenta de nuevo.";
+"error.generic" = "Ocurrió un error. Por favor, intentá de nuevo.";
 "error.network" = "Error de conexión. Verifica tu conexión a internet.";

--- a/Sources/MPFoundation/Resources/es-CO.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-CO.lproj/Localizable.strings
@@ -88,5 +88,5 @@
 "common.prepaid" = "Tarjeta Prepago";
 
 /* MARK: - Errors */
-"error.generic" = "Ocurrió un error. Por favor, intentá de nuevo.";
+"error.generic" = "Ocurrió un error. Por favor, intenta de nuevo.";
 "error.network" = "Error de conexión. Verifica tu conexión a internet.";

--- a/Sources/MPFoundation/Resources/es-MX.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-MX.lproj/Localizable.strings
@@ -15,7 +15,7 @@
 "card_number.error.empty" = "Completa este campo.";
 "card_number.error.incomplete" = "Ingresa el número completo.";
 "card_number.error.invalid" = "Ingresa el número tal como aparece en la tarjeta.";
-"card_number.error.credit_limit" = "Ingresa una tarjeta con límite suficiente para pagar el monto.";
+"card_number.error.credit_limit" = "Verifica que la tarjeta tenga límite suficiente.";
 "card_number.error.debit_balance" = "Ingresa una tarjeta con saldo suficiente para pagar el monto.";
 "card_number.error.seller_exclusion" = "La tienda no acepta tarjetas %@.";
 "card_number.error.credit_only" = "La tienda solo acepta tarjetas de crédito.";
@@ -44,9 +44,8 @@
 "cvv.error.empty" = "Completa este campo.";
 "cvv.error.incomplete" = "Ingresa el código completo.";
 "cvv.optional" = "Dato opcional.";
-"cvv.tooltip.static" = "Es un número de %ld dígitos que está %@ de tu tarjeta.";
-"cvv.tooltip.location.back" = "en el dorso";
-"cvv.tooltip.location.front" = "en el frente";
+"cvv.tooltip.static.back" = "Es un número de %ld dígitos que está en el dorso de tu tarjeta o en la app de tu banco.";
+"cvv.tooltip.static.front" = "Es un número de %ld dígitos que está en el frente de tu tarjeta o en la app de tu banco.";
 "cvv.tooltip.dynamic.default" = "Es un número de 3 dígitos que encuentras en la app de tu banco o billetera.";
 "cvv.tooltip.dynamic.amex" = "Es un número de 4 dígitos que encuentras en la app de tu banco o billetera.";
 "cvv.tooltip.unknown.default" = "Es un número de 3 dígitos que está en el dorso de tu tarjeta.";
@@ -89,6 +88,6 @@
 "common.prepaid" = "Tarjeta Prepagada";
 
 /* MARK: - Errors */
-"error.generic" = "Algo salió mal. Por favor, intenta de nuevo.";
+"error.generic" = "Ocurrió un error. Por favor, intentá de nuevo.";
 "error.network" = "Error de conexión. Verifica tu conexión a internet.";
 

--- a/Sources/MPFoundation/Resources/es-MX.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-MX.lproj/Localizable.strings
@@ -88,6 +88,6 @@
 "common.prepaid" = "Tarjeta Prepagada";
 
 /* MARK: - Errors */
-"error.generic" = "Ocurrió un error. Por favor, intentá de nuevo.";
+"error.generic" = "Ocurrió un error. Por favor, intenta de nuevo.";
 "error.network" = "Error de conexión. Verifica tu conexión a internet.";
 

--- a/Sources/MPFoundation/Resources/es-PE.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-PE.lproj/Localizable.strings
@@ -15,7 +15,7 @@
 "card_number.error.empty" = "Completa este campo.";
 "card_number.error.incomplete" = "Ingresa el número completo.";
 "card_number.error.invalid" = "Ingresa el número tal como aparece en la tarjeta.";
-"card_number.error.credit_limit" = "Ingresa una tarjeta con límite suficiente para pagar el monto.";
+"card_number.error.credit_limit" = "Verifica que la tarjeta tenga límite suficiente.";
 "card_number.error.debit_balance" = "Ingresa una tarjeta con saldo suficiente para pagar el monto.";
 "card_number.error.seller_exclusion" = "La tienda no acepta tarjetas %@.";
 "card_number.error.credit_only" = "La tienda solo acepta tarjetas de crédito.";
@@ -44,9 +44,8 @@
 "cvv.error.empty" = "Completa este campo.";
 "cvv.error.incomplete" = "Ingresa el código completo.";
 "cvv.optional" = "Dato opcional.";
-"cvv.tooltip.static" = "Es un número de %ld dígitos que está %@ de tu tarjeta.";
-"cvv.tooltip.location.back" = "en el dorso";
-"cvv.tooltip.location.front" = "en el frente";
+"cvv.tooltip.static.back" = "Es un número de %ld dígitos que está en el dorso de tu tarjeta o en la app de tu banco.";
+"cvv.tooltip.static.front" = "Es un número de %ld dígitos que está en el frente de tu tarjeta o en la app de tu banco.";
 "cvv.tooltip.dynamic.default" = "Es un número de 3 dígitos que encuentras en la app de tu banco o billetera.";
 "cvv.tooltip.dynamic.amex" = "Es un número de 4 dígitos que encuentras en la app de tu banco o billetera.";
 "cvv.tooltip.unknown.default" = "Es un número de 3 dígitos que está en el dorso de tu tarjeta.";
@@ -89,5 +88,5 @@
 "common.prepaid" = "Tarjeta Prepago";
 
 /* MARK: - Errors */
-"error.generic" = "Algo salió mal. Por favor, intenta de nuevo.";
+"error.generic" = "Ocurrió un error. Por favor, intentá de nuevo.";
 "error.network" = "Error de conexión. Verifica tu conexión a internet.";

--- a/Sources/MPFoundation/Resources/es-PE.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-PE.lproj/Localizable.strings
@@ -88,5 +88,5 @@
 "common.prepaid" = "Tarjeta Prepago";
 
 /* MARK: - Errors */
-"error.generic" = "Ocurrió un error. Por favor, intentá de nuevo.";
+"error.generic" = "Ocurrió un error. Por favor, intenta de nuevo.";
 "error.network" = "Error de conexión. Verifica tu conexión a internet.";

--- a/Sources/MPFoundation/Resources/es-UY.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/es-UY.lproj/Localizable.strings
@@ -15,7 +15,7 @@
 "card_number.error.empty" = "Completá este campo.";
 "card_number.error.incomplete" = "Ingresá el número completo.";
 "card_number.error.invalid" = "Ingresá el número tal como aparece en la tarjeta.";
-"card_number.error.credit_limit" = "Ingresá una tarjeta con límite suficiente para pagar el monto.";
+"card_number.error.credit_limit" = "Verificá que la tarjeta tenga límite suficiente.";
 "card_number.error.debit_balance" = "Ingresá una tarjeta con saldo suficiente para pagar el monto.";
 "card_number.error.seller_exclusion" = "La tienda no acepta tarjetas %@.";
 "card_number.error.credit_only" = "La tienda solo acepta tarjetas de crédito.";
@@ -44,9 +44,8 @@
 "cvv.error.empty" = "Completá este campo.";
 "cvv.error.incomplete" = "Ingresá el código completo.";
 "cvv.optional" = "Dato opcional.";
-"cvv.tooltip.static" = "Es un número de %ld dígitos que está %@ de tu tarjeta.";
-"cvv.tooltip.location.back" = "en el dorso";
-"cvv.tooltip.location.front" = "en el frente";
+"cvv.tooltip.static.back" = "Es un número de %ld dígitos que está en el dorso de tu tarjeta o en la app de tu banco.";
+"cvv.tooltip.static.front" = "Es un número de %ld dígitos que está en el frente de tu tarjeta o en la app de tu banco.";
 "cvv.tooltip.dynamic.default" = "Es un número de 3 dígitos que encontrás en la app de tu banco o billetera.";
 "cvv.tooltip.dynamic.amex" = "Es un número de 4 dígitos que encontrás en la app de tu banco o billetera.";
 "cvv.tooltip.unknown.default" = "Es un número de 3 dígitos que está en el dorso de tu tarjeta.";
@@ -89,5 +88,5 @@
 "common.prepaid" = "Tarjeta Prepaga";
 
 /* MARK: - Errors */
-"error.generic" = "Algo salió mal. Por favor, intentá de nuevo.";
+"error.generic" = "Ocurrió un error. Por favor, intentá de nuevo.";
 "error.network" = "Error de conexión. Verificá tu conexión a internet.";

--- a/Sources/MPFoundation/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/MPFoundation/Resources/pt-BR.lproj/Localizable.strings
@@ -14,8 +14,8 @@
 "card_number.placeholder" = "1234 1234 1234 1234";
 "card_number.error.empty" = "Preencha este campo.";
 "card_number.error.incomplete" = "Insira o número completo.";
-"card_number.error.invalid" = "Insira-o conforme está no cartão.";
-"card_number.error.credit_limit" = "Use um cartão com limite suficiente para pagar o valor.";
+"card_number.error.invalid" = "Insira conforme está no cartão.";
+"card_number.error.credit_limit" = "Verifique se o cartão tem limite suficiente.";
 "card_number.error.debit_balance" = "Use um cartão com saldo suficiente para pagar o valor.";
 "card_number.error.seller_exclusion" = "A loja não aceita cartões %@.";
 "card_number.error.credit_only" = "A loja só aceita cartões de crédito.";
@@ -44,9 +44,8 @@
 "cvv.error.empty" = "Preencha este campo.";
 "cvv.error.incomplete" = "Insira o código completo.";
 "cvv.optional" = "Dado opcional.";
-"cvv.tooltip.static" = "É um número de %ld dígitos que está %@ do seu cartão.";
-"cvv.tooltip.location.back" = "atrás";
-"cvv.tooltip.location.front" = "na parte da frente";
+"cvv.tooltip.static.back" = "É um número de %ld dígitos que está atrás do seu cartão ou no app do seu banco.";
+"cvv.tooltip.static.front" = "É um número de %ld dígitos que está na parte da frente do seu cartão ou no app do seu banco.";
 "cvv.tooltip.dynamic.default" = "É um número de 3 dígitos. Você o encontra no app do seu banco ou carteira digital.";
 "cvv.tooltip.dynamic.amex" = "É um número de 4 dígitos. Você o encontra no app do seu banco ou carteira digital.";
 "cvv.tooltip.unknown.default" = "É um número de 3 dígitos que está atrás do seu cartão.";
@@ -89,5 +88,5 @@
 "common.prepaid" = "Cartão Pré-pago";
 
 /* MARK: - Errors */
-"error.generic" = "Algo deu errado. Por favor, tente novamente.";
+"error.generic" = "Ocorreu um erro. Por favor, tente novamente.";
 "error.network" = "Erro de conexão. Verifique sua conexão com a internet.";


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
N/A

## Description
- Refactored CVV tooltip string keys from a composite pattern (`cvv.tooltip.static` + `cvv.tooltip.location.*`) into two direct keys (`cvv.tooltip.static.front` / `cvv.tooltip.static.back`), with the location text embedded inline — also adds a reference to the banking app ("ou no app do seu banco" / "o en la app de tu banco")
- Updated `MPStrings+CardForm.swift` `tooltipStatic(length:location:)` to use the new key structure
- Fixed `card_number.error.credit_limit` wording across all locales (es-AR, es-CL, es-CO, es-MX, es-PE, es-UY, pt-BR) to be more concise and user-friendly
- Fixed `error.generic` wording across all locales for more neutral tone
- Fixed minor wording in `card_number.error.invalid` (pt-BR)

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.