### PR TITLE
[Feature]: Add MPBottomSheet component

### DIFF
--- a/Sources/MPComponents/BaseElements/BottomSheet/MPBottomSheet.swift
+++ b/Sources/MPComponents/BaseElements/BottomSheet/MPBottomSheet.swift
@@ -5,91 +5,79 @@
 
 import SwiftUI
 
-// MARK: - MPBottomSheet
+// MARK: - mpBottomSheet Modifier
 
-/// A bottom sheet component with two presentation modes.
+/// Turns any view into a tap target that presents a bottom sheet with a selectable list.
 ///
-/// **Options picker** — built-in trigger and list of selectable items:
 /// ```swift
-/// MPBottomSheet(
-///     title: "Documento do titular",
-///     options: viewModel.identificationTypes,
-///     selected: $viewModel.selectTypeDocument
-/// ) { documentLabel() }
+/// documentLabel()
+///     .mpBottomSheet(
+///         title: "Documento do titular",
+///         options: viewModel.identificationTypes,
+///         selected: $viewModel.selectTypeDocument
+///     )
 /// ```
-///
-/// **Custom content** — caller-provided trigger and sheet body:
-/// ```swift
-/// MPBottomSheet(title: "Filtros") {
-///     Image(systemName: "slider.horizontal.3")
-/// } content: {
-///     FilterView()
-/// }
-/// ```
-package struct MPBottomSheet: View {
-    private let title: String
-    private let height: CGFloat?
+private struct MPBottomSheetModifier<Option: MPBottomSheetListOption>: ViewModifier {
+    let title: String
+    let options: [Option]
+    @Binding var selected: Option?
     @State private var isPresented = false
 
-    private let makeTrigger: () -> AnyView
-    private let makeContent: (@escaping () -> Void) -> AnyView
+    func body(content: Content) -> some View {
+        content
+            .overlay(
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture { self.isPresented = true }
+            )
+            .bottomSheet(isPresented: self.$isPresented, title: self.title, height: self.sheetHeight) {
+                MPBottomSheetOptionsList(
+                    options: self.options,
+                    selected: self.$selected,
+                    onDismiss: {
+                        self.isPresented = false
+                    }
+                )
+            }
+    }
 
-    // MARK: - Init: options picker
+    private var sheetHeight: CGFloat {
+        let dragIndicator: CGFloat = 20
+        let header: CGFloat = 40
+        let itemHeight: CGFloat = 52
+        let bottomPadding: CGFloat = 60
+        let calculated = dragIndicator + header + CGFloat(self.options.count) * itemHeight + bottomPadding
+        return min(calculated, UIScreen.main.bounds.height * 0.6)
+    }
+}
 
-    package init<Option: MPBottomSheetListOption>(
+package extension View {
+    /// Presents a selectable bottom sheet when this view is tapped (internal state).
+    func mpBottomSheet<Option: MPBottomSheetListOption>(
         title: String,
         options: [Option],
-        selected: Binding<Option?>,
-        @ViewBuilder label: @escaping () -> some View
-    ) {
-        self.title = title
-        self.height = Self.optionsHeight(count: options.count)
-        self.makeTrigger = { AnyView(label()) }
-        self.makeContent = { dismiss in
-            AnyView(MPBottomSheetOptionsList(options: options, selected: selected, onDismiss: dismiss))
-        }
+        selected: Binding<Option?>
+    ) -> some View {
+        modifier(MPBottomSheetModifier(title: title, options: options, selected: selected))
     }
 
-    // MARK: - Init: custom content
-
-    package init(
+    /// Presents a selectable bottom sheet controlled by an external binding.
+    /// Apply this to the screen body and control presentation via `isPresented`.
+    func mpBottomSheet<Option: MPBottomSheetListOption>(
+        isPresented: Binding<Bool>,
         title: String,
-        height: CGFloat? = nil,
-        @ViewBuilder label: @escaping () -> some View,
-        @ViewBuilder content: @escaping () -> some View
-    ) {
-        self.title = title
-        self.height = height
-        self.makeTrigger = { AnyView(label()) }
-        self.makeContent = { _ in AnyView(content()) }
-    }
-
-    // MARK: - Body
-
-    package var body: some View {
-        Button { self.isPresented = true } label: {
-            self.makeTrigger()
+        options: [Option],
+        selected: Binding<Option?>
+    ) -> some View {
+        let calculated: CGFloat = 20 + 40 + CGFloat(options.count) * 52 + 60
+        let height = min(calculated, UIScreen.main.bounds.height * 0.6)
+        return bottomSheet(isPresented: isPresented, title: title, height: height) {
+            MPBottomSheetOptionsList(
+                options: options,
+                selected: selected,
+                onDismiss: { isPresented.wrappedValue = false }
+            )
         }
-        .buttonStyle(.plain)
-        .bottomSheet(isPresented: self.$isPresented, title: self.title, height: self.height) {
-            self.makeContent { self.isPresented = false }
-        }
-    }
-
-    // MARK: - Height
-
-    private enum Layout {
-        static let dragIndicator: CGFloat = 20
-        static let header: CGFloat = 40
-        static let itemHeight: CGFloat = 52
-        static let bottomPadding: CGFloat = 60
-        static let maxHeightRatio: CGFloat = 0.6
-    }
-
-    private static func optionsHeight(count: Int) -> CGFloat {
-        let calculated = Layout.dragIndicator + Layout.header + CGFloat(count) * Layout.itemHeight + Layout.bottomPadding
-        let maxHeight = UIScreen.main.bounds.height * Layout.maxHeightRatio
-        return min(calculated, maxHeight)
     }
 }
 

--- a/Sources/MPComponents/BaseElements/BottomSheet/MPBottomSheet.swift
+++ b/Sources/MPComponents/BaseElements/BottomSheet/MPBottomSheet.swift
@@ -1,0 +1,116 @@
+//
+//  MPBottomSheet.swift
+//  MPComponents
+//
+
+import SwiftUI
+
+// MARK: - MPBottomSheet
+
+/// A bottom sheet component with two presentation modes.
+///
+/// **Options picker** — built-in trigger and list of selectable items:
+/// ```swift
+/// MPBottomSheet(
+///     title: "Documento do titular",
+///     options: viewModel.identificationTypes,
+///     selected: $viewModel.selectTypeDocument
+/// ) { documentLabel() }
+/// ```
+///
+/// **Custom content** — caller-provided trigger and sheet body:
+/// ```swift
+/// MPBottomSheet(title: "Filtros") {
+///     Image(systemName: "slider.horizontal.3")
+/// } content: {
+///     FilterView()
+/// }
+/// ```
+package struct MPBottomSheet: View {
+    private let title: String
+    private let height: CGFloat?
+    @State private var isPresented = false
+
+    private let makeTrigger: () -> AnyView
+    private let makeContent: (@escaping () -> Void) -> AnyView
+
+    // MARK: - Init: options picker
+
+    package init<Option: MPBottomSheetListOption>(
+        title: String,
+        options: [Option],
+        selected: Binding<Option?>,
+        @ViewBuilder label: @escaping () -> some View
+    ) {
+        self.title = title
+        self.height = Self.optionsHeight(count: options.count)
+        self.makeTrigger = { AnyView(label()) }
+        self.makeContent = { dismiss in
+            AnyView(MPBottomSheetOptionsList(options: options, selected: selected, onDismiss: dismiss))
+        }
+    }
+
+    // MARK: - Init: custom content
+
+    package init(
+        title: String,
+        height: CGFloat? = nil,
+        @ViewBuilder label: @escaping () -> some View,
+        @ViewBuilder content: @escaping () -> some View
+    ) {
+        self.title = title
+        self.height = height
+        self.makeTrigger = { AnyView(label()) }
+        self.makeContent = { _ in AnyView(content()) }
+    }
+
+    // MARK: - Body
+
+    package var body: some View {
+        Button { self.isPresented = true } label: {
+            self.makeTrigger()
+        }
+        .buttonStyle(.plain)
+        .bottomSheet(isPresented: self.$isPresented, title: self.title, height: self.height) {
+            self.makeContent { self.isPresented = false }
+        }
+    }
+
+    // MARK: - Height
+
+    private enum Layout {
+        static let dragIndicator: CGFloat = 20
+        static let header: CGFloat = 40
+        static let itemHeight: CGFloat = 52
+        static let bottomPadding: CGFloat = 60
+        static let maxHeightRatio: CGFloat = 0.6
+    }
+
+    private static func optionsHeight(count: Int) -> CGFloat {
+        let calculated = Layout.dragIndicator + Layout.header + CGFloat(count) * Layout.itemHeight + Layout.bottomPadding
+        let maxHeight = UIScreen.main.bounds.height * Layout.maxHeightRatio
+        return min(calculated, maxHeight)
+    }
+}
+
+// MARK: - View Extension
+
+package extension View {
+    /// Presents an `MPBottomSheet` edge-to-edge via custom `UIPresentationController`.
+    /// Compatible with iOS 13+.
+    func bottomSheet(
+        isPresented: Binding<Bool>,
+        title: String,
+        height: CGFloat? = nil,
+        @ViewBuilder content: @escaping () -> some View
+    ) -> some View {
+        background(
+            MPBottomSheetPresenter(
+                isPresented: isPresented,
+                title: title,
+                height: height,
+                content: content
+            )
+        )
+    }
+}

--- a/Sources/MPComponents/BaseElements/BottomSheet/MPBottomSheetContent.swift
+++ b/Sources/MPComponents/BaseElements/BottomSheet/MPBottomSheetContent.swift
@@ -1,0 +1,51 @@
+//
+//  MPBottomSheetContent.swift
+//  MPComponents
+//
+
+import MPFoundation
+import SwiftUI
+
+/// Visual container: drag indicator + header + scrollable content.
+/// Used internally by `MPBottomSheetPresenter`.
+package struct MPBottomSheetContent<Content: View>: View {
+    let title: String
+    let onDismiss: () -> Void
+    @ViewBuilder let content: () -> Content
+
+    @Environment(\.checkoutTheme) private var theme: MPTheme
+
+    package var body: some View {
+        VStack(spacing: 0) {
+            self.dragIndicator
+            self.header
+            ScrollView { self.content() }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(self.theme.colors.background.primary.edgesIgnoringSafeArea(.all))
+    }
+
+    private var dragIndicator: some View {
+        RoundedRectangle(cornerRadius: self.theme.borderRadius.full)
+            .fill(self.theme.colors.interactive.iconIdle)
+            .frame(width: 32, height: 4)
+            .frame(height: 20)
+            .frame(maxWidth: .infinity)
+    }
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: 0) {
+            Text(self.title).textStyle(.headingMedium())
+            Spacer()
+            Button(action: self.onDismiss) {
+                Image(Logos.close, bundle: .bundleMP)
+                    .renderingMode(.template)
+                    .foregroundColor(self.theme.colors.icon.primary)
+                    .frame(width: 24, height: 24)
+            }
+        }
+        .padding(.horizontal, self.theme.spacings.micro)
+        .padding(.vertical, self.theme.spacings.xmicro)
+        .background(self.theme.colors.background.primary)
+    }
+}

--- a/Sources/MPComponents/BaseElements/BottomSheet/MPBottomSheetContent.swift
+++ b/Sources/MPComponents/BaseElements/BottomSheet/MPBottomSheetContent.swift
@@ -16,13 +16,14 @@ package struct MPBottomSheetContent<Content: View>: View {
     @Environment(\.checkoutTheme) private var theme: MPTheme
 
     package var body: some View {
-        VStack(spacing: 0) {
-            self.dragIndicator
-            self.header
-            ScrollView { self.content() }
+        ZStack(alignment: .top) {
+            self.theme.colors.background.primary.edgesIgnoringSafeArea(.all)
+            VStack(spacing: 0) {
+                self.dragIndicator
+                self.header
+                ScrollView { self.content() }
+            }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .background(self.theme.colors.background.primary.edgesIgnoringSafeArea(.all))
     }
 
     private var dragIndicator: some View {

--- a/Sources/MPComponents/BaseElements/BottomSheet/MPBottomSheetListOption.swift
+++ b/Sources/MPComponents/BaseElements/BottomSheet/MPBottomSheetListOption.swift
@@ -1,0 +1,11 @@
+//
+//  MPBottomSheetListOption.swift
+//  MPComponents
+//
+
+import Foundation
+
+/// Describes an item that can be displayed in an `MPBottomSheet` options list.
+package protocol MPBottomSheetListOption: Identifiable, Hashable {
+    var displayName: String { get }
+}

--- a/Sources/MPComponents/BaseElements/BottomSheet/MPBottomSheetOptionsList.swift
+++ b/Sources/MPComponents/BaseElements/BottomSheet/MPBottomSheetOptionsList.swift
@@ -21,7 +21,11 @@ struct MPBottomSheetOptionsList<Option: MPBottomSheetListOption>: View {
                         set: {
                             if $0 {
                                 self.selected = option
-                                self.onDismiss()
+
+                                Task {
+                                    try? await Task.sleep(nanoseconds: 20_000_000)
+                                    self.onDismiss()
+                                }
                             }
                         }
                     ),

--- a/Sources/MPComponents/BaseElements/BottomSheet/MPBottomSheetOptionsList.swift
+++ b/Sources/MPComponents/BaseElements/BottomSheet/MPBottomSheetOptionsList.swift
@@ -1,0 +1,36 @@
+//
+//  MPBottomSheetOptionsList.swift
+//  MPComponents
+//
+
+import MPFoundation
+import SwiftUI
+
+struct MPBottomSheetOptionsList<Option: MPBottomSheetListOption>: View {
+    let options: [Option]
+    @Binding var selected: Option?
+    let onDismiss: () -> Void
+    @Environment(\.checkoutTheme) private var theme: MPTheme
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(self.options) { option in
+                MPListItem(
+                    isSelected: Binding(
+                        get: { self.selected?.id == option.id },
+                        set: {
+                            if $0 {
+                                self.selected = option
+                                self.onDismiss()
+                            }
+                        }
+                    ),
+                    contentInfo: MPListItemContentInfo(title: option.displayName)
+                )
+            }
+        }
+        .listItemStyle(.pick)
+        .padding(.horizontal, self.theme.spacings.xnano)
+        .padding(.bottom, self.theme.spacings.micro)
+    }
+}

--- a/Sources/MPComponents/BaseElements/BottomSheet/UIKit/MPBottomSheetPresenter.swift
+++ b/Sources/MPComponents/BaseElements/BottomSheet/UIKit/MPBottomSheetPresenter.swift
@@ -1,0 +1,113 @@
+//
+//  MPBottomSheetPresenter.swift
+//  MPComponents
+//
+
+import SwiftUI
+import UIKit
+
+struct MPBottomSheetPresenter<Content: View>: UIViewControllerRepresentable {
+    // MARK: - Properties
+
+    let isPresented: Binding<Bool>
+    let title: String
+    let height: CGFloat?
+    let content: () -> Content
+
+    // MARK: - UIViewControllerRepresentable
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self.isPresented, height: self.height)
+    }
+
+    func makeUIViewController(context _: Context) -> UIViewController {
+        let vc = UIViewController()
+        vc.view.backgroundColor = .clear
+        return vc
+    }
+
+    func updateUIViewController(_ backgroundVC: UIViewController, context: Context) {
+        if self.isPresented.wrappedValue {
+            if let existing = context.coordinator.presentedController as? MPAutoUpdateHostingController<MPBottomSheetContent<Content>>,
+               backgroundVC.presentedViewController === existing {
+                existing.rootView = self.makeSheetContent()
+                return
+            }
+            guard backgroundVC.presentedViewController == nil else { return }
+            self.presentSheet(from: backgroundVC, context: context)
+        } else {
+            if let presented = backgroundVC.presentedViewController,
+               presented === context.coordinator.presentedController,
+               !presented.isBeingDismissed {
+                presented.dismiss(animated: true)
+            }
+            context.coordinator.presentedController = nil
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeSheetContent() -> MPBottomSheetContent<Content> {
+        MPBottomSheetContent(
+            title: self.title,
+            onDismiss: { self.isPresented.wrappedValue = false },
+            content: self.content
+        )
+    }
+
+    private func presentSheet(from backgroundVC: UIViewController, context: Context) {
+        let hostingVC = MPAutoUpdateHostingController(rootView: makeSheetContent())
+        hostingVC.modalPresentationStyle = .custom
+        hostingVC.transitioningDelegate = context.coordinator
+        context.coordinator.presentedController = hostingVC
+
+        DispatchQueue.main.async {
+            guard backgroundVC.view.window != nil,
+                  backgroundVC.presentedViewController == nil else { return }
+            backgroundVC.present(hostingVC, animated: true)
+        }
+    }
+
+    // MARK: - Coordinator
+
+    final class Coordinator: NSObject, UIViewControllerTransitioningDelegate, UIAdaptivePresentationControllerDelegate {
+        let isPresented: Binding<Bool>
+        let height: CGFloat?
+        weak var presentedController: UIViewController?
+
+        init(_ isPresented: Binding<Bool>, height: CGFloat?) {
+            self.isPresented = isPresented
+            self.height = height
+        }
+
+        func presentationController(
+            forPresented presented: UIViewController,
+            presenting: UIViewController?,
+            source _: UIViewController
+        ) -> UIPresentationController? {
+            let ctrl = MPSheetPresentationController(
+                presentedViewController: presented,
+                presenting: presenting,
+                height: height
+            )
+            ctrl.delegate = self
+            ctrl.onDidDismiss = { [weak self] in
+                self?.isPresented.wrappedValue = false
+                self?.presentedController = nil
+            }
+            return ctrl
+        }
+
+        func animationController(
+            forPresented _: UIViewController,
+            presenting _: UIViewController,
+            source _: UIViewController
+        ) -> UIViewControllerAnimatedTransitioning? {
+            MPSheetTransitionAnimator(isPresenting: true)
+        }
+
+        func animationController(forDismissed _: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+            MPSheetTransitionAnimator(isPresenting: false)
+        }
+    }
+}

--- a/Sources/MPComponents/BaseElements/BottomSheet/UIKit/MPBottomSheetPresenter.swift
+++ b/Sources/MPComponents/BaseElements/BottomSheet/UIKit/MPBottomSheetPresenter.swift
@@ -27,17 +27,17 @@ struct MPBottomSheetPresenter<Content: View>: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ backgroundVC: UIViewController, context: Context) {
+        context.coordinator.height = self.height
         if self.isPresented.wrappedValue {
             if let existing = context.coordinator.presentedController as? MPAutoUpdateHostingController<MPBottomSheetContent<Content>>,
-               backgroundVC.presentedViewController === existing {
+               !existing.isBeingDismissed {
                 existing.rootView = self.makeSheetContent()
                 return
             }
-            guard backgroundVC.presentedViewController == nil else { return }
+            guard context.coordinator.presentedController == nil else { return }
             self.presentSheet(from: backgroundVC, context: context)
         } else {
-            if let presented = backgroundVC.presentedViewController,
-               presented === context.coordinator.presentedController,
+            if let presented = context.coordinator.presentedController,
                !presented.isBeingDismissed {
                 presented.dismiss(animated: true)
             }
@@ -75,7 +75,7 @@ struct MPBottomSheetPresenter<Content: View>: UIViewControllerRepresentable {
 
     final class Coordinator: NSObject, UIViewControllerTransitioningDelegate, UIAdaptivePresentationControllerDelegate {
         let isPresented: Binding<Bool>
-        let height: CGFloat?
+        var height: CGFloat?
         weak var presentedController: UIViewController?
 
         init(_ isPresented: Binding<Bool>, height: CGFloat?) {
@@ -112,5 +112,17 @@ struct MPBottomSheetPresenter<Content: View>: UIViewControllerRepresentable {
         func animationController(forDismissed _: UIViewController) -> UIViewControllerAnimatedTransitioning? {
             MPSheetTransitionAnimator(isPresenting: false)
         }
+    }
+}
+
+// MARK: - UIWindow helper
+
+private extension UIWindow {
+    var topMostViewController: UIViewController? {
+        var current = rootViewController
+        while let presented = current?.presentedViewController {
+            current = presented
+        }
+        return current
     }
 }

--- a/Sources/MPComponents/BaseElements/BottomSheet/UIKit/MPBottomSheetPresenter.swift
+++ b/Sources/MPComponents/BaseElements/BottomSheet/UIKit/MPBottomSheetPresenter.swift
@@ -61,10 +61,13 @@ struct MPBottomSheetPresenter<Content: View>: UIViewControllerRepresentable {
         hostingVC.transitioningDelegate = context.coordinator
         context.coordinator.presentedController = hostingVC
 
-        DispatchQueue.main.async {
-            guard backgroundVC.view.window != nil,
-                  backgroundVC.presentedViewController == nil else { return }
-            backgroundVC.present(hostingVC, animated: true)
+        Task { @MainActor in
+            guard
+                let presenter = backgroundVC.view.window?.topMostViewController,
+                presenter.presentedViewController == nil else {
+                return
+            }
+            presenter.present(hostingVC, animated: true)
         }
     }
 

--- a/Sources/MPComponents/BaseElements/BottomSheet/UIKit/MPSheetPresentationController.swift
+++ b/Sources/MPComponents/BaseElements/BottomSheet/UIKit/MPSheetPresentationController.swift
@@ -1,0 +1,141 @@
+//
+//  MPSheetPresentationController.swift
+//  MPComponents
+//
+
+import UIKit
+
+final class MPSheetPresentationController: UIPresentationController {
+    // MARK: - Layout Constants
+
+    enum Layout {
+        static let cornerRadius: CGFloat = 20
+        static let dimmingAlpha: CGFloat = 0.4
+        static let dismissVelocityThreshold: CGFloat = 500
+        static let dismissDistanceRatio: CGFloat = 0.4
+    }
+
+    // MARK: - Properties
+
+    private let sheetHeight: CGFloat?
+    private let dimmingView = UIView()
+    var onDidDismiss: (() -> Void)?
+
+    /// Prevents `onDidDismiss` from firing more than once per dismissal cycle.
+    /// Set eagerly in user-initiated dismissals (pan, dimmer tap) so
+    /// `dismissalTransitionDidEnd` becomes a no-op if those paths already fired it.
+    private var dismissNotified = false
+    private var panStartY: CGFloat = 0
+
+    // MARK: - Init
+
+    init(presentedViewController: UIViewController, presenting: UIViewController?, height: CGFloat?) {
+        self.sheetHeight = height
+        super.init(presentedViewController: presentedViewController, presenting: presenting)
+    }
+
+    // MARK: - Frame
+
+    override var frameOfPresentedViewInContainerView: CGRect {
+        guard let containerView else { return .zero }
+        let height = self.sheetHeight ?? containerView.bounds.height * 0.5
+        return CGRect(
+            x: 0,
+            y: containerView.bounds.height - height,
+            width: containerView.bounds.width,
+            height: height
+        )
+    }
+
+    // MARK: - Transition Hooks
+
+    override func presentationTransitionWillBegin() {
+        guard let containerView else { return }
+        self.dimmingView.backgroundColor = UIColor.black.withAlphaComponent(Layout.dimmingAlpha)
+        self.dimmingView.alpha = 0
+        self.dimmingView.frame = containerView.bounds
+        containerView.insertSubview(self.dimmingView, at: 0)
+        self.dimmingView.addGestureRecognizer(
+            UITapGestureRecognizer(target: self, action: #selector(self.dimmingTapped))
+        )
+        presentedViewController.transitionCoordinator?.animate { _ in
+            self.dimmingView.alpha = Layout.dimmingAlpha
+        }
+    }
+
+    override func presentationTransitionDidEnd(_ completed: Bool) {
+        guard completed else { return }
+        presentedViewController.view.addGestureRecognizer(
+            UIPanGestureRecognizer(target: self, action: #selector(self.handlePan(_:)))
+        )
+    }
+
+    override func dismissalTransitionWillBegin() {
+        presentedViewController.transitionCoordinator?.animate(
+            alongsideTransition: { _ in self.dimmingView.alpha = 0 },
+            completion: { _ in self.dimmingView.removeFromSuperview() }
+        )
+    }
+
+    override func dismissalTransitionDidEnd(_ completed: Bool) {
+        guard completed, !self.dismissNotified else { return }
+        self.dismissNotified = true
+        self.onDidDismiss?()
+    }
+
+    override func containerViewWillLayoutSubviews() {
+        presentedViewController.view.frame = self.frameOfPresentedViewInContainerView
+        presentedViewController.view.layer.cornerRadius = Layout.cornerRadius
+        presentedViewController.view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        presentedViewController.view.layer.masksToBounds = true
+    }
+
+    // MARK: - Gesture Handlers
+
+    @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {
+        guard let view = gesture.view, let containerView else { return }
+        let translation = gesture.translation(in: containerView)
+        let velocity = gesture.velocity(in: containerView)
+        let origin = self.frameOfPresentedViewInContainerView.origin.y
+
+        switch gesture.state {
+        case .began:
+            self.panStartY = view.frame.origin.y
+
+        case .changed:
+            let newY = max(origin, panStartY + translation.y)
+            view.frame.origin.y = newY
+            self.dimmingView.alpha = Layout.dimmingAlpha * (1 - (newY - origin) / view.frame.height)
+
+        case .ended, .cancelled:
+            let distanceDragged = view.frame.origin.y - origin
+            let shouldDismiss = velocity.y > Layout.dismissVelocityThreshold
+                || distanceDragged > view.frame.height * Layout.dismissDistanceRatio
+
+            if shouldDismiss {
+                self.dismissNotified = true
+                self.onDidDismiss?()
+                presentingViewController.dismiss(animated: true)
+            } else {
+                UIView.animate(
+                    withDuration: 0.3,
+                    delay: 0,
+                    usingSpringWithDamping: 0.8,
+                    initialSpringVelocity: 0.5
+                ) {
+                    view.frame.origin.y = origin
+                    self.dimmingView.alpha = Layout.dimmingAlpha
+                }
+            }
+
+        default:
+            break
+        }
+    }
+
+    @objc private func dimmingTapped() {
+        self.dismissNotified = true
+        self.onDidDismiss?()
+        presentingViewController.dismiss(animated: true)
+    }
+}

--- a/Sources/MPComponents/BaseElements/BottomSheet/UIKit/MPSheetTransitionAnimator.swift
+++ b/Sources/MPComponents/BaseElements/BottomSheet/UIKit/MPSheetTransitionAnimator.swift
@@ -1,0 +1,53 @@
+//
+//  MPSheetTransitionAnimator.swift
+//  MPComponents
+//
+
+import UIKit
+
+final class MPSheetTransitionAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+    let isPresenting: Bool
+
+    init(isPresenting: Bool) { self.isPresenting = isPresenting }
+
+    func transitionDuration(using _: UIViewControllerContextTransitioning?) -> TimeInterval { 0.35 }
+
+    func animateTransition(using ctx: UIViewControllerContextTransitioning) {
+        if self.isPresenting {
+            self.animatePresentation(ctx)
+        } else {
+            self.animateDismissal(ctx)
+        }
+    }
+
+    private func animatePresentation(_ ctx: UIViewControllerContextTransitioning) {
+        guard let toVC = ctx.viewController(forKey: .to), let toView = ctx.view(forKey: .to) else { return }
+        let finalFrame = ctx.finalFrame(for: toVC)
+        ctx.containerView.addSubview(toView)
+        toView.frame = finalFrame.offsetBy(dx: 0, dy: finalFrame.height)
+        UIView.animate(
+            withDuration: self.transitionDuration(using: ctx),
+            delay: 0,
+            usingSpringWithDamping: 0.85,
+            initialSpringVelocity: 0.3,
+            options: .curveEaseOut
+        ) {
+            toView.frame = finalFrame
+        } completion: { _ in
+            ctx.completeTransition(!ctx.transitionWasCancelled)
+        }
+    }
+
+    private func animateDismissal(_ ctx: UIViewControllerContextTransitioning) {
+        guard let fromView = ctx.view(forKey: .from) else { return }
+        UIView.animate(
+            withDuration: self.transitionDuration(using: ctx),
+            delay: 0.15,
+            options: .curveEaseIn
+        ) {
+            fromView.frame = fromView.frame.offsetBy(dx: 0, dy: fromView.frame.height)
+        } completion: { _ in
+            ctx.completeTransition(!ctx.transitionWasCancelled)
+        }
+    }
+}

--- a/Sources/MercadoPagoCheckout/Utils/Extensions/IdentificationType+Checkout.swift
+++ b/Sources/MercadoPagoCheckout/Utils/Extensions/IdentificationType+Checkout.swift
@@ -6,7 +6,12 @@
 //
 
 import CoreMethods
+import MPComponents
 import SwiftUI
+
+extension IdentificationType: MPBottomSheetListOption {
+    package var displayName: String { name }
+}
 
 extension IdentificationType {
     func getPlaceholder() -> String? {

--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -24,6 +24,7 @@ struct CardFormScreen: View {
     @State private var isSnackbarPresented = false
     @State private var footerHeight: CGFloat = 0
     @State private var isCardNumberFocused = false
+    @State private var isDocumentSheetPresented = false
     @State private var didTapBack = false
     @State private var didComplete = false
     @State private var editedFields: Set<CardFormField> = []
@@ -238,6 +239,12 @@ struct CardFormScreen: View {
                 self.onDismiss(self.cardForm.cancelledFormContext)
             }
         }
+        .mpBottomSheet(
+            isPresented: self.$isDocumentSheetPresented,
+            title: MPStrings.CardForm.Document.label,
+            options: self.viewModel.identificationTypes,
+            selected: self.$viewModel.selectTypeDocument
+        )
     }
 
     private func documentLabel() -> some View {
@@ -258,14 +265,9 @@ struct CardFormScreen: View {
 
     private func dropdownDocument() -> some View {
         HStack(spacing: 0) {
-            MPBottomSheet(
-                title: MPStrings.CardForm.Document.label,
-                options: self.viewModel.identificationTypes,
-                selected: self.$viewModel.selectTypeDocument
-            ) {
-                self.documentLabel()
-            }
-            .accessibility(label: Text(verbatim: self.viewModel.selectTypeDocument?.name ?? String()))
+            self.documentLabel()
+                .onTapGesture { self.isDocumentSheetPresented = true }
+                .accessibility(label: Text(verbatim: self.viewModel.selectTypeDocument?.name ?? String()))
 
             Rectangle()
                 .fill(self.theme.textFields.standard.idle.borderColor)

--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -240,53 +240,8 @@ struct CardFormScreen: View {
         }
     }
 
-    private func dropdownDocument() -> some View {
-        HStack(spacing: 0) {
-            if #available(iOS 14.0, *) {
-                self.documentPickerMenu()
-            } else {
-                self.documentPickerFallback()
-            }
-
-            Rectangle()
-                .fill(self.theme.textFields.standard.idle.borderColor)
-                .frame(width: self.theme.borderWidth.small)
-        }
-    }
-
-    @available(iOS 14.0, *)
-    private func documentPickerMenu() -> some View {
-        Menu {
-            Picker(
-                selection: self.$viewModel.selectTypeDocument,
-                label: EmptyView()
-            ) {
-                ForEach(self.viewModel.identificationTypes, id: \.id) { type in
-                    Text(type.name).tag(Optional(type))
-                }
-            }
-        } label: {
-            self.documentLabel()
-        }
-        .accessibility(label: Text(verbatim: self.viewModel.selectTypeDocument?.name ?? String()))
-    }
-
-    private func documentPickerFallback() -> some View {
-        Picker(
-            selection: self.$viewModel.selectTypeDocument,
-            label: self.documentLabel()
-        ) {
-            ForEach(self.viewModel.identificationTypes, id: \.id) { type in
-                Text(type.name).tag(Optional(type))
-            }
-        }
-        .fixedSize(horizontal: true, vertical: false)
-        .accentColor(self.theme.textFields.standard.idle.textColor)
-        .accessibility(label: Text(verbatim: self.viewModel.selectTypeDocument?.name ?? String()))
-    }
-
     private func documentLabel() -> some View {
-        HStack {
+        HStack(spacing: 0) {
             Text(self.viewModel.selectTypeDocument?.name ?? String())
                 .textStyle(.bodyMedium(colorType: .secondary))
                 .lineLimit(1)
@@ -299,6 +254,23 @@ struct CardFormScreen: View {
         }
         .padding(.leading, self.theme.spacings.micro)
         .animation(nil)
+    }
+
+    private func dropdownDocument() -> some View {
+        HStack(spacing: 0) {
+            MPBottomSheet(
+                title: MPStrings.CardForm.Document.label,
+                options: self.viewModel.identificationTypes,
+                selected: self.$viewModel.selectTypeDocument
+            ) {
+                self.documentLabel()
+            }
+            .accessibility(label: Text(verbatim: self.viewModel.selectTypeDocument?.name ?? String()))
+
+            Rectangle()
+                .fill(self.theme.textFields.standard.idle.borderColor)
+                .frame(width: self.theme.borderWidth.small)
+        }
     }
 
     private func updateCardNumberLength(cardData: CardPaymentBrickCardData?) {


### PR DESCRIPTION
## O que foi feito

- Criado `MPBottomSheet` — bottom sheet customizado com `UIPresentationController` (iOS 13+, edge-to-edge)
- Dois inits: options picker (lista com `MPListItem` pick style) e custom content (trigger + conteúdo livre)
- Drag-to-dismiss com rubber band, threshold de velocidade e distância
- Animação de entrada com spring, saída com delay de 0.15s para feedback de seleção visível
- `MPBottomSheetListOption` protocol para itens da lista (substitui `MPOptionPicker` e fallback do picker)
- Código UIKit separado em pasta própria (`UIKit/`)
- Substituído o `Menu/Picker` de tipo de documento no `CardFormScreen` por `MPBottomSheet`

## Como testar

- [ ] Abrir o `CardFormScreen` e tocar no campo de tipo de documento
- [ ] Verificar que o bottom sheet abre edge-to-edge com animação spring
- [ ] Selecionar uma opção — highlight visível antes do sheet fechar
- [ ] Fechar via botão X, tap no dimmer e drag para baixo
- [ ] Verificar que após fechar é possível reabrir normalmente

## Checklist

- [x] I have tested my changes creating a local version
- [x] New and existing unit tests pass locally
- [x] I have run swiftlint and fixed any possible issues

🇨🇴
<img width="340" alt="columbia" src="https://github.com/user-attachments/assets/99fa3d48-0826-4a41-a0c4-4d3c869910c4" />
🇨🇱
<img width="340" alt="chile" src="https://github.com/user-attachments/assets/8b333ba7-ee44-41b2-8f77-bd516e023c77" />
🇵🇪
<img width="340" alt="peru" src="https://github.com/user-attachments/assets/12ab5383-4d5b-4e1f-a87f-aec3a158c032" />
🇺🇾
<img width="340" alt="uruguai" src="https://github.com/user-attachments/assets/ccbf2996-1e41-426e-bb74-2c5abcbc16cb" />
🇧🇷
<img width="340" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-05 at 15 31 35" src="https://github.com/user-attachments/assets/5cb7a03b-72a8-4d21-8114-afd05c0299a4" />

