### PR TITLE
(Fix): Fix card number length validation

### DIFF
--- a/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
+++ b/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
@@ -75,7 +75,7 @@ package struct CardNumberRule: CardFormRuleType {
         let digits = value.filter(\.isNumber)
         guard !digits.isEmpty else { return nil }
         if let externalError { return self.validateExternalError(externalError) }
-        guard digits.count >= self.max else { return nil }
+        guard digits.count == self.max else { return nil }
         if !self.luhnCheck(digits) { return self.validation.errorInvalid }
         return nil
     }

--- a/Tests/MercadoPagoCheckoutTests/Rules/CardFormRulesTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Rules/CardFormRulesTests.swift
@@ -235,6 +235,18 @@ final class CardFormRulesTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    func test_cardNumberRule_validateLive_whenInvalidLuhnAboveMaxLength_shouldReturnNil() {
+        // Arrange - simulates transitional state when formatter hasn't truncated yet
+        var rule = CardNumberRule(validation: Self.defaultCardNumberValidation())
+        rule.apply(.cardNumberRange(min: 16, max: 16))
+
+        // Act
+        let result = rule.validateLive("4111 1111 1111 11123")
+
+        // Assert
+        XCTAssertNil(result)
+    }
+
     func test_cardNumberRule_validateLive_whenInvalidLuhnAtMaxLength_shouldReturnInvalidError() {
         // Arrange
         var rule = CardNumberRule(validation: Self.defaultCardNumberValidation())


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
| antes | depois |
| --- | --- | 
| ![Simulator Screen Recording - iPhone 17 Pro - 2026-04-06 at 16 47 59](https://github.com/user-attachments/assets/dd445f6b-1d18-4370-a239-80ff3e7adc77) | ![Simulator Screen Recording - iPhone 17 Pro - 2026-04-06 at 17 30 15](https://github.com/user-attachments/assets/98adedc2-2215-4f4b-a88d-38e8aa76bf54) |

## Description
- Fixed `CardNumberRule.validateLive()`: changed condition from `digits.count >= self.max` to `digits.count == self.max` so that the Luhn check (and invalid error) only triggers exactly when the card number reaches its maximum length — preventing premature error display when the user types beyond the minimum but hasn't yet reached the max
- Added test coverage for the boundary condition in `CardFormRulesTests`

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [x] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.