### PR TITLE
(Refactor): Map user_error_message to payment method not found error

### DIFF
--- a/Sources/MercadoPagoCheckout/Domain/CardAcceptanceError.swift
+++ b/Sources/MercadoPagoCheckout/Domain/CardAcceptanceError.swift
@@ -6,5 +6,5 @@
 package enum CardAcceptanceError: Error, Equatable {
     case paymentMethodNotAllowed(String)
     case paymentTypeNotAllowed(String)
-    case paymentMethodNotFound
+    case paymentMethodNotFound(String)
 }

--- a/Sources/MercadoPagoCheckout/Domain/CheckoutAPIErrorCode.swift
+++ b/Sources/MercadoPagoCheckout/Domain/CheckoutAPIErrorCode.swift
@@ -3,14 +3,26 @@
 //  MercadoPagoSDK
 //
 
-enum CheckoutAPIErrorCode {
-    enum Integration: String {
-        case identificationTypeUnavailable = "IDENTIFICATION_TYPE_UNAVAILABLE"
-        case unsupportedSite = "UNSUPPORTED_SITE"
-    }
+enum CheckoutAPIErrorCode: String {
+    case emptyPaymentMethods = "EMPTY_PAYMENT_METHODS"
+    case paymentMethodUnavailable = "PAYMENT_METHOD_UNAVAILABLE"
+    case installmentsUnavailable = "INSTALLMENTS_UNAVAILABLE"
+    case identificationTypeUnavailable = "IDENTIFICATION_TYPE_UNAVAILABLE"
+    case unsupportedSite = "UNSUPPORTED_SITE"
 
-    enum Acceptance: String {
-        case emptyPaymentMethods = "EMPTY_PAYMENT_METHODS"
-        case paymentMethodUnavailable = "PAYMENT_METHOD_UNAVAILABLE"
+    static let binValidation: Set<Self> = [
+        .emptyPaymentMethods,
+        .paymentMethodUnavailable,
+        .installmentsUnavailable,
+        .identificationTypeUnavailable
+    ]
+
+    static let integration: Set<Self> = [
+        .identificationTypeUnavailable,
+        .unsupportedSite
+    ]
+
+    static func isIntegrationError(_ errorCode: String) -> Bool {
+        CheckoutAPIErrorCode(rawValue: errorCode).map(CheckoutAPIErrorCode.integration.contains) == true
     }
 }

--- a/Sources/MercadoPagoCheckout/Domain/UseCases/FetchCardPaymentBrickCardUseCase.swift
+++ b/Sources/MercadoPagoCheckout/Domain/UseCases/FetchCardPaymentBrickCardUseCase.swift
@@ -26,7 +26,7 @@ struct FetchCardPaymentBrickCardUseCase {
                     serviceError: APIErrorResponse(
                         code: "",
                         message: "",
-                        errorCode: CheckoutAPIErrorCode.Acceptance.emptyPaymentMethods.rawValue
+                        errorCode: CheckoutAPIErrorCode.emptyPaymentMethods.rawValue
                     )
                 )
             }

--- a/Sources/MercadoPagoCheckout/Domain/UseCases/InitializeCardFormUseCase.swift
+++ b/Sources/MercadoPagoCheckout/Domain/UseCases/InitializeCardFormUseCase.swift
@@ -28,7 +28,7 @@ struct InitializeCardFormUseCase {
         } catch let error as APIClientError {
             if case let .apiError(response) = error,
                let errorCode = response.errorCode,
-               CheckoutAPIErrorCode.Integration(rawValue: errorCode) != nil {
+               CheckoutAPIErrorCode.isIntegrationError(errorCode) {
                 throw MercadoPagoCheckoutError(
                     code: .integrationError,
                     localizedDescription: response.message,

--- a/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
+++ b/Sources/MercadoPagoCheckout/Utils/Rules/CardFormRules.swift
@@ -111,8 +111,8 @@ package struct CardNumberRule: CardFormRuleType {
                 type: .invalid,
                 message: message
             )
-        case .paymentMethodNotFound:
-            return CardFormFieldError(type: .invalid, message: self.validation.errorInvalid)
+        case let .paymentMethodNotFound(message):
+            return CardFormFieldError(type: .invalid, message: message)
         }
     }
 

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -210,7 +210,9 @@ final class CardFormViewModel: ObservableObject {
         do {
             let data = try await withRetry(isRetryable: { error in
                 guard let checkoutError = error as? MercadoPagoCheckoutError else { return true }
-                guard checkoutError.serviceError?.errorCode.flatMap(CheckoutAPIErrorCode.Acceptance.init) == nil else { return false }
+                guard checkoutError.serviceError?.errorCode
+                    .flatMap(CheckoutAPIErrorCode.init)
+                    .map(CheckoutAPIErrorCode.binValidation.contains) != true else { return false }
                 return checkoutError.code == .networkConnectionFailed
                     || checkoutError.code == .networkTimeout
                     || checkoutError.code == .serviceError
@@ -222,13 +224,17 @@ final class CardFormViewModel: ObservableObject {
         } catch let error as MercadoPagoCheckoutError {
             guard !Task.isCancelled else { return }
             self.cardData = nil
-            switch error.serviceError?.errorCode.flatMap(CheckoutAPIErrorCode.Acceptance.init) {
-            case .emptyPaymentMethods:
-                self.cardAcceptanceError = .paymentMethodNotFound
-            case .paymentMethodUnavailable:
-                self.cardAcceptanceError = .paymentMethodNotAllowed(error.serviceError?.userErrorMessage ?? String())
-            case nil:
+            let message = error.serviceError?.userErrorMessage ?? String()
+            guard let code = error.serviceError?.errorCode.flatMap(CheckoutAPIErrorCode.init),
+                  CheckoutAPIErrorCode.binValidation.contains(code) else {
                 self.binNetworkError = error
+                return
+            }
+            switch code {
+            case .paymentMethodUnavailable:
+                self.cardAcceptanceError = .paymentMethodNotAllowed(message)
+            default:
+                self.cardAcceptanceError = .paymentMethodNotFound(message)
             }
         } catch {
             guard !Task.isCancelled else { return }

--- a/Tests/MercadoPagoCheckoutTests/UseCases/FetchCardPaymentBrickCardUseCaseTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/UseCases/FetchCardPaymentBrickCardUseCaseTests.swift
@@ -87,7 +87,7 @@ final class FetchCardPaymentBrickCardUseCaseTests: XCTestCase {
             XCTFail("Expected MercadoPagoCheckoutError to be thrown")
         } catch {
             XCTAssertEqual(error.code, .serviceError)
-            XCTAssertEqual(error.serviceError?.errorCode, CheckoutAPIErrorCode.Acceptance.emptyPaymentMethods.rawValue)
+            XCTAssertEqual(error.serviceError?.errorCode, CheckoutAPIErrorCode.emptyPaymentMethods.rawValue)
         }
     }
 

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
@@ -563,6 +563,77 @@ final class CardFormViewModelTests: XCTestCase {
         XCTAssertEqual(sut.viewModel.cvvTooltipText, "cvv_translations_tooltip")
     }
 
+    // MARK: - Acceptance errors (binValidation)
+
+    func test_onCardNumberChange_whenEmptyPaymentMethodsWithMessage_shouldSetPaymentMethodNotFound() async {
+        // Arrange
+        let sut = self.makeSUT()
+        await sut.repository.setResult(.failure(APIClientError.apiError(APIErrorResponse(
+            code: "400", message: "error",
+            errorCode: "EMPTY_PAYMENT_METHODS",
+            userErrorMessage: "Insira conforme está no cartão"
+        ))))
+
+        // Act
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$cardAcceptanceError)
+
+        // Assert
+        XCTAssertEqual(sut.viewModel.cardAcceptanceError, .paymentMethodNotFound("Insira conforme está no cartão"))
+    }
+
+    func test_onCardNumberChange_whenInstallmentsUnavailable_shouldSetPaymentMethodNotFound() async {
+        // Arrange
+        let sut = self.makeSUT()
+        await sut.repository.setResult(.failure(APIClientError.apiError(APIErrorResponse(
+            code: "400", message: "error",
+            errorCode: "INSTALLMENTS_UNAVAILABLE",
+            userErrorMessage: "Insira conforme está no cartão"
+        ))))
+
+        // Act
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$cardAcceptanceError)
+
+        // Assert
+        XCTAssertEqual(sut.viewModel.cardAcceptanceError, .paymentMethodNotFound("Insira conforme está no cartão"))
+    }
+
+    func test_onCardNumberChange_whenIdentificationTypeUnavailable_shouldSetPaymentMethodNotFound() async {
+        // Arrange
+        let sut = self.makeSUT()
+        await sut.repository.setResult(.failure(APIClientError.apiError(APIErrorResponse(
+            code: "400", message: "error",
+            errorCode: "IDENTIFICATION_TYPE_UNAVAILABLE",
+            userErrorMessage: "Insira conforme está no cartão"
+        ))))
+
+        // Act
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$cardAcceptanceError)
+
+        // Assert
+        XCTAssertEqual(sut.viewModel.cardAcceptanceError, .paymentMethodNotFound("Insira conforme está no cartão"))
+    }
+
+    func test_onCardNumberChange_whenUnsupportedSite_shouldSetBinNetworkError() async {
+        // Arrange — UNSUPPORTED_SITE is not in binValidation → falls to binNetworkError (snackbar)
+        let sut = self.makeSUT()
+        await sut.repository.setResult(.failure(APIClientError.apiError(APIErrorResponse(
+            code: "400", message: "error",
+            errorCode: "UNSUPPORTED_SITE",
+            userErrorMessage: "Your country is not supported"
+        ))))
+
+        // Act
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$binNetworkError)
+
+        // Assert
+        XCTAssertNil(sut.viewModel.cardAcceptanceError)
+        XCTAssertNotNil(sut.viewModel.binNetworkError)
+    }
+
     // MARK: - retryBinFetch
 
     func test_retryBinFetch_whenNoPreviousError_shouldNotShowSnackbar() {
@@ -597,7 +668,7 @@ final class CardFormViewModelTests: XCTestCase {
         await sut.repository.setResult(.failure(APIClientError.apiError(APIErrorResponse(code: "400", message: "error", errorCode: "EMPTY_PAYMENT_METHODS", userErrorMessage: nil))))
         sut.viewModel.onCardNumberChange("12345678")
         await self.waitForChange(sut.viewModel.$cardAcceptanceError)
-        XCTAssertEqual(sut.viewModel.cardAcceptanceError, .paymentMethodNotFound)
+        XCTAssertEqual(sut.viewModel.cardAcceptanceError, .paymentMethodNotFound(""))
 
         // Act — guard: binNetworkError is nil → does nothing
         sut.viewModel.retryBinFetch()


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
N/A

## Description
- `CardAcceptanceError.paymentMethodNotFound` now carries an associated `String` message (previously a no-arg case), allowing the BFF's `user_error_message` to surface directly in the card number field error
- `CheckoutAPIErrorCode` refactored from nested enums (`Integration`, `Acceptance`) to a flat enum with two static sets: `binValidation` (in-field errors) and `integration` (fatal errors), plus `isIntegrationError(_:)` helper
- `CardNumberRule`: `paymentMethodNotFound` case now displays the associated message instead of the static `errorInvalid` localization string
- `CardFormViewModel`: error handling refactored to use `binValidation` set — errors in the set show in-field (`cardAcceptanceError`), others fall through to snackbar (`binNetworkError`); `userErrorMessage` is propagated to `paymentMethodNotFound`
- `FetchCardPaymentBrickCardUseCase` and `InitializeCardFormUseCase` updated to use the new flat `CheckoutAPIErrorCode` API
- Added 4 new test cases in `CardFormViewModelTests` covering `EMPTY_PAYMENT_METHODS`, `INSTALLMENTS_UNAVAILABLE`, `IDENTIFICATION_TYPE_UNAVAILABLE`, and `UNSUPPORTED_SITE` error scenarios; updated 1 existing test to match new associated value

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [x] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.