### PR TITLE
(Chore): Removed amount from footer

### DIFF
--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -59,7 +59,7 @@ struct CardFormScreen: View {
             footer: {
                 MPFooter(
                     title: MPStrings.Common.total,
-                    amount: self.viewModel.footerAmount(),
+                    amount: nil,
                     buttonData: .init(
                         text: MPStrings.CardForm.button,
                         onClick: {


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
N/A

## Description
- Removed amount display from the `CardFormScreen` footer by passing `nil` instead of `viewModel.footerAmount()` to `MPFooter`

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>