### PR TITLE
[CHOBK-3907] (Feature): Add contribution guidelines and community files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Report a reproducible bug in the SDK
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## SDK Version
+<!-- e.g. 4.2.1 -->
+
+## iOS Version / Device
+<!-- e.g. iOS 17.4 / iPhone 15 Pro — also test on simulator if possible -->
+
+## Installation Method
+- [ ] Swift Package Manager
+- [ ] CocoaPods
+
+---
+
+## Description
+<!-- A clear and concise description of the bug -->
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behavior
+<!-- What should have happened -->
+
+## Actual Behavior
+<!-- What actually happened -->
+
+## Relevant Logs
+<!-- Paste Xcode console output or os_log entries. Remove any sensitive/PCI data before pasting -->
+```
+```
+
+## Screenshots / Screen Recording
+<!-- If applicable — remove any visible card data before attaching -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Suggest an enhancement or new capability for the SDK
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+<!-- What problem are you trying to solve? Who is affected and how often? -->
+
+## Proposed Solution
+<!-- Describe the behavior or API you'd like to see -->
+
+## API Sketch (optional)
+<!-- If this involves a public API change, show a rough Swift snippet -->
+```swift
+
+```
+
+## Alternatives Considered
+<!-- Any other approaches you've evaluated, and why you prefer the proposed solution -->
+
+## Impact
+<!-- API compatibility, performance, security — any known trade-offs -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,24 +1,25 @@
 # Pull Request
-<!--Provide the title of the pull request-->
-## Ticket or Issue link
-<!--Provide link for your issue or ticket that describes this pull request-->
+
+## Ticket / Issue
+<!-- Link to the ticket or issue this PR addresses -->
 
 ## Description
-<!--Include a list of the changes that were made. List the dependencies that were required for this change.-->
+<!-- Summarize the changes made and the motivation behind them -->
 
 ## Checklist
-- [] I have tested my changes creating a local version (More info in README file).
-- [] I have added tests that prove my solution is effective and works
-- [] New and existing unit tests pass locally with my changes.
-- [] Verify that you are merged with the latest in develop.
-- [] I have run `swiftlint` and fixed any possible issues of my code.
-- [] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
-- [] I have tested the accessibility of the changes and added them to the screenshots.
-- [] I have added a tag to the pull request that contains the product this pull request is related to.
+- [ ] Branch is up to date with `main`
+- [ ] `swiftformat .` was run and the diff is clean
+- [ ] `swiftlint lint` passes with no errors
+- [ ] Tests were added or updated to cover the change
+- [ ] All unit tests pass locally (`swift test`)
+- [ ] Coverage stays at or above 80% (`bundle exec fastlane test`)
+- [ ] Tested on a physical device or simulator (rotation, no connection, error handling)
+- [ ] Accessibility verified for any UI changes
+- [ ] No PCI data (PAN, CVV, expiry) appears in logs, screenshots, or this description
 
-## Screenshots or videos (if applies)
-<!---
-Provide videos or screenshots. You can change their size in the src
+## Screenshots / Screen Recording
+<!-- Required for any UI change. Remove visible card data before attaching -->
+<!--
 <p float="center">
     <img width="200" src="">
     <img width="200" src="">

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as contributors and maintainers pledge to make participation in this project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community and the project
+- Showing empathy towards other contributors
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Maintainers have the right to remove, edit, or reject comments, commits, code, issues, and other contributions that are not aligned with this Code of Conduct.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — GitHub issues, pull requests, code review comments, and any other official communication channel related to this project.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the team at **developers@mercadopago.com**. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -1,0 +1,140 @@
+# Coding Guidelines
+
+## Language
+Use English in all source code, comments, doc comments, commit messages, PR descriptions, and review comments.
+
+---
+
+## Code Style
+
+Enforced via **SwiftLint** and **SwiftFormat** with pre-commit hooks.
+
+Setup:
+```bash
+brew install swiftlint swiftformat pre-commit
+pre-commit install
+```
+
+Manual execution:
+```bash
+swiftformat .      # auto-format
+swiftlint lint     # static analysis
+```
+
+Config: `.swiftlint.yml` and `.swiftformat.yml` at the repo root.
+
+---
+
+## Swift Guidelines
+
+- Prefer `let` over `var`; prefer value types (`struct`, `enum`) over reference types when appropriate
+- Avoid force-unwrap (`!`); use `guard let`, `if let`, optional chaining (`?.`), or `?? default`
+- Use `async`/`await` with structured concurrency; avoid `DispatchQueue.global()` in new code; inject concurrency context via `@MainActor` or actor isolation
+- Use `enum` with associated values or `Result<Success, Failure>` for error and state modeling
+- No `// swiftlint:disable` without an explanatory comment
+
+---
+
+## Architecture Guidelines
+
+Module boundaries:
+
+```
+MercadoPagoSDK         ← SDK entry point, top-level initialization
+MPCore                 ← networking, base infrastructure, DeviceFingerPrint
+CoreMethods            ← API layer (identification, installments, tokenization)
+MercadoPagoCheckout    ← card payment UI (SwiftUI), ViewModel, checkout flow
+MPComponents           ← reusable SwiftUI components
+MPFoundation           ← design system, theme, base UI
+MPAnalytics            ← event tracking
+MPApplePay             ← Apple Pay integration
+MPExtended             ← extended APIs (deviceSession)
+```
+
+Dependency direction is strict. No circular dependencies.
+
+- **State**: `@Published` on `ObservableObject` ViewModels or `@State`/`@Binding` in views; never expose mutable state directly to callers
+- **No logic inside SwiftUI `body`** — extract to ViewModel, UseCase, or a plain function
+- **File size**: 300 lines max — extract types or extensions before reaching the limit
+
+---
+
+## Security Guidelines
+
+- Never persist PCI data to disk (`@State` / in-memory only, not `@AppStorage`, `UserDefaults`, or files)
+- Never log PCI data (`print`, `os_log`, crash reporters, analytics SDKs)
+- Never hardcode credentials — pass via `MercadoPagoSDK.Configuration`
+- Always validate inputs at module boundaries
+
+See [SECURITY.md](SECURITY.md) for the full security policy.
+
+---
+
+## Comment Guidelines
+
+- Comment departures from convention, non-obvious decisions, and safety-critical invariants
+- Do not explain obvious code or leave commented-out blocks in production code
+- All public API requires doc comments (`///`)
+
+---
+
+## Testing Guidelines
+
+- Unit tests mandatory for all production code with relevant logic
+- SwiftUI view files (`*Screen.swift`, `*Brick.swift`) are excluded from the coverage gate — logic belongs in ViewModels and UseCases
+- Minimum **80%** line coverage enforced by `xcov` via Fastlane
+- XCTest + Fakes/Stubs; prefer fakes over mocks to avoid tight coupling
+- `tearDown()` must clean up any shared or singleton state
+- Use snapshot tests (`swift-snapshot-testing`) for UI component regression
+
+---
+
+## Branching Guidelines
+
+Branch from `main`:
+
+| Pattern | Use case |
+|---------|----------|
+| `feature/TICKET-description` | New feature |
+| `fix/TICKET-description` | Bug fix |
+| `hotfix/description` | Critical patch |
+| `docs/description` | Docs only |
+| `refactor/description` | Refactor only |
+
+---
+
+## Git Guidelines
+
+Follow the [seven rules](https://chris.beams.io/posts/git-commit): imperative mood, 72-char subject, blank line before body, explain what and why.
+
+```bash
+# Good
+git commit -m "Fix card number validation rejecting valid BIN prefix"
+
+# Also good (with body)
+git commit -m "Add Apple Pay fallback for unsupported devices
+
+Devices without Secure Element cannot use Apple Pay. This change
+adds a graceful fallback to the standard card form instead of
+crashing at runtime."
+```
+
+Unacceptable: `fix tests`, `now it works`, `wip`, `asdfgh`
+
+---
+
+## Pull Request Guidelines
+
+- Every PR must reference a ticket or issue
+- Fill in the PR template completely
+- PRs failing CI will not be reviewed
+- One concern per PR
+- Screenshots or screen recordings required for UI changes
+- Run full checklist before marking ready:
+
+```bash
+swiftformat .
+swiftlint lint
+swift test
+bundle exec fastlane test   # tests + coverage report
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,10 +63,10 @@ Changes via PR are the best way to contribute. Before writing code, read the [Co
 
 | Command | Description |
 |---------|-------------|
-| `make setup` | Full initial setup — runs all steps below in sequence |
-| `make install-tools` | Installs SwiftLint and SwiftFormat via Homebrew |
-| `make setup-git-hooks` | Configures the git pre-commit hook for auto-formatting |
-| `make install-fastlane` | Installs Fastlane and its dependencies via Bundler |
+| `make setup` | Full initial setup — runs the three commands below in sequence |
+| `make install-tools` | Installs SwiftLint and SwiftFormat via Homebrew *(called by `make setup`)* |
+| `make setup-git-hooks` | Configures the git pre-commit hook for auto-formatting *(called by `make setup`)* |
+| `make install-fastlane` | Installs Fastlane and its dependencies via Bundler *(called by `make setup`)* |
 | `make format` | Auto-formats Swift code with SwiftFormat |
 | `make test` | Runs unit tests and generates coverage report via Fastlane |
 | `make clean` | Removes installed tools and generated test/coverage output |
@@ -100,7 +100,7 @@ Commits like `fix tests`, `now it works`, or `wip` will not be accepted. See [Co
 
 ## Example app
 
-The `Example/` directory contains an Xcode project that demonstrates the SDK integrations — CardForm (SwiftUI and UIKit), Device Session, 3DS, and Installments. It links to the local SDK via Swift Package Manager, so changes you make to the SDK are immediately reflected.
+The `Example/` directory contains an Xcode project that demonstrates the SDK integrations — CardForm (SwiftUI and UIKit), Device Session, and Installments. It links to the local SDK via Swift Package Manager, so changes you make to the SDK are immediately reflected.
 
 ### Setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,194 @@
+# Contributing to Mercado Pago SDK iOS
+
+Thank you for contributing to **Mercado Pago SDK iOS**. This guide explains how to report issues, propose changes, and open Pull Requests (PRs) with quality and safety.
+
+## Code of Conduct
+
+By participating in this project, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+---
+
+## How can I contribute?
+
+### 1) Report bugs
+
+Before opening an issue:
+- Check whether a similar issue already exists (open or closed).
+- Provide as much context as possible:
+  - SDK version
+  - iOS version / device model
+  - Steps to reproduce
+  - Expected result vs. actual result
+  - Relevant logs (Xcode console, `os_log`) and/or screenshots
+
+### 2) Suggest enhancements
+
+Suggestions are welcome. Please explain:
+- What problem you are solving
+- Your proposed solution
+- Expected impact (API, compatibility, performance)
+
+### 3) Submit code (Pull Request)
+
+Changes via PR are the best way to contribute. Before writing code, read the [Coding Guidelines](CODING_GUIDELINES.md) — they cover language, style, architecture, security, testing, and commit conventions for this project.
+
+---
+
+## Requirements before you start
+
+### Environment
+
+- Xcode 16.0+ (latest stable recommended)
+- Swift 5.5+
+- iOS 13.0+ deployment target
+- Homebrew — required to install development tools
+
+### Running the project locally
+
+1. Fork the repository
+2. Clone your fork and add upstream:
+   ```bash
+   git clone https://github.com/<your-user>/sdk-ios.git
+   cd sdk-ios
+   git remote add upstream https://github.com/mercadopago/sdk-ios.git
+   ```
+3. Run the full setup (installs SwiftLint, SwiftFormat, git hooks, and Fastlane):
+   ```bash
+   make setup
+   ```
+4. Open `Package.swift` in Xcode to build and run the project
+5. Create a branch for your change (see naming convention below)
+
+### Available `make` commands
+
+| Command | Description |
+|---------|-------------|
+| `make setup` | Full initial setup — installs all tools, git hooks, and Fastlane |
+| `make format` | Auto-formats Swift code with SwiftFormat |
+| `make test` | Runs unit tests and generates coverage report via Fastlane |
+| `make clean` | Removes installed tools and generated test/coverage output |
+
+### Branch naming convention
+
+Create branches from `main`. Suggested names:
+
+- `feature/<ticket>/short-description`
+- `fix/<ticket>/short-description`
+- `hotfix/short-description`
+- `docs/<ticket>/short-description`
+- `refactor/<ticket>/short-description`
+
+Example:
+```bash
+git checkout -b fix/3795/card-number-error
+```
+
+### Commit message convention
+
+Follow the [seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit). Use the imperative mood, capitalize the subject, limit to 72 characters, and explain **what and why** in the body.
+
+```bash
+git commit -m "Fix card number validation rejecting valid BIN prefix"
+```
+
+Commits like `fix tests`, `now it works`, or `wip` will not be accepted. See [Coding Guidelines — Git](CODING_GUIDELINES.md#git-guidelines) for full details and examples.
+
+---
+
+## Example app
+
+The `Example/` directory contains an Xcode project that demonstrates the SDK integrations — CardForm (SwiftUI and UIKit), Device Session, 3DS, and Installments. It links to the local SDK via CocoaPods, so changes you make to the SDK are immediately reflected.
+
+### Setup
+
+```bash
+cd Example
+pod install
+open Example.xcworkspace
+```
+
+> Requires CocoaPods (`gem install cocoapods`). Use `Example.xcworkspace`, not `Example.xcodeproj`.
+
+### When to use it
+
+- **UI changes** — run the affected flow end-to-end and record a screen capture to attach to your PR.
+- **New public API** — add a usage example in the relevant screen to confirm the integration works as expected.
+- **Bug fixes** — reproduce the bug in the app before fixing, and verify it is gone after.
+
+> The Example app is excluded from the coverage gate and from SwiftLint — it exists solely for manual validation.
+
+---
+
+## Quality and compatibility
+
+### General guidelines
+
+- Avoid breaking changes without prior discussion.
+- Keep binary and source compatibility whenever possible (library/SDK).
+- Update documentation when the change affects public usage (README, doc comments, sample app).
+- All public API must include doc comments (`///`).
+
+### Style and lint
+
+This project uses **SwiftLint** and **SwiftFormat**, configured via `.swiftlint.yml` and `.swiftformat.yml`. After running `make setup`, a git hook runs formatting automatically before each commit. You can also run manually:
+
+```bash
+make format        # auto-format with SwiftFormat
+swiftlint lint     # static analysis with SwiftLint
+```
+
+See [Coding Guidelines — Code Style](CODING_GUIDELINES.md#code-style) for configuration details.
+
+### Tests
+
+- Add tests for any change that includes relevant logic.
+- Ensure existing tests keep passing.
+- Minimum line coverage: **80%** (enforced by `xcov` via Fastlane).
+- SwiftUI view files (`*Screen.swift`, `*Brick.swift`) are excluded from coverage — test logic in ViewModels and UseCases instead.
+
+See [Coding Guidelines — Testing](CODING_GUIDELINES.md#testing-guidelines) for tooling and patterns.
+
+### Local checks (required before opening a PR)
+
+```bash
+make format        # format code
+swiftlint lint     # check for lint errors
+make test          # run tests + coverage report
+```
+
+---
+
+## Pull Request checklist
+
+Your PR should:
+- [ ] Be small and focused (one concern per PR)
+- [ ] Include a clear description and reference to the related ticket/issue
+- [ ] Pass all CI checks (SwiftLint, SwiftFormat, tests, coverage)
+- [ ] Include screenshots or screen recordings for any UI change
+- [ ] Not introduce new public API without doc comments (`///`)
+
+---
+
+## Review process
+
+- Keep the PR up to date with `main` (rebase preferred over merge commits).
+- Reply to comments with context and apply incremental updates when needed.
+- PRs that fail CI will not be reviewed until green.
+
+---
+
+## Security
+
+This SDK handles PCI-sensitive payment data. Contributors must follow the security rules defined in [Coding Guidelines — Security](CODING_GUIDELINES.md#security-guidelines):
+
+- Never persist card data (PAN, CVV, expiry) to disk or logs.
+- Never hardcode credentials, tokens, or API keys in source code.
+- Never include sensitive data in screenshots or PR descriptions.
+
+If you discover a vulnerability, **do not open a public issue**. Report it privately following the process in [SECURITY.md](SECURITY.md).
+
+---
+
+## License
+
+By contributing, you agree that your contribution will be licensed under the [Apache License 2.0](LICENSE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,10 @@ Changes via PR are the best way to contribute. Before writing code, read the [Co
 
 | Command | Description |
 |---------|-------------|
-| `make setup` | Full initial setup — installs all tools, git hooks, and Fastlane |
+| `make setup` | Full initial setup — runs all steps below in sequence |
+| `make install-tools` | Installs SwiftLint and SwiftFormat via Homebrew |
+| `make setup-git-hooks` | Configures the git pre-commit hook for auto-formatting |
+| `make install-fastlane` | Installs Fastlane and its dependencies via Bundler |
 | `make format` | Auto-formats Swift code with SwiftFormat |
 | `make test` | Runs unit tests and generates coverage report via Fastlane |
 | `make clean` | Removes installed tools and generated test/coverage output |
@@ -97,7 +100,7 @@ Commits like `fix tests`, `now it works`, or `wip` will not be accepted. See [Co
 
 ## Example app
 
-The `Example/` directory contains an Xcode project that demonstrates the SDK integrations — CardForm (SwiftUI and UIKit), Device Session, 3DS, and Installments. It links to the local SDK via CocoaPods, so changes you make to the SDK are immediately reflected.
+The `Example/` directory contains an Xcode project that demonstrates the SDK integrations — CardForm (SwiftUI and UIKit), Device Session, 3DS, and Installments. It links to the local SDK via Swift Package Manager, so changes you make to the SDK are immediately reflected.
 
 ### Setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,13 +101,7 @@ The `Example/` directory contains an Xcode project that demonstrates the SDK int
 
 ### Setup
 
-```bash
-cd Example
-pod install
-open Example.xcworkspace
-```
-
-> Requires CocoaPods (`gem install cocoapods`). Use `Example.xcworkspace`, not `Example.xcodeproj`.
+Open `Example/Example.xcodeproj` directly in Xcode. The SDK is linked locally via Swift Package Manager — no extra steps required.
 
 ### When to use it
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,74 @@
+# Security Policy
+
+## Supported Versions
+
+We actively maintain and release security fixes for the following versions:
+
+| Version | Supported |
+|---------|-----------|
+| Latest stable | ✅ |
+| Previous minor | ✅ (critical fixes only) |
+| Older versions | ❌ |
+
+We strongly recommend always using the latest version of the SDK to receive security patches and PCI DSS compliance updates.
+
+---
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+To report a security issue, please use one of the following channels:
+
+- **GitHub Private Security Advisory:** [Report a vulnerability](../../security/advisories/new) *(preferred)*
+- **Email:** developers@mercadopago.com (Subject: `[SECURITY] sdk-ios - <description>`)
+
+### What to include
+
+- Clear description of the vulnerability
+- Steps to reproduce or a proof-of-concept (if safe to share)
+- Potential impact and affected versions
+- Suggested fix (optional)
+
+---
+
+## Response Timeline
+
+| Severity | Initial Response | Fix Target |
+|---|---|---|
+| Critical | 24 hours | 48–72 hours |
+| High | 48 hours | 1 week |
+| Medium | 1 week | 2–4 weeks |
+| Low | 2 weeks | Next release |
+
+---
+
+## Scope
+
+Covers all modules under the `MercadoPagoSDK` Swift package:
+- `CoreMethods`, `MPCore`, `MPComponents`, `MPFoundation`, `MercadoPagoCheckout`, `MPAnalytics`, `MPApplePay`, `MPExtended`
+
+Out of scope: third-party dependencies, backend API, Example app.
+
+---
+
+## Security Design
+
+Key properties (PCI DSS compliant):
+
+- **PCI data in memory only** — card fields use `@State` / in-memory bindings, never `@AppStorage`, `UserDefaults`, or any file write
+- **No plaintext card data on disk** — never written to `UserDefaults`, unencrypted `Keychain` entries, `NSFileManager`, or crash/analytics reporters
+- **Public key handling** — passed via `MercadoPagoSDK.Configuration`; never committed to source code or bundled in binary resources
+- **Tokenization** — card data tokenized server-side; never stored raw beyond the active checkout session
+- **Network security** — HTTPS/TLS enforced via App Transport Security (ATS); `NSAllowsArbitraryLoads` must remain `false`
+
+---
+
+## Integrator Responsibilities
+
+1. Keep the SDK up to date
+2. Never log PCI data (PAN, CVV, expiry) via `print`, `os_log`, or third-party crash/analytics SDKs
+3. Never store PCI data in `UserDefaults`, files, or unencrypted `Keychain` entries
+4. Scope ViewModels appropriately — avoid retaining payment state beyond the checkout flow
+5. Keep `NSAllowsArbitraryLoads = false` in your `Info.plist`
+6. Review Apple's [Secure Coding Guide](https://developer.apple.com/documentation/security) for additional hardening


### PR DESCRIPTION
## O que foi feito
- Adicionado `CONTRIBUTING.md` com setup via `make`, comandos disponíveis, convenções de branch/commit, app de exemplo e orientações de segurança
- Adicionado `CODING_GUIDELINES.md` com padrões de Swift, arquitetura de módulos, testes, Git e PR
- Adicionado `SECURITY.md` com política de versões suportadas, canal de reporte privado e design de segurança PCI DSS
- Adicionado `CODE_OF_CONDUCT.md` baseado no Contributor Covenant 2.1
- Adicionados issue templates (`bug_report.md` e `feature_request.md`) em `.github/ISSUE_TEMPLATE/`
- Corrigido PR template: checkboxes `[]` → `[ ]`, `develop` → `main`, adicionados checks de coverage e PCI

## Como testar
- [ ] Verificar que os issue templates aparecem ao abrir uma nova issue no GitHub
- [ ] Verificar que o PR template carrega automaticamente ao abrir um novo PR
- [ ] Revisar consistência entre os arquivos (links cruzados funcionando)

## Checklist
- [x] Arquivos revisados e consistentes entre si
- [x] Referências cruzadas entre arquivos funcionando (links relativos)
- [x] Nenhum dado sensível ou PCI nos arquivos