### PR TITLE
(Fix): Fix immediate feedback on field validations

### DIFF
--- a/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
+++ b/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
@@ -68,7 +68,6 @@ package struct CardNumberRule: CardFormRuleType {
         if digits.isEmpty { return self.validation.errorEmpty }
         if let externalError { return self.validateExternalError(externalError) }
         if digits.count < self.min { return self.validation.errorIncomplete }
-        if !self.luhnCheck(digits) { return self.validation.errorInvalid }
         return nil
     }
 
@@ -76,7 +75,8 @@ package struct CardNumberRule: CardFormRuleType {
         let digits = value.filter(\.isNumber)
         guard !digits.isEmpty else { return nil }
         if let externalError { return self.validateExternalError(externalError) }
-        guard digits.count >= self.min else { return nil }
+        guard digits.count >= self.max else { return nil }
+        if !self.luhnCheck(digits) { return self.validation.errorInvalid }
         return nil
     }
 

--- a/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
+++ b/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
@@ -220,4 +220,13 @@ package struct DocumentRule: CardFormRuleType {
         if self.isNumericType, chars.allSatisfy({ $0 == "0" }) { return self.validation.errorInvalid }
         return nil
     }
+
+    package func validateLive(_ value: String) -> String? {
+        let chars = self.isNumericType
+            ? value.filter(\.isNumber)
+            : value.filter { $0.isLetter || $0.isNumber }
+        guard chars.count >= self.maxLength else { return nil }
+        if self.isNumericType, chars.allSatisfy({ $0 == "0" }) { return self.validation.errorInvalid }
+        return nil
+    }
 }

--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -136,6 +136,7 @@ struct CardFormScreen: View {
                             label: self.initResult.fields.document.label,
                             placeholder: self.viewModel.selectTypeDocument?.getPlaceholder(),
                             errorMessage: self.cardForm.$documentHolder,
+                            liveErrorMessage: self.cardForm.documentHolderLiveErrors,
                             keyboard: self.viewModel.selectTypeDocument?.getKeyboardType() ?? .default,
                             formatter: self.viewModel.documentFormatter,
                             prefix: {

--- a/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
+++ b/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
@@ -74,6 +74,7 @@ struct CardFormData {
 
     func isFormValid(isSecurityCodeMandatory: Bool, isDocumentRequired: Bool = true) -> Bool {
         return _cardNumber.errorMessages.isEmpty
+            && _cardNumber.liveErrorMessages.isEmpty
             && _cardHolder.errorMessages.isEmpty
             && _expirationDate.errorMessages.isEmpty
             && (isSecurityCodeMandatory ? _securityCode.errorMessages.isEmpty : true)

--- a/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
+++ b/Sources/MercadoPagoCheckout/Views/Fields/CardFormData.swift
@@ -72,6 +72,10 @@ struct CardFormData {
         _cardNumber.liveErrorMessages
     }
 
+    var documentHolderLiveErrors: [String] {
+        _documentHolder.liveErrorMessages
+    }
+
     func isFormValid(isSecurityCodeMandatory: Bool, isDocumentRequired: Bool = true) -> Bool {
         return _cardNumber.errorMessages.isEmpty
             && _cardNumber.liveErrorMessages.isEmpty

--- a/Tests/MercadoPagoCheckoutTests/Rules/CardFormRulesTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Rules/CardFormRulesTests.swift
@@ -78,48 +78,15 @@ final class CardFormRulesTests: XCTestCase {
         XCTAssertNotNil(result)
     }
 
-    func test_cardNumberRule_whenValidLuhn_shouldReturnNil() {
+    func test_cardNumberRule_whenAboveMinLength_shouldReturnNil() {
         // Arrange
         let rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
 
-        // Act -- 4111111111111111 is a valid Luhn number
+        // Act
         let result = rule.validate("4111 1111 1111 1111")
 
         // Assert
         XCTAssertNil(result)
-    }
-
-    func test_cardNumberRule_whenInvalidLuhn_shouldReturnInvalidError() {
-        // Arrange
-        let rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
-
-        // Act -- invalid Luhn
-        let result = rule.validate("4111 1111 1111 1112")
-
-        // Assert
-        XCTAssertNotNil(result)
-    }
-
-    func test_cardNumberRule_whenAllDigitsSame_shouldReturnInvalidError() {
-        // Arrange
-        let rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
-
-        // Act -- all digits repeated (1111111111111111)
-        let result = rule.validate("1111 1111 1111 1111")
-
-        // Assert
-        XCTAssertNotNil(result)
-    }
-
-    func test_cardNumberRule_whenAllDigitsSameDifferentDigit_shouldReturnInvalidError() {
-        // Arrange
-        let rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
-
-        // Act -- all digits repeated (4444444444444444)
-        let result = rule.validate("4444 4444 4444 4444")
-
-        // Assert
-        XCTAssertNotNil(result)
     }
 
     func test_cardNumberRule_whenPaymentMethodNotAllowed_shouldReturnSellerExclusionError() {
@@ -223,7 +190,8 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardNumberRule_validateLive_whenAllDigitsSameAndComplete_shouldReturnInvalidError() {
         // Arrange
-        let rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
+        var rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
+        rule.apply(.cardNumberRange(min: 16, max: 16))
 
         // Act
         let result = rule.validateLive("1111 1111 1111 1111")
@@ -250,6 +218,30 @@ final class CardFormRulesTests: XCTestCase {
 
         // Act
         let result = rule.validateLive("4111 1111 1111 1111")
+
+        // Assert
+        XCTAssertNotNil(result)
+    }
+
+    func test_cardNumberRule_validateLive_whenInvalidLuhnButBelowMaxLength_shouldReturnNil() {
+        // Arrange
+        var rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
+        rule.apply(.cardNumberRange(min: 13, max: 16))
+
+        // Act
+        let result = rule.validateLive("4111 1111 1111 2")
+
+        // Assert
+        XCTAssertNil(result)
+    }
+
+    func test_cardNumberRule_validateLive_whenInvalidLuhnAtMaxLength_shouldReturnInvalidError() {
+        // Arrange
+        var rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
+        rule.apply(.cardNumberRange(min: 16, max: 16))
+
+        // Act
+        let result = rule.validateLive("4111 1111 1111 1112")
 
         // Assert
         XCTAssertNotNil(result)
@@ -495,8 +487,8 @@ final class CardFormRulesTests: XCTestCase {
         // Act / Assert -- empty
         XCTAssertEqual(rule.validate(""), "CUSTOM_EMPTY")
 
-        // Act / Assert -- invalid (all same digits)
-        XCTAssertEqual(rule.validate("1111 1111 1111 1111"), "CUSTOM_INVALID")
+        // Act / Assert -- above min length, no Luhn check in validate
+        XCTAssertNil(rule.validate("1111 1111 1111 1111"))
 
         // Act / Assert -- incomplete
         var ruleWithRange = CardNumberRule(validation: customValidation)

--- a/Tests/MercadoPagoCheckoutTests/Rules/CardFormRulesTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Rules/CardFormRulesTests.swift
@@ -646,4 +646,55 @@ final class CardFormRulesTests: XCTestCase {
         // Assert — string type: all zeros valid
         XCTAssertNil(rule.validate("000"))
     }
+
+    // MARK: - DocumentRule (validateLive)
+
+    func test_documentRule_validateLive_whenBelowMaxLength_shouldReturnNil() {
+        // Arrange
+        var rule = DocumentRule(validation: Self.defaultDocumentValidation())
+        rule.apply(.documentLength(min: 11, max: 11))
+
+        // Act
+        let result = rule.validateLive("1234567890")
+
+        // Assert
+        XCTAssertNil(result)
+    }
+
+    func test_documentRule_validateLive_whenAtMaxLength_andValid_shouldReturnNil() {
+        // Arrange
+        var rule = DocumentRule(validation: Self.defaultDocumentValidation())
+        rule.apply(.documentLength(min: 11, max: 11))
+
+        // Act
+        let result = rule.validateLive("12345678901")
+
+        // Assert
+        XCTAssertNil(result)
+    }
+
+    func test_documentRule_validateLive_whenAtMaxLength_andAllZeros_shouldReturnInvalidError() {
+        // Arrange
+        var rule = DocumentRule(validation: Self.defaultDocumentValidation())
+        rule.apply(.documentLength(min: 11, max: 11))
+
+        // Act
+        let result = rule.validateLive("00000000000")
+
+        // Assert
+        XCTAssertEqual(result, MPStrings.CardForm.Document.errorInvalid)
+    }
+
+    func test_documentRule_validateLive_whenStringType_atMaxLength_andAllZeros_shouldReturnNil() {
+        // Arrange -- all zeros is valid for string type
+        var rule = DocumentRule(validation: Self.defaultDocumentValidation())
+        rule.apply(.documentLength(min: 3, max: 3))
+        rule.apply(.documentType(isNumeric: false))
+
+        // Act
+        let result = rule.validateLive("000")
+
+        // Assert
+        XCTAssertNil(result)
+    }
 }


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
N/A

## Description
- `CardNumberRule`: moved Luhn check from `validate()` to `validateLive()`, triggering the invalid error only after the card number reaches its maximum length — giving immediate feedback while typing instead of only on submit
- `DocumentRule`: added `validateLive()` method that shows validation errors (e.g. all-zeros) as soon as `maxLength` is reached
- `CardFormData`: added `documentHolderLiveErrors` computed property and included `liveErrorMessages` in `isFormValid()` so the submit button stays disabled while live errors are present
- `CardFormScreen`: wired `liveErrorMessage` for the document field using the new `documentHolderLiveErrors`
- Updated `CardFormRulesTests` to cover the new live validation paths for both card number (Luhn) and document rules

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [x] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
| CardNumber | Document | 
| --- | --- |
| ![Simulator Screen Recording - iPhone 17 Pro - 2026-04-06 at 15 13 33](https://github.com/user-attachments/assets/a53a9f59-ad91-48b0-b237-c995b1d6c2bd) | ![Simulator Screen Recording - iPhone 17 Pro - 2026-04-06 at 16 07 35](https://github.com/user-attachments/assets/ffd16709-3312-4656-a93e-6db778395164) |
