### PR TITLE
[CHOBK-3918] (Feature): Installments data mapping from BFF

### DIFF
--- a/Sources/MPComponents/BaseElements/ListItem/MPListItem.swift
+++ b/Sources/MPComponents/BaseElements/ListItem/MPListItem.swift
@@ -9,6 +9,7 @@ import MPFoundation
 import SwiftUI
 
 package struct MPListItem: View {
+    @Environment(\.checkoutTheme) private var theme: MPTheme
     @Environment(\.listItemStyle) private var style
     @Environment(\.listItemTrailingStyle) private var trailingStyle
     @State private var isPressed = false
@@ -68,7 +69,16 @@ package struct MPListItem: View {
     @ViewBuilder
     private var titleView: some View {
         if let title = contentInfo.title {
-            Text(title)
+            if let suffix = contentInfo.titleDecimalSuffix {
+                HStack(alignment: .top, spacing: self.theme.spacings.xnano) {
+                    Text(title)
+                    Text(suffix)
+                        .font(self.theme.typography.body.small.emphasis.toFont())
+                        .offset(y: 0)
+                }
+            } else {
+                Text(title)
+            }
         }
     }
 
@@ -80,7 +90,6 @@ package struct MPListItem: View {
         }
     }
 
-    @ViewBuilder
     private var leftImageView: some View {
         self.leftImage
     }
@@ -102,14 +111,14 @@ package struct MPListItem: View {
     struct MPListItemView: View {
         @State private var selectedIndex: Int? = 0
 
-        public init() {}
+        init() {}
 
-        public var body: some View {
+        var body: some View {
             VStack(spacing: 16) {
                 VStack(spacing: 8) {
                     MPListItem(
                         isSelected: self.bindingForIndex(0),
-                        contentInfo: .init(title: "Title")
+                        contentInfo: .init(title: "1x R$10", titleDecimalSuffix: "00")
                     )
 
                     MPListItem(

--- a/Sources/MPComponents/BaseElements/ListItem/MPListItemContentInfo.swift
+++ b/Sources/MPComponents/BaseElements/ListItem/MPListItemContentInfo.swift
@@ -13,13 +13,16 @@ import SwiftUI
 package struct MPListItemContentInfo {
     /// Primary label of the list item.
     package let title: String?
+    /// Suffix rendered in a smaller font after `title` (e.g. decimal part of a price).
+    package let titleDecimalSuffix: String?
     /// Secondary label displayed above the title.
     package let header: String?
     /// Supporting text displayed below the title .
     package let description: String?
-    
-    package init(title: String? = nil, header: String? = nil, description: String? = nil) {
+
+    package init(title: String? = nil, titleDecimalSuffix: String? = nil, header: String? = nil, description: String? = nil) {
         self.title = title
+        self.titleDecimalSuffix = titleDecimalSuffix
         self.header = header
         self.description = description
     }

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -43,7 +43,7 @@ struct CardFormBrick: View {
             installment: .init(
                 selectionType: String(),
                 quotas: [],
-                translations: .init(headerTitle: String(), interestFreeLabel: String(), totalLabel: String())
+                translations: .init(headerTitle: String(), totalLabel: String(), payButtonLabel: String())
             ),
             cardDisplayInfo: .init(issuerName: String(), paymentTypeId: String(), lastFourDigits: String())
         ))

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -39,14 +39,7 @@ struct CardFormBrick: View {
         self.transactionAmount = configuration.type.configuration.amount
         self.configuration = configuration
         self._paymentData = State(initialValue: MPPaymentData(transactionAmount: self.transactionAmount))
-        self._installmentsData = State(initialValue: .init(
-            installment: .init(
-                selectionType: String(),
-                quotas: [],
-                translations: .init(headerTitle: String(), totalLabel: String(), payButtonLabel: String())
-            ),
-            cardDisplayInfo: .init(issuerName: String(), paymentTypeId: String(), lastFourDigits: String())
-        ))
+        self._installmentsData = State(initialValue: .empty)
         self.brickViewModel = CardFormBrickViewModel(configuration: configuration, appearance: appearance)
     }
 

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -15,6 +15,7 @@ struct CardFormBrick: View {
 
     @State private var route: Route?
     @State private var paymentData: MPPaymentData
+    @State private var installmentsData: MPInstallmentsData
     @ObservedObject private var brickViewModel: CardFormBrickViewModel
 
     private var configuration: MercadoPagoCheckout.CheckoutConfiguration
@@ -38,6 +39,14 @@ struct CardFormBrick: View {
         self.transactionAmount = configuration.type.configuration.amount
         self.configuration = configuration
         self._paymentData = State(initialValue: MPPaymentData(transactionAmount: self.transactionAmount))
+        self._installmentsData = State(initialValue: .init(
+            installment: .init(
+                selectionType: String(),
+                quotas: [],
+                translations: .init(headerTitle: String(), interestFreeLabel: String(), totalLabel: String())
+            ),
+            cardDisplayInfo: .init(issuerName: String(), paymentTypeId: String(), lastFourDigits: String())
+        ))
         self.brickViewModel = CardFormBrickViewModel(configuration: configuration, appearance: appearance)
     }
 
@@ -94,9 +103,14 @@ struct CardFormBrick: View {
                 self.route = nil
                 self.onResult(.userCancelled(.cardForm(context)))
             },
-            onSuccess: { paymentData in
+            onSuccess: { paymentData, installmentsData in
                 self.paymentData = paymentData
-                self.completeCheckout()
+                if let installmentsData {
+                    self.installmentsData = installmentsData
+                    self.route = .installments
+                } else {
+                    self.completeCheckout()
+                }
             },
             onFailure: { error in
                 self.fail(error)
@@ -107,7 +121,7 @@ struct CardFormBrick: View {
     private func installmentScreen() -> some View {
         InstallmentScreen(
             paymentData: self.$paymentData,
-            installments: InstallmentMock.visa,
+            installmentsData: self.$installmentsData,
             onBack: {
                 self.presentationMode.wrappedValue.dismiss()
             },

--- a/Sources/MercadoPagoCheckout/Data/Model/CardFormInitializationResponse.swift
+++ b/Sources/MercadoPagoCheckout/Data/Model/CardFormInitializationResponse.swift
@@ -127,18 +127,14 @@ struct CardFormInitializationResponse: Codable {
 
     struct InstallmentsTranslation: Codable {
         let header: HeaderTranslation
-        let interestFreeLabel: String
         let totalLabel: String
 
         enum CodingKeys: String, CodingKey {
             case header
-            case interestFreeLabel = "interest_free_label"
             case totalLabel = "total_label"
         }
 
         struct HeaderTranslation: Codable {
-            let chevron: String
-            let radio: String
             let title: String
         }
     }

--- a/Sources/MercadoPagoCheckout/Data/Model/CardFormTranslationsResponse.swift
+++ b/Sources/MercadoPagoCheckout/Data/Model/CardFormTranslationsResponse.swift
@@ -72,8 +72,6 @@ struct CardFormTranslationsResponse: Codable {
         }
 
         struct HeaderData: Codable {
-            let chevron: String
-            let radio: String
             let title: String
         }
     }

--- a/Sources/MercadoPagoCheckout/Data/Model/CardFormTranslationsResponse.swift
+++ b/Sources/MercadoPagoCheckout/Data/Model/CardFormTranslationsResponse.swift
@@ -62,13 +62,13 @@ struct CardFormTranslationsResponse: Codable {
 
     struct InstallmentsTranslationsData: Codable {
         let header: HeaderData
-        let interestFreeLabel: String
         let totalLabel: String
+        let payButtonLabel: String
 
         enum CodingKeys: String, CodingKey {
             case header
-            case interestFreeLabel = "interest_free_label"
             case totalLabel = "total_label"
+            case payButtonLabel = "pay_button_label"
         }
 
         struct HeaderData: Codable {

--- a/Sources/MercadoPagoCheckout/Data/Model/CardPaymentBrickCardResponse.swift
+++ b/Sources/MercadoPagoCheckout/Data/Model/CardPaymentBrickCardResponse.swift
@@ -37,10 +37,20 @@ struct CardPaymentBrickCardResponse: Codable {
         struct QuotaData: Codable {
             let installments: Int
             let installmentAmount: Double
+            let totalAmount: Double
+            let primaryLabel: String
+            let secondaryLabel: String
+            let state: String
+            let tertiaryLabel: String?
 
             enum CodingKeys: String, CodingKey {
                 case installments
                 case installmentAmount = "installment_amount"
+                case totalAmount = "total_amount"
+                case primaryLabel = "primary_label"
+                case secondaryLabel = "secondary_label"
+                case state
+                case tertiaryLabel = "tertiary_label"
             }
         }
     }

--- a/Sources/MercadoPagoCheckout/Data/Repositories/RemoteCardPaymentBrickCardRepository.swift
+++ b/Sources/MercadoPagoCheckout/Data/Repositories/RemoteCardPaymentBrickCardRepository.swift
@@ -84,8 +84,8 @@ struct RemoteCardPaymentBrickCardRepository: CardPaymentBrickCardRepository {
             },
             translations: CardPaymentBrickCardData.Installment.InstallmentTranslations(
                 headerTitle: translations.header.title,
-                interestFreeLabel: translations.interestFreeLabel,
-                totalLabel: translations.totalLabel
+                totalLabel: translations.totalLabel,
+                payButtonLabel: translations.payButtonLabel
             )
         )
     }

--- a/Sources/MercadoPagoCheckout/Data/Repositories/RemoteCardPaymentBrickCardRepository.swift
+++ b/Sources/MercadoPagoCheckout/Data/Repositories/RemoteCardPaymentBrickCardRepository.swift
@@ -21,17 +21,22 @@ struct RemoteCardPaymentBrickCardRepository: CardPaymentBrickCardRepository {
         let response: CardPaymentBrickCardResponse = try await dependencies.networkService.request(
             CardPaymentBrickEndpoint.getCard(params: params)
         )
-        return self.map(response: response)
+        return self.map(response: response, params: params)
     }
 
     // MARK: - Mapping
 
-    private func map(response: CardPaymentBrickCardResponse) -> CardPaymentBrickCardData {
+    private func map(response: CardPaymentBrickCardResponse, params _: CardPaymentBrickCardParams) -> CardPaymentBrickCardData {
         CardPaymentBrickCardData(
             securityCodeTranslations: response.translations.securityCode.map {
                 self.mapSecurityCodeTranslations($0, response)
             },
-            installment: response.installment.map { self.mapInstallment($0) },
+            installment: response.installment.map {
+                self.mapInstallment(
+                    $0,
+                    translations: response.translations.installments
+                )
+            },
             paymentMethods: response.paymentMethods.map { self.mapPaymentMethod($0) }
         )
     }
@@ -61,16 +66,27 @@ struct RemoteCardPaymentBrickCardRepository: CardPaymentBrickCardRepository {
     }
 
     private func mapInstallment(
-        _ data: CardPaymentBrickCardResponse.InstallmentData
+        _ data: CardPaymentBrickCardResponse.InstallmentData,
+        translations: CardFormTranslationsResponse.InstallmentsTranslationsData
     ) -> CardPaymentBrickCardData.Installment {
-        CardPaymentBrickCardData.Installment(
+        return CardPaymentBrickCardData.Installment(
             selectionType: data.selectionType,
             quotas: data.quotas.map {
                 CardPaymentBrickCardData.Installment.Quota(
                     installments: $0.installments,
-                    installmentAmount: $0.installmentAmount
+                    installmentAmount: $0.installmentAmount,
+                    totalAmount: $0.totalAmount,
+                    primaryLabel: $0.primaryLabel,
+                    secondaryLabel: $0.secondaryLabel,
+                    state: .init($0.state),
+                    tertiaryLabel: $0.tertiaryLabel
                 )
-            }
+            },
+            translations: CardPaymentBrickCardData.Installment.InstallmentTranslations(
+                headerTitle: translations.header.title,
+                interestFreeLabel: translations.interestFreeLabel,
+                totalLabel: translations.totalLabel
+            )
         )
     }
 

--- a/Sources/MercadoPagoCheckout/Domain/Model/CardDisplayInfo.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Model/CardDisplayInfo.swift
@@ -1,0 +1,10 @@
+//
+//  CardDisplayInfo.swift
+//  MercadoPagoSDK
+//
+
+struct CardDisplayInfo: Equatable {
+    let issuerName: String
+    let paymentTypeId: String
+    let lastFourDigits: String
+}

--- a/Sources/MercadoPagoCheckout/Domain/Model/MPInstallmentsData.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Model/MPInstallmentsData.swift
@@ -1,0 +1,9 @@
+//
+//  MPInstallmentsData.swift
+//  MercadoPagoSDK
+//
+
+struct MPInstallmentsData: Equatable {
+    let installment: CardPaymentBrickCardData.Installment
+    let cardDisplayInfo: CardDisplayInfo
+}

--- a/Sources/MercadoPagoCheckout/Domain/Model/MPInstallmentsData.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Model/MPInstallmentsData.swift
@@ -10,8 +10,14 @@ struct MPInstallmentsData: Equatable {
 
 extension MPInstallmentsData {
     static var empty: MPInstallmentsData {
-        MPInstallmentsData(
-            installment: .init(selectionType: String(), quotas: [], translations: .init(headerTitle: String(), totalLabel: String(), payButtonLabel: String())),
+        let translations = CardPaymentBrickCardData.Installment.InstallmentTranslations(
+            headerTitle: String(), totalLabel: String(), payButtonLabel: String()
+        )
+        let installment = CardPaymentBrickCardData.Installment(
+            selectionType: String(), quotas: [], translations: translations
+        )
+        return MPInstallmentsData(
+            installment: installment,
             cardDisplayInfo: .init(issuerName: String(), paymentTypeId: String(), lastFourDigits: String())
         )
     }

--- a/Sources/MercadoPagoCheckout/Domain/Model/MPInstallmentsData.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Model/MPInstallmentsData.swift
@@ -7,3 +7,12 @@ struct MPInstallmentsData: Equatable {
     let installment: CardPaymentBrickCardData.Installment
     let cardDisplayInfo: CardDisplayInfo
 }
+
+extension MPInstallmentsData {
+    static var empty: MPInstallmentsData {
+        MPInstallmentsData(
+            installment: .init(selectionType: String(), quotas: [], translations: .init(headerTitle: String(), totalLabel: String(), payButtonLabel: String())),
+            cardDisplayInfo: .init(issuerName: String(), paymentTypeId: String(), lastFourDigits: String())
+        )
+    }
+}

--- a/Sources/MercadoPagoCheckout/Model/Internal/CardPaymentBrickCardData.swift
+++ b/Sources/MercadoPagoCheckout/Model/Internal/CardPaymentBrickCardData.swift
@@ -45,8 +45,8 @@ struct CardPaymentBrickCardData: Equatable {
 
         struct InstallmentTranslations: Equatable {
             let headerTitle: String
-            let interestFreeLabel: String
             let totalLabel: String
+            let payButtonLabel: String
         }
     }
 

--- a/Sources/MercadoPagoCheckout/Model/Internal/CardPaymentBrickCardData.swift
+++ b/Sources/MercadoPagoCheckout/Model/Internal/CardPaymentBrickCardData.swift
@@ -15,10 +15,38 @@ struct CardPaymentBrickCardData: Equatable {
     struct Installment: Equatable {
         let selectionType: String
         let quotas: [Quota]
+        let translations: InstallmentTranslations
 
-        struct Quota: Equatable {
+        struct Quota: Equatable, Identifiable {
+            var id: Int {
+                self.installments
+            }
+
             let installments: Int
             let installmentAmount: Double
+            let totalAmount: Double
+            let primaryLabel: String
+            let secondaryLabel: String
+            let state: QuotaState
+            let tertiaryLabel: String?
+        }
+
+        enum QuotaState: Equatable {
+            case success
+            case none
+
+            init(_ rawValue: String) {
+                switch rawValue {
+                case "success": self = .success
+                default: self = .none
+                }
+            }
+        }
+
+        struct InstallmentTranslations: Equatable {
+            let headerTitle: String
+            let interestFreeLabel: String
+            let totalLabel: String
         }
     }
 

--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct CardFormScreen: View {
     private let onBack: (CardFormUserCancelledContext) -> Void
     private let onDismiss: (CardFormUserCancelledContext) -> Void
-    private let onSuccess: (MPPaymentData) -> Void
+    private let onSuccess: (MPPaymentData, MPInstallmentsData?) -> Void
     private let onFailure: (MercadoPagoCheckoutError) -> Void
     private let transactionAmount: Double?
 
@@ -38,7 +38,7 @@ struct CardFormScreen: View {
         viewModel: CardFormViewModel,
         onBack: @escaping (CardFormUserCancelledContext) -> Void = { _ in },
         onDismiss: @escaping (CardFormUserCancelledContext) -> Void = { _ in },
-        onSuccess: @escaping (MPPaymentData) -> Void = { _ in },
+        onSuccess: @escaping (MPPaymentData, MPInstallmentsData?) -> Void = { _, _ in },
         onFailure: @escaping (MercadoPagoCheckoutError) -> Void = { _ in }
     ) {
         self.onBack = onBack
@@ -77,7 +77,7 @@ struct CardFormScreen: View {
                                 transactionAmount: self.transactionAmount,
                                 onSuccess: {
                                     self.didComplete = true
-                                    self.onSuccess($0)
+                                    self.onSuccess($0, self.makeInstallmentsData())
                                 },
                                 onFailure: {
                                     self.didComplete = true
@@ -315,5 +315,20 @@ struct CardFormScreen: View {
         guard let identificationType else { return }
         self.cardForm.setDocumentLength(identificationType.minLenght, identificationType.maxLenght)
         self.cardForm.setDocumentType(isNumeric: identificationType.type != "string")
+    }
+
+    private func makeInstallmentsData() -> MPInstallmentsData? {
+        guard
+            let installment = self.viewModel.cardData?.installment,
+            let method = self.viewModel.cardData?.paymentMethods.first
+        else { return nil }
+
+        let lastFourDigits = String(self.cardForm.cardNumber.filter(\.isNumber).suffix(4))
+        let cardDisplayInfo = CardDisplayInfo(
+            issuerName: method.issuers.first?.name ?? String(),
+            paymentTypeId: method.paymentTypeId,
+            lastFourDigits: lastFourDigits
+        )
+        return MPInstallmentsData(installment: installment, cardDisplayInfo: cardDisplayInfo)
     }
 }

--- a/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
@@ -5,7 +5,6 @@
 //  Created by Guilherme Prata Costa on 14/11/25.
 //
 
-import CoreMethods
 import MPComponents
 import MPFoundation
 import SwiftUI
@@ -19,8 +18,8 @@ protocol InstallmentInteractionStyle {
     func footerButtonData(onContinue: @escaping () -> Void) -> MPFixedFooterButtonData?
 
     func selectionBinding(
-        for payerCost: Installment.PayerCost,
-        selected: Binding<Installment.PayerCost?>,
+        for quota: CardPaymentBrickCardData.Installment.Quota,
+        selected: Binding<CardPaymentBrickCardData.Installment.Quota?>,
         onContinue: @escaping () -> Void
     ) -> Binding<Bool>
 }
@@ -41,13 +40,13 @@ struct RadioButtonInstallmentStyle: InstallmentInteractionStyle {
     }
 
     func selectionBinding(
-        for payerCost: Installment.PayerCost,
-        selected: Binding<Installment.PayerCost?>,
+        for quota: CardPaymentBrickCardData.Installment.Quota,
+        selected: Binding<CardPaymentBrickCardData.Installment.Quota?>,
         onContinue _: @escaping () -> Void
     ) -> Binding<Bool> {
         Binding(
-            get: { selected.wrappedValue == payerCost },
-            set: { if $0 { selected.wrappedValue = payerCost } }
+            get: { selected.wrappedValue == quota },
+            set: { if $0 { selected.wrappedValue = quota } }
         )
     }
 }
@@ -66,8 +65,8 @@ struct ChevronInstallmentStyle: InstallmentInteractionStyle {
     }
 
     func selectionBinding(
-        for _: Installment.PayerCost,
-        selected _: Binding<Installment.PayerCost?>,
+        for _: CardPaymentBrickCardData.Installment.Quota,
+        selected _: Binding<CardPaymentBrickCardData.Installment.Quota?>,
         onContinue: @escaping () -> Void
     ) -> Binding<Bool> {
         Binding(
@@ -93,23 +92,11 @@ extension InstallmentInteractionStyle where Self == ChevronInstallmentStyle {
 
 // MARK: - Installment Extension for Style Resolution
 
-extension Installment {
-    /// Resolves the interaction style based on the `interactionMode` returned by the backend.
-    ///
-    /// This computed property reads the `interactionMode` value and returns the appropriate style.
-    /// If `interactionMode` is `nil` or unknown, returns the default style (RadioButton).
-    ///
-    /// Example usage:
-    /// ```swift
-    /// let installment = Installment(..., interactionMode: "chevron")
-    /// let style = installment.resolvedInteractionStyle // ChevronInstallmentStyle
-    /// ```
+extension CardPaymentBrickCardData.Installment {
     var resolvedInteractionStyle: any InstallmentInteractionStyle {
-        switch self.interactionMode?.lowercased() {
+        switch self.selectionType.lowercased() {
         case "chevron":
             return ChevronInstallmentStyle()
-        case "radio_button", nil:
-            return RadioButtonInstallmentStyle()
         default:
             return RadioButtonInstallmentStyle()
         }
@@ -134,7 +121,7 @@ struct InstallmentScreen: View {
     @Environment(\.presentationMode) var presentationMode
 
     @ObservedObject private var viewModel: InstallmentsScreenViewModel
-    @State var selectedPayerCost: Installment.PayerCost?
+    @State var selectedQuota: CardPaymentBrickCardData.Installment.Quota?
 
     private let style: any InstallmentInteractionStyle
     private let onBack: () -> Void
@@ -143,27 +130,27 @@ struct InstallmentScreen: View {
 
     init(
         paymentData: Binding<MPPaymentData>,
-        installments: Installment,
+        installmentsData: Binding<MPInstallmentsData>,
         style: (any InstallmentInteractionStyle)? = nil,
         onBack: @escaping () -> Void,
         onContinue: @escaping () -> Void = {}
     ) {
         self._paymentData = paymentData
-        self.viewModel = InstallmentsScreenViewModel(installments: installments)
-        self.style = style ?? installments.resolvedInteractionStyle
+        self.viewModel = InstallmentsScreenViewModel(installmentsData: installmentsData)
+        self.style = style ?? installmentsData.wrappedValue.installment.resolvedInteractionStyle
         self.onBack = onBack
         self.onContinue = onContinue
     }
 
     var body: some View {
         MPHeader(
-            title: MPStrings.Installments.title,
+            title: self.viewModel.headerTitle,
             onBack: {
                 self.presentationMode.wrappedValue.dismiss()
             },
             content: {
-                ForEach(self.viewModel.payerCosts) { payerCost in
-                    self.listItem(for: payerCost)
+                ForEach(self.viewModel.quotas) { quota in
+                    self.listItem(for: quota)
                 }
             },
             footer: {
@@ -174,16 +161,16 @@ struct InstallmentScreen: View {
 
     // MARK: - Computed Properties
 
-    private func listItem(for payerCost: Installment.PayerCost) -> AnyView {
+    private func listItem(for quota: CardPaymentBrickCardData.Installment.Quota) -> AnyView {
         MPListItem(
-            isSelected: self.bindingForPayerCost(payerCost),
+            isSelected: self.bindingForQuota(quota),
             contentInfo: .init(
-                title: self.viewModel.formatInstallmentLabel(for: payerCost),
-                description: nil
+                title: quota.primaryLabel,
+                description: quota.tertiaryLabel
             ),
             trailing: MPListItemTrailing(
-                text: self.viewModel.formatInterestLabel(for: payerCost),
-                color: self.viewModel.findInterestLabelColor(for: payerCost)
+                text: quota.secondaryLabel,
+                color: self.viewModel.color(for: quota)
             )
         )
         .listItemStyle(self.style.listItemStyle)
@@ -192,19 +179,19 @@ struct InstallmentScreen: View {
 
     private var footer: some View {
         MPFooter(
-            title: MPStrings.Common.total,
-            amount: self.viewModel.selectedTotalAmount(self.selectedPayerCost),
-            subtitle: self.viewModel.formatFooterDescription(),
+            title: self.viewModel.totalLabel,
+            amount: self.viewModel.selectedTotalAmount(self.selectedQuota),
+            subtitle: self.viewModel.footerDescription(),
             buttonData: self.style.footerButtonData(onContinue: self.onContinue)
         )
     }
 
     // MARK: - Helper Methods
 
-    private func bindingForPayerCost(_ payerCost: Installment.PayerCost) -> Binding<Bool> {
+    private func bindingForQuota(_ quota: CardPaymentBrickCardData.Installment.Quota) -> Binding<Bool> {
         self.style.selectionBinding(
-            for: payerCost,
-            selected: self.$selectedPayerCost,
+            for: quota,
+            selected: self.$selectedQuota,
             onContinue: self.onContinue
         )
     }
@@ -217,7 +204,7 @@ struct InstallmentScreen: View {
         paymentData: .constant(
             MPPaymentData(transactionAmount: 100)
         ),
-        installments: InstallmentMock.visa,
+        installmentsData: .constant(InstallmentMock.visa),
         style: .radioButton,
         onBack: {}
     )
@@ -228,7 +215,7 @@ struct InstallmentScreen: View {
         paymentData: .constant(
             MPPaymentData(transactionAmount: 100)
         ),
-        installments: InstallmentMock.visa,
+        installmentsData: .constant(InstallmentMock.visa),
         style: .chevron,
         onBack: {}
     )
@@ -236,55 +223,49 @@ struct InstallmentScreen: View {
 
 #if DEBUG
     enum InstallmentMock {
-        static let visa = Installment(
-            paymentMethodId: "visa",
-            paymentTypeId: "credit_card",
-            thumbnail: "https://http2.mlstatic.com/storage/mobile-on-demand-resources/image/cho_off-visa_mdpi",
-            issuer: Installment.Issuer(
-                id: "25",
-                thumbnail: "https://http2.mlstatic.com/storage/mobile-on-demand-resources/image/cho_off-visa_mdpi",
-                name: "Tarjeta de crédito Mercado Pago"
-            ),
-            processingMode: "aggregator",
-            merchantAccountId: "",
-            payerCosts: [
-                Installment.PayerCost(
-                    id: 1, installments: 1, installmentAmount: 1000.0, installmentRate: 0.0,
-                    installmentRateCollector: ["MERCADOPAGO"], totalAmount: 1000.0,
-                    minAllowedAmount: 0.5, maxAllowedAmount: 60000.0,
-                    discountRate: 0.0, reimbursementRate: 0.0, labels: [],
-                    paymentMethodOptionId: ""
-                ),
-                Installment.PayerCost(
-                    id: 2, installments: 2, installmentAmount: 500, installmentRate: 0,
-                    installmentRateCollector: ["MERCADOPAGO"], totalAmount: 1096.4,
-                    minAllowedAmount: 10.0, maxAllowedAmount: 60000.0,
-                    discountRate: 0.0, reimbursementRate: 0.0, labels: [],
-                    paymentMethodOptionId: ""
-                ),
-                Installment.PayerCost(
-                    id: 3, installments: 3, installmentAmount: 370.77, installmentRate: 11.23,
-                    installmentRateCollector: ["MERCADOPAGO"], totalAmount: 1112.3,
-                    minAllowedAmount: 15.0, maxAllowedAmount: 60000.0,
-                    discountRate: 0.0, reimbursementRate: 0.0, labels: [],
-                    paymentMethodOptionId: ""
-                ),
-                Installment.PayerCost(
-                    id: 4, installments: 4, installmentAmount: 278.4, installmentRate: 11.36,
-                    installmentRateCollector: ["MERCADOPAGO"], totalAmount: 1113.6,
-                    minAllowedAmount: 20.0, maxAllowedAmount: 60000.0,
-                    discountRate: 0.0, reimbursementRate: 0.0, labels: [],
-                    paymentMethodOptionId: ""
-                ),
-                Installment.PayerCost(
-                    id: 5, installments: 5, installmentAmount: 228.62, installmentRate: 14.31,
-                    installmentRateCollector: ["MERCADOPAGO"], totalAmount: 1143.1,
-                    minAllowedAmount: 25.0, maxAllowedAmount: 60000.0,
-                    discountRate: 0.0, reimbursementRate: 0.0, labels: [],
-                    paymentMethodOptionId: ""
+        static let visa = MPInstallmentsData(
+            installment: .init(
+                selectionType: "radio_button",
+                quotas: [
+                    .init(
+                        installments: 1,
+                        installmentAmount: 1000.0,
+                        totalAmount: 1000.0,
+                        primaryLabel: "1x R$ 1.000,00",
+                        secondaryLabel: "À vista",
+                        state: .none,
+                        tertiaryLabel: nil
+                    ),
+                    .init(
+                        installments: 3,
+                        installmentAmount: 333.34,
+                        totalAmount: 1000.0,
+                        primaryLabel: "3x R$ 333,34",
+                        secondaryLabel: "Sem juros",
+                        state: .success,
+                        tertiaryLabel: nil
+                    ),
+                    .init(
+                        installments: 6,
+                        installmentAmount: 175.0,
+                        totalAmount: 1050.0,
+                        primaryLabel: "6x R$ 175,00",
+                        secondaryLabel: "R$ 1.050,00",
+                        state: .none,
+                        tertiaryLabel: "CFT: 12,5%  TEA: 18,5%"
+                    )
+                ],
+                translations: .init(
+                    headerTitle: "Escolha o parcelamento",
+                    interestFreeLabel: "Sem acréscimo",
+                    totalLabel: "Total"
                 )
-            ],
-            agreements: []
+            ),
+            cardDisplayInfo: .init(
+                issuerName: "Santander",
+                paymentTypeId: "credit_card",
+                lastFourDigits: "1234"
+            )
         )
     }
 #endif

--- a/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
@@ -15,7 +15,7 @@ protocol InstallmentInteractionStyle {
     var listItemStyle: MPListItemStyle { get }
     var listItemTrailingStyle: MPListItemTrailingStyle? { get }
 
-    func footerButtonData(onContinue: @escaping () -> Void) -> MPFixedFooterButtonData?
+    func footerButtonData(_ label: String, onContinue: @escaping () -> Void) -> MPFixedFooterButtonData?
 
     func selectionBinding(
         for quota: CardPaymentBrickCardData.Installment.Quota,
@@ -35,8 +35,8 @@ struct RadioButtonInstallmentStyle: InstallmentInteractionStyle {
         nil
     }
 
-    func footerButtonData(onContinue: @escaping () -> Void) -> MPFixedFooterButtonData? {
-        .init(text: "text", icon: .padlockClose, onClick: onContinue)
+    func footerButtonData(_ label: String, onContinue: @escaping () -> Void) -> MPFixedFooterButtonData? {
+        .init(text: label, icon: .padlockClose, onClick: onContinue)
     }
 
     func selectionBinding(
@@ -60,7 +60,7 @@ struct ChevronInstallmentStyle: InstallmentInteractionStyle {
         .textIcon(Image(systemName: "chevron.right"))
     }
 
-    func footerButtonData(onContinue _: @escaping () -> Void) -> MPFixedFooterButtonData? {
+    func footerButtonData(_: String, onContinue _: @escaping () -> Void) -> MPFixedFooterButtonData? {
         nil
     }
 
@@ -182,7 +182,7 @@ struct InstallmentScreen: View {
             title: self.viewModel.totalLabel,
             amount: self.viewModel.selectedTotalAmount(self.selectedQuota),
             subtitle: self.viewModel.footerDescription(),
-            buttonData: self.style.footerButtonData(onContinue: self.onContinue)
+            buttonData: self.style.footerButtonData(self.viewModel.payButtonLabel, onContinue: self.onContinue)
         )
     }
 
@@ -257,8 +257,9 @@ struct InstallmentScreen: View {
                 ],
                 translations: .init(
                     headerTitle: "Escolha o parcelamento",
-                    interestFreeLabel: "Sem acréscimo",
-                    totalLabel: "Total"
+
+                    totalLabel: "Total",
+                    payButtonLabel: "Pagar!"
                 )
             ),
             cardDisplayInfo: .init(

--- a/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
@@ -164,10 +164,7 @@ struct InstallmentScreen: View {
     private func listItem(for quota: CardPaymentBrickCardData.Installment.Quota) -> AnyView {
         MPListItem(
             isSelected: self.bindingForQuota(quota),
-            contentInfo: .init(
-                title: quota.primaryLabel,
-                description: quota.tertiaryLabel
-            ),
+            contentInfo: self.viewModel.contentInfo(for: quota),
             trailing: MPListItemTrailing(
                 text: quota.secondaryLabel,
                 color: self.viewModel.color(for: quota)

--- a/Sources/MercadoPagoCheckout/Views/InstallmentScreenViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/InstallmentScreenViewModel.swift
@@ -45,12 +45,30 @@ final class InstallmentsScreenViewModel: ObservableObject {
         quota.state == .success ? .feedbackPositive : nil
     }
 
+    func primaryLabelComponents(_ label: String) -> (title: String, decimalSuffix: String?) {
+        guard
+            let commaIndex = label.lastIndex(of: ","),
+            label.distance(from: commaIndex, to: label.endIndex) == 3
+        else { return (label, nil) }
+
+        let decimalPart = label[label.index(after: commaIndex)...]
+        return (String(label[..<commaIndex]), String(decimalPart))
+    }
+
+    func contentInfo(for quota: CardPaymentBrickCardData.Installment.Quota) -> MPListItemContentInfo {
+        let components = self.primaryLabelComponents(quota.primaryLabel)
+        return .init(
+            title: components.title,
+            titleDecimalSuffix: components.decimalSuffix,
+            description: quota.tertiaryLabel
+        )
+    }
+
     func footerDescription() -> String {
         let info = self.installmentsData.cardDisplayInfo
         let issuerName = MPFormatIssuerName.applyCapitalizationRules(
             MPFormatIssuerName.cleanIssuerName(info.issuerName ?? String())
         )
-//        let paymentTypeLabel = MPFormatIssuerName.formattedPaymentType(info.paymentTypeId ?? String())
         return "\(issuerName) **** \(info.lastFourDigits)"
     }
 }

--- a/Sources/MercadoPagoCheckout/Views/InstallmentScreenViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/InstallmentScreenViewModel.swift
@@ -5,76 +5,48 @@
 //  Created by Danielle Nozaki Ogawa on 28/01/26.
 //
 
-import CoreMethods
 import MPComponents
 import MPFoundation
 import SwiftUI
 
 final class InstallmentsScreenViewModel: ObservableObject {
-    private(set) var payerCosts: [Installment.PayerCost] = []
-    private let installment: Installment?
+    @Binding var installmentsData: MPInstallmentsData
 
-    init(installments: Installment) {
-        self.installment = installments
-        self.payerCosts = self.installment?.payerCosts ?? []
+    init(installmentsData: Binding<MPInstallmentsData>) {
+        self._installmentsData = installmentsData
     }
 
-    // MARK: - Formatted strings
+    // MARK: - Computed Properties
 
-    func formatInstallmentLabel(for payerCost: Installment.PayerCost) -> String {
-        "\(payerCost.installments)x \(MPStrings.formatPrice(payerCost.installmentAmount))"
+    var headerTitle: String {
+        self.installmentsData.installment.translations.headerTitle
     }
 
-    func formatInterestLabel(for payerCost: Installment.PayerCost) -> String {
-        if payerCost.installments == 1 {
-            return String()
-        } else {
-            return payerCost.installmentRate == 0 ?
-                MPStrings.Installments.interestFree :
-                MPStrings.formatPrice(payerCost.totalAmount)
-        }
+    var totalLabel: String {
+        self.installmentsData.installment.translations.totalLabel
     }
 
-    func findInterestLabelColor(for payerCost: Installment.PayerCost) -> TextStyleColorType? {
-        return payerCost.installmentRate == 0 ? .feedbackPositive : nil
+    var quotas: [CardPaymentBrickCardData.Installment.Quota] {
+        self.installmentsData.installment.quotas
     }
 
     // MARK: - Footer
 
-    func selectedTotalAmount(_ selected: Installment.PayerCost?) -> MPAmountData {
-        let value = selected?.totalAmount ?? self.payerCosts.first?.installmentAmount ?? 0
+    func selectedTotalAmount(_ selected: CardPaymentBrickCardData.Installment.Quota?) -> MPAmountData {
+        let value = selected?.totalAmount ?? self.quotas.first?.totalAmount ?? 0
         return MPAmountData(from: value)
     }
 
-    func formatFooterDescription() -> String {
-        guard
-            let issuerName = installment?.issuer.name,
-            let type = installment?.paymentTypeId
-        else {
-            return String()
-        }
-
-        return self.getSavedCardName(
-            issuerName: issuerName,
-            paymentTypeLabel: MPFormatIssuerName.formattedPaymentType(type),
-            lastDigits: "1234"
-        )
+    func color(for quota: CardPaymentBrickCardData.Installment.Quota) -> TextStyleColorType? {
+        quota.state == .success ? .feedbackPositive : nil
     }
 
-    func getSavedCardName(
-        issuerName: String,
-        paymentTypeLabel: String,
-        lastDigits: String,
-        isMercadoPagoCard: Bool = false
-    ) -> String {
-        let normalizedIssuerName = MPFormatIssuerName.applyCapitalizationRules(
-            MPFormatIssuerName.cleanIssuerName(issuerName)
+    func footerDescription() -> String {
+        let info = self.installmentsData.cardDisplayInfo
+        let issuerName = MPFormatIssuerName.applyCapitalizationRules(
+            MPFormatIssuerName.cleanIssuerName(info.issuerName ?? String())
         )
-
-        if isMercadoPagoCard {
-            return "\(normalizedIssuerName) \(paymentTypeLabel)"
-        }
-
-        return "\(normalizedIssuerName) \(paymentTypeLabel) **** \(lastDigits)"
+//        let paymentTypeLabel = MPFormatIssuerName.formattedPaymentType(info.paymentTypeId ?? String())
+        return "\(issuerName) **** \(info.lastFourDigits)"
     }
 }

--- a/Sources/MercadoPagoCheckout/Views/InstallmentScreenViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/InstallmentScreenViewModel.swift
@@ -26,6 +26,10 @@ final class InstallmentsScreenViewModel: ObservableObject {
         self.installmentsData.installment.translations.totalLabel
     }
 
+    var payButtonLabel: String {
+        self.installmentsData.installment.translations.payButtonLabel
+    }
+
     var quotas: [CardPaymentBrickCardData.Installment.Quota] {
         self.installmentsData.installment.quotas
     }

--- a/Tests/MercadoPagoCheckoutTests/Data/RemoteCardPaymentBrickCardRepositoryTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Data/RemoteCardPaymentBrickCardRepositoryTests.swift
@@ -39,8 +39,26 @@ final class RemoteCardPaymentBrickCardRepositoryTests: XCTestCase {
     private func makeValidResponseData(includeInstallment: Bool = true, includeSecurityCode: Bool = true) -> Data {
         let installmentJSON = includeInstallment ? """
         "installment": {
-            "selection_type": "radio",
-            "quotas": [{ "installments": 3, "installment_amount": 100.0 }]
+            "selection_type": "radio_button",
+            "quotas": [
+                {
+                    "installments": 3,
+                    "installment_amount": 33.34,
+                    "total_amount": 100.00,
+                    "primary_label": "3x R$ 33,34",
+                    "secondary_label": "Sem juros",
+                    "state": "success",
+                    "tertiary_label": "CFT: 12,5%  TEA: 18,5%"
+                },
+                {
+                    "installments": 1,
+                    "installment_amount": 100.00,
+                    "total_amount": 100.00,
+                    "primary_label": "1x R$ 100,00",
+                    "secondary_label": "A vista",
+                    "state": "none"
+                }
+            ]
         },
         """ : ""
 
@@ -107,8 +125,6 @@ final class RemoteCardPaymentBrickCardRepositoryTests: XCTestCase {
                 },
                 "installments": {
                     "header": {
-                        "chevron": "Escolha o parcelamento",
-                        "radio": "Escolha o parcelamento",
                         "title": "Escolha o parcelamento"
                     },
                     "interest_free_label": "Sem acréscimo",
@@ -196,7 +212,7 @@ final class RemoteCardPaymentBrickCardRepositoryTests: XCTestCase {
         let result = try await sut.repository.fetchCard(params: self.makeParams())
 
         // Assert
-        XCTAssertEqual(result.installment?.selectionType, "radio")
+        XCTAssertEqual(result.installment?.selectionType, "radio_button")
     }
 
     func testFetchCard_whenSuccess_mapsInstallmentQuotas() async throws {
@@ -209,9 +225,68 @@ final class RemoteCardPaymentBrickCardRepositoryTests: XCTestCase {
         let result = try await sut.repository.fetchCard(params: self.makeParams())
 
         // Assert
-        XCTAssertEqual(result.installment?.quotas.count, 1)
+        XCTAssertEqual(result.installment?.quotas.count, 2)
         XCTAssertEqual(result.installment?.quotas.first?.installments, 3)
-        XCTAssertEqual(result.installment?.quotas.first?.installmentAmount, 100.0)
+        XCTAssertEqual(result.installment?.quotas.first?.installmentAmount, 33.34)
+    }
+
+    func testFetchCard_whenSuccess_mapsQuotaNewFields() async throws {
+        // Arrange
+        let sut = self.makeSUT()
+        await sut.session.mock.setData(self.makeValidResponseData())
+        await sut.session.mock.setResponse(self.makeHTTPResponse())
+
+        // Act
+        let result = try await sut.repository.fetchCard(params: self.makeParams())
+
+        // Assert
+        let firstQuota = result.installment?.quotas.first
+        XCTAssertEqual(firstQuota?.totalAmount, 100.00)
+        XCTAssertEqual(firstQuota?.primaryLabel, "3x R$ 33,34")
+        XCTAssertEqual(firstQuota?.secondaryLabel, "Sem juros")
+        XCTAssertEqual(firstQuota?.state, .success)
+        XCTAssertEqual(firstQuota?.tertiaryLabel, "CFT: 12,5%  TEA: 18,5%")
+    }
+
+    func testFetchCard_whenSuccess_mapsQuotaStateNone() async throws {
+        // Arrange
+        let sut = self.makeSUT()
+        await sut.session.mock.setData(self.makeValidResponseData())
+        await sut.session.mock.setResponse(self.makeHTTPResponse())
+
+        // Act
+        let result = try await sut.repository.fetchCard(params: self.makeParams())
+
+        // Assert — second quota has state "none"
+        XCTAssertEqual(result.installment?.quotas.last?.state, .none)
+    }
+
+    func testFetchCard_whenSuccess_mapsQuotaTertiaryLabelAbsent() async throws {
+        // Arrange
+        let sut = self.makeSUT()
+        await sut.session.mock.setData(self.makeValidResponseData())
+        await sut.session.mock.setResponse(self.makeHTTPResponse())
+
+        // Act
+        let result = try await sut.repository.fetchCard(params: self.makeParams())
+
+        // Assert — second quota has no tertiary_label
+        XCTAssertNil(result.installment?.quotas.last?.tertiaryLabel)
+    }
+
+    func testFetchCard_whenSuccess_mapsInstallmentTranslations() async throws {
+        // Arrange
+        let sut = self.makeSUT()
+        await sut.session.mock.setData(self.makeValidResponseData())
+        await sut.session.mock.setResponse(self.makeHTTPResponse())
+
+        // Act
+        let result = try await sut.repository.fetchCard(params: self.makeParams())
+
+        // Assert
+        XCTAssertEqual(result.installment?.translations.headerTitle, "Escolha o parcelamento")
+        XCTAssertEqual(result.installment?.translations.interestFreeLabel, "Sem acréscimo")
+        XCTAssertEqual(result.installment?.translations.totalLabel, "Total")
     }
 
     func testFetchCard_whenInstallmentAbsent_returnsNilInstallment() async throws {

--- a/Tests/MercadoPagoCheckoutTests/Data/RemoteCardPaymentBrickCardRepositoryTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Data/RemoteCardPaymentBrickCardRepositoryTests.swift
@@ -127,7 +127,7 @@ final class RemoteCardPaymentBrickCardRepositoryTests: XCTestCase {
                     "header": {
                         "title": "Escolha o parcelamento"
                     },
-                    "interest_free_label": "Sem acréscimo",
+
                     "total_label": "Total"
                 }
             },
@@ -285,7 +285,6 @@ final class RemoteCardPaymentBrickCardRepositoryTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(result.installment?.translations.headerTitle, "Escolha o parcelamento")
-        XCTAssertEqual(result.installment?.translations.interestFreeLabel, "Sem acréscimo")
         XCTAssertEqual(result.installment?.translations.totalLabel, "Total")
     }
 

--- a/Tests/MercadoPagoCheckoutTests/Data/RemoteCardPaymentBrickCardRepositoryTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Data/RemoteCardPaymentBrickCardRepositoryTests.swift
@@ -128,7 +128,8 @@ final class RemoteCardPaymentBrickCardRepositoryTests: XCTestCase {
                         "title": "Escolha o parcelamento"
                     },
 
-                    "total_label": "Total"
+                    "total_label": "Total",
+                    "pay_button_label": "Pagar"
                 }
             },
             \(installmentJSON)
@@ -258,7 +259,7 @@ final class RemoteCardPaymentBrickCardRepositoryTests: XCTestCase {
         let result = try await sut.repository.fetchCard(params: self.makeParams())
 
         // Assert — second quota has state "none"
-        XCTAssertEqual(result.installment?.quotas.last?.state, .none)
+        XCTAssertEqual(result.installment?.quotas.last?.state, CardPaymentBrickCardData.Installment.QuotaState.none)
     }
 
     func testFetchCard_whenSuccess_mapsQuotaTertiaryLabelAbsent() async throws {

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/InstallmentsScreenViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/InstallmentsScreenViewModelTests.swift
@@ -8,6 +8,7 @@
 @testable import MercadoPagoCheckout
 @testable import MPComponents
 @testable import MPFoundation
+import SwiftUI
 import XCTest
 
 final class InstallmentsScreenViewModelTests: XCTestCase {
@@ -92,7 +93,7 @@ final class InstallmentsScreenViewModelTests: XCTestCase {
     // MARK: - Helpers
 
     private func makeSUT(
-        installmentsData: InstallmentsData = .validInstallmentsData
+        installmentsData: MPInstallmentsData = .validMPInstallmentsData
     ) -> InstallmentsScreenViewModel {
         var data = installmentsData
         return InstallmentsScreenViewModel(installmentsData: Binding(get: { data }, set: { data = $0 }))
@@ -101,8 +102,8 @@ final class InstallmentsScreenViewModelTests: XCTestCase {
 
 // MARK: - Test Fixtures
 
-extension InstallmentsData {
-    static let validInstallmentsData = InstallmentsData(
+extension MPInstallmentsData {
+    static let validMPInstallmentsData = MPInstallmentsData(
         installment: .validInstallments,
         cardDisplayInfo: .make()
     )
@@ -118,8 +119,8 @@ extension CardPaymentBrickCardData.Installment {
         ],
         translations: .init(
             headerTitle: "Escolha o parcelamento",
-
-            totalLabel: "Total"
+            totalLabel: "Total",
+            payButtonLabel: "Pagar"
         )
     )
 }

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/InstallmentsScreenViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/InstallmentsScreenViewModelTests.swift
@@ -5,79 +5,15 @@
 //  Created by Danielle Nozaki Ogawa on 28/01/26.
 //
 
-@testable import CoreMethods
 @testable import MercadoPagoCheckout
 @testable import MPComponents
 @testable import MPFoundation
 import XCTest
 
 final class InstallmentsScreenViewModelTests: XCTestCase {
-    func test_formatInstallmentLabel_shouldReturnCorrectFormat() {
-        // Arrange
-        let sut = self.makeSUT()
-        let payerCost = Installment.makePayerCost(installments: 3, installmentAmount: 370.77)
+    // MARK: - selectedTotalAmount
 
-        // Act
-        let result = sut.formatInstallmentLabel(for: payerCost)
-
-        // Assert
-        XCTAssertTrue(result.contains("3x"))
-        XCTAssertTrue(result.contains("370"))
-    }
-
-    func test_formatInstallmentLabel_withOneInstallment_shouldShowOneX() {
-        // Arrange
-        let sut = self.makeSUT()
-        let payerCost = Installment.makePayerCost(installments: 1, installmentAmount: 1000.0)
-
-        // Act
-        let result = sut.formatInstallmentLabel(for: payerCost)
-
-        // Assert
-        XCTAssertTrue(result.hasPrefix("1x"))
-    }
-
-    // MARK: - formatInterestLabel Tests
-
-    func test_formatInterestLabel_withZeroRate_shouldReturnEmpty() {
-        // Arrange
-        let sut = self.makeSUT()
-        let payerCost = Installment.makePayerCost(installmentRate: 0.0)
-
-        // Act
-        let result = sut.formatInterestLabel(for: payerCost)
-
-        // Assert
-        XCTAssertEqual(result, String())
-    }
-
-    func test_formatInterestLabel_withZeroRate_shouldReturnInterestFree() {
-        // Arrange
-        let sut = self.makeSUT(installments: Installment.validInstallments)
-        let payerCost = Installment.makePayerCost(installments: 2, installmentRate: 0.0)
-
-        // Act
-        let result = sut.formatInterestLabel(for: payerCost)
-
-        // Assert
-        XCTAssertEqual(result, MPStrings.Installments.interestFree)
-    }
-
-    func test_formatInterestLabel_withPositiveRate_shouldReturnTotalAmount() {
-        // Arrange
-        let sut = self.makeSUT()
-        let payerCost = Installment.makePayerCost(installments: 2, installmentRate: 9.64, totalAmount: 1096.4)
-
-        // Act
-        let result = sut.formatInterestLabel(for: payerCost)
-
-        // Assert
-        XCTAssertEqual("\(MPStrings.Common.currency) 1.096,40", result)
-    }
-
-    // MARK: - selectedTotalAmount Tests
-
-    func test_selectedTotalAmount_whenSelectedIsNil_shouldReturnFirstInstallmentAmount() {
+    func test_selectedTotalAmount_whenSelectedIsNil_shouldReturnFirstQuotaTotalAmount() {
         // Arrange
         let sut = self.makeSUT()
 
@@ -91,197 +27,131 @@ final class InstallmentsScreenViewModelTests: XCTestCase {
     func test_selectedTotalAmount_whenSelected_shouldReturnSelectedTotalAmount() {
         // Arrange
         let sut = self.makeSUT()
-        let selectedPayerCost = Installment.makePayerCost(totalAmount: 1221.1)
+        let selectedQuota = CardPaymentBrickCardData.Installment.Quota.make(totalAmount: 1221.1)
 
         // Act
-        let result = sut.selectedTotalAmount(selectedPayerCost)
+        let result = sut.selectedTotalAmount(selectedQuota)
 
         // Assert
         XCTAssertEqual(MPAmountData(from: 1221.1), result)
     }
 
-    // MARK: - formatInterestLabel — one-installment edge case
+    // MARK: - color(for:)
 
-    func test_formatInterestLabel_withOneInstallment_shouldReturnEmpty() {
-        // Arrange -- single installment: no interest label regardless of rate
-        let sut = self.makeSUT()
-        let payerCost = Installment.makePayerCost(installments: 1, installmentRate: 5.0, totalAmount: 1000.0)
-
-        // Act
-        let result = sut.formatInterestLabel(for: payerCost)
-
-        // Assert
-        XCTAssertEqual(result, String())
-    }
-
-    // MARK: - findInterestLabelColor
-
-    func test_findInterestLabelColor_whenZeroRate_shouldReturnFeedbackPositive() {
+    func test_color_whenStateIsSuccess_shouldReturnFeedbackPositive() {
         // Arrange
         let sut = self.makeSUT()
-        let payerCost = Installment.makePayerCost(installmentRate: 0.0)
+        let quota = CardPaymentBrickCardData.Installment.Quota.make(state: .success)
 
         // Act
-        let result = sut.findInterestLabelColor(for: payerCost)
+        let result = sut.color(for: quota)
 
         // Assert
         XCTAssertEqual(result, .feedbackPositive)
     }
 
-    func test_findInterestLabelColor_whenPositiveRate_shouldReturnNil() {
+    func test_color_whenStateIsNone_shouldReturnNil() {
         // Arrange
         let sut = self.makeSUT()
-        let payerCost = Installment.makePayerCost(installmentRate: 9.64)
+        let quota = CardPaymentBrickCardData.Installment.Quota.make(state: .none)
 
         // Act
-        let result = sut.findInterestLabelColor(for: payerCost)
+        let result = sut.color(for: quota)
 
         // Assert
         XCTAssertNil(result)
     }
 
-    // MARK: - formatFooterDescription
+    // MARK: - headerTitle / totalLabel
 
-    func test_formatFooterDescription_whenAllFieldsPresent_shouldReturnFormattedDescription() {
-        // Arrange -- validInstallments has issuer.name "Mercado Pago" and paymentTypeId "credit_card"
+    func test_headerTitle_shouldMatchTranslations() {
         let sut = self.makeSUT()
-
-        // Act
-        let result = sut.formatFooterDescription()
-
-        // Assert -- format is "<Normalized issuer> <Credit/Debit> **** <lastDigits>"
-        XCTAssertTrue(result.contains("Mercado Pago"))
-        XCTAssertTrue(result.contains(MPStrings.Common.creditCard))
-        XCTAssertTrue(result.contains("****"))
+        XCTAssertEqual(sut.headerTitle, "Escolha o parcelamento")
     }
 
-    func test_formatFooterDescription_whenIssuerHasNoName_shouldReturnEmpty() {
-        // Arrange -- Issuer.name is String?; nil causes the guard in formatFooterDescription to fail
-        let installment = Installment(
-            paymentMethodId: "visa",
-            paymentTypeId: "credit_card",
-            thumbnail: "",
-            issuer: Installment.Issuer(id: "1", thumbnail: "", name: nil),
-            processingMode: "aggregator",
-            merchantAccountId: "",
-            payerCosts: Installment.payerCosts,
-            agreements: []
-        )
-        let sut = InstallmentsScreenViewModel(installments: installment)
-
-        // Act
-        let result = sut.formatFooterDescription()
-
-        // Assert
-        XCTAssertEqual(result, "")
+    func test_totalLabel_shouldMatchTranslations() {
+        let sut = self.makeSUT()
+        XCTAssertEqual(sut.totalLabel, "Total")
     }
 
-    // MARK: - getSavedCardName
+    // MARK: - footerDescription
 
-    func test_getSavedCardName_whenNotMercadoPagoCard_shouldIncludeMaskedLastDigits() {
+    func test_footerDescription_shouldFormatIssuerPaymentTypeAndLastFourDigits() {
         // Arrange
         let sut = self.makeSUT()
 
         // Act
-        let result = sut.getSavedCardName(
-            issuerName: "Bradesco",
-            paymentTypeLabel: "Crédito",
-            lastDigits: "4321",
-            isMercadoPagoCard: false
-        )
+        let result = sut.footerDescription()
 
         // Assert
-        XCTAssertEqual(result, "Bradesco Crédito **** 4321")
+        XCTAssertTrue(result.contains("Bradesco"))
+        XCTAssertTrue(result.contains("****"))
+        XCTAssertTrue(result.contains("4321"))
     }
 
-    func test_getSavedCardName_whenIsMercadoPagoCard_shouldOmitMaskAndLastDigits() {
-        // Arrange -- MercadoPago-issued cards don't show the masked suffix
-        let sut = self.makeSUT()
+    // MARK: - Helpers
 
-        // Act
-        let result = sut.getSavedCardName(
-            issuerName: "Mercado Pago",
-            paymentTypeLabel: "Crédito",
-            lastDigits: "4321",
-            isMercadoPagoCard: true
-        )
-
-        // Assert
-        XCTAssertEqual(result, "Mercado Pago Crédito")
-    }
-
-    func test_getSavedCardName_shouldNormalizeIssuerName_byStrippingCreditWord() {
-        // Arrange -- issuerName passes through MPFormatIssuerName.cleanIssuerName before joining
-        let sut = self.makeSUT()
-
-        // Act
-        let result = sut.getSavedCardName(
-            issuerName: "Banco de Crédito del Perú",
-            paymentTypeLabel: "Crédito",
-            lastDigits: "1234",
-            isMercadoPagoCard: false
-        )
-
-        // Assert -- "Crédito" word removed, capitalization applied ("de"/"del" stay lowercase)
-        XCTAssertEqual(result, "Banco de del Perú Crédito **** 1234")
-    }
-
-    // MARK: - Helpers:
-
-    private func makeSUT(installments: Installment = Installment.validInstallments) -> InstallmentsScreenViewModel {
-        InstallmentsScreenViewModel(installments: installments)
+    private func makeSUT(
+        installmentsData: InstallmentsData = .validInstallmentsData
+    ) -> InstallmentsScreenViewModel {
+        var data = installmentsData
+        return InstallmentsScreenViewModel(installmentsData: Binding(get: { data }, set: { data = $0 }))
     }
 }
 
-extension Installment {
-    static let validInstallments = Installment(
-        paymentMethodId: "visa",
-        paymentTypeId: "credit_card",
-        thumbnail: "https://example.com/visa.png",
-        issuer: Installment.Issuer(id: "25", thumbnail: "https://example.com/visa.png", name: "Mercado Pago"),
-        processingMode: "aggregator",
-        merchantAccountId: "",
-        payerCosts: payerCosts,
-        agreements: []
+// MARK: - Test Fixtures
+
+extension InstallmentsData {
+    static let validInstallmentsData = InstallmentsData(
+        installment: .validInstallments,
+        cardDisplayInfo: .make()
     )
+}
 
-    static let payerCosts: [Installment.PayerCost] = [
-        makePayerCost(id: 1, installments: 1, installmentAmount: 1000.0, installmentRate: 0.0, totalAmount: 1000.0),
-        makePayerCost(id: 2, installments: 2, installmentAmount: 548.2, installmentRate: 9.64, totalAmount: 1096.4),
-        makePayerCost(id: 3, installments: 3, installmentAmount: 370.77, installmentRate: 11.23, totalAmount: 1112.3)
-    ]
-
-    static let singleInstallment = Installment(
-        paymentMethodId: "visa",
-        paymentTypeId: "credit_card",
-        thumbnail: "",
-        issuer: Installment.Issuer(id: "1", thumbnail: ""),
-        processingMode: "aggregator",
-        merchantAccountId: "",
-        payerCosts: [makePayerCost(id: 1, installments: 1, installmentAmount: 500.0, installmentRate: 0.0, totalAmount: 500.0)],
-        agreements: []
+extension CardPaymentBrickCardData.Installment {
+    static let validInstallments = CardPaymentBrickCardData.Installment(
+        selectionType: "radio_button",
+        quotas: [
+            .make(installments: 1, installmentAmount: 1000.0, totalAmount: 1000.0, state: .none),
+            .make(installments: 2, installmentAmount: 548.2, totalAmount: 1096.4, state: .none),
+            .make(installments: 3, installmentAmount: 370.77, totalAmount: 1112.3, state: .success)
+        ],
+        translations: .init(
+            headerTitle: "Escolha o parcelamento",
+            interestFreeLabel: "Sem acréscimo",
+            totalLabel: "Total"
+        )
     )
+}
 
-    static func makePayerCost(
-        id: Int = 1,
+extension CardPaymentBrickCardData.Installment.Quota {
+    static func make(
         installments: Int = 1,
         installmentAmount: Double = 1000.0,
-        installmentRate: Double = 0.0,
-        totalAmount: Double = 1000.0
-    ) -> Installment.PayerCost {
-        Installment.PayerCost(
-            id: id,
+        totalAmount: Double = 1000.0,
+        primaryLabel: String = "1x R$ 1.000,00",
+        secondaryLabel: String = "À vista",
+        state: CardPaymentBrickCardData.Installment.QuotaState = .none,
+        tertiaryLabel: String? = nil
+    ) -> CardPaymentBrickCardData.Installment.Quota {
+        .init(
             installments: installments,
             installmentAmount: installmentAmount,
-            installmentRate: installmentRate,
-            installmentRateCollector: ["MERCADOPAGO"],
             totalAmount: totalAmount,
-            minAllowedAmount: 0.5,
-            maxAllowedAmount: 60000.0,
-            discountRate: 0.0,
-            reimbursementRate: 0.0,
-            labels: [],
-            paymentMethodOptionId: "test-\(id)"
+            primaryLabel: primaryLabel,
+            secondaryLabel: secondaryLabel,
+            state: state,
+            tertiaryLabel: tertiaryLabel
         )
+    }
+}
+
+extension CardDisplayInfo {
+    static func make(
+        issuerName: String = "Bradesco",
+        paymentTypeId: String = "credit_card",
+        lastFourDigits: String = "4321"
+    ) -> CardDisplayInfo {
+        .init(issuerName: issuerName, paymentTypeId: paymentTypeId, lastFourDigits: lastFourDigits)
     }
 }

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/InstallmentsScreenViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/InstallmentsScreenViewModelTests.swift
@@ -118,7 +118,7 @@ extension CardPaymentBrickCardData.Installment {
         ],
         translations: .init(
             headerTitle: "Escolha o parcelamento",
-            interestFreeLabel: "Sem acréscimo",
+
             totalLabel: "Total"
         )
     )

--- a/Tests/SnapshotTests/MercadoPagoCheckout/InstallmentsViewTests.swift
+++ b/Tests/SnapshotTests/MercadoPagoCheckout/InstallmentsViewTests.swift
@@ -80,7 +80,7 @@ final class InstallmentsViewTests: XCTestCase {
             ],
             translations: .init(
                 headerTitle: "Escolha o parcelamento",
-                interestFreeLabel: "Sem acréscimo",
+
                 totalLabel: "Total"
             )
         ),

--- a/Tests/SnapshotTests/MercadoPagoCheckout/InstallmentsViewTests.swift
+++ b/Tests/SnapshotTests/MercadoPagoCheckout/InstallmentsViewTests.swift
@@ -5,7 +5,6 @@
 //  Created by Danielle Nozaki Ogawa on 28/01/26.
 //
 
-@testable import CoreMethods
 @testable import MercadoPagoCheckout
 import SnapshotTesting
 import SwiftUI
@@ -15,9 +14,10 @@ import XCTest
 final class InstallmentsViewTests: XCTestCase {
     func test_installmentScreen_radioButton() {
         var paymentData = MPPaymentData(transactionAmount: 1000, token: "")
+        var installmentsData = Self.validInstallmentsData
         let view = InstallmentScreen(
             paymentData: Binding(get: { paymentData }, set: { paymentData = $0 }),
-            installments: Self.validInstallments,
+            installmentsData: Binding(get: { installmentsData }, set: { installmentsData = $0 }),
             style: .radioButton,
             onBack: {}
         )
@@ -30,9 +30,10 @@ final class InstallmentsViewTests: XCTestCase {
 
     func test_installmentScreen_chevron() {
         var paymentData = MPPaymentData(transactionAmount: 1000, token: "")
+        var installmentsData = Self.validInstallmentsData
         let view = InstallmentScreen(
             paymentData: Binding(get: { paymentData }, set: { paymentData = $0 }),
-            installments: Self.validInstallments,
+            installmentsData: Binding(get: { installmentsData }, set: { installmentsData = $0 }),
             style: .chevron,
             onBack: {}
         )
@@ -45,41 +46,48 @@ final class InstallmentsViewTests: XCTestCase {
 
     // MARK: - Fixture
 
-    private static let validInstallments = Installment(
-        paymentMethodId: "visa",
-        paymentTypeId: "credit_card",
-        thumbnail: "https://example.com/visa.png",
-        issuer: Installment.Issuer(id: "25", thumbnail: "https://example.com/visa.png", name: "Mercado Pago"),
-        processingMode: "aggregator",
-        merchantAccountId: "",
-        payerCosts: [
-            InstallmentsViewTests.makePayerCost(id: 1, installments: 1, installmentAmount: 1000.0, totalAmount: 1000.0),
-            InstallmentsViewTests.makePayerCost(id: 2, installments: 2, installmentAmount: 548.2, installmentRate: 9.64, totalAmount: 1096.4),
-            InstallmentsViewTests.makePayerCost(id: 3, installments: 3, installmentAmount: 370.77, installmentRate: 11.23, totalAmount: 1112.3)
-        ],
-        agreements: []
-    )
-
-    private static func makePayerCost(
-        id: Int,
-        installments: Int,
-        installmentAmount: Double,
-        installmentRate: Double = 0.0,
-        totalAmount: Double
-    ) -> Installment.PayerCost {
-        Installment.PayerCost(
-            id: id,
-            installments: installments,
-            installmentAmount: installmentAmount,
-            installmentRate: installmentRate,
-            installmentRateCollector: ["MERCADOPAGO"],
-            totalAmount: totalAmount,
-            minAllowedAmount: 0.5,
-            maxAllowedAmount: 60000.0,
-            discountRate: 0.0,
-            reimbursementRate: 0.0,
-            labels: [],
-            paymentMethodOptionId: "test-\(id)"
+    private static let validInstallmentsData = InstallmentsData(
+        installment: .init(
+            selectionType: "radio_button",
+            quotas: [
+                .init(
+                    installments: 1,
+                    installmentAmount: 1000.0,
+                    totalAmount: 1000.0,
+                    primaryLabel: "1x R$ 1.000,00",
+                    secondaryLabel: "À vista",
+                    state: .none,
+                    tertiaryLabel: nil
+                ),
+                .init(
+                    installments: 2,
+                    installmentAmount: 548.2,
+                    totalAmount: 1096.4,
+                    primaryLabel: "2x R$ 548,20",
+                    secondaryLabel: "R$ 1.096,40",
+                    state: .none,
+                    tertiaryLabel: nil
+                ),
+                .init(
+                    installments: 3,
+                    installmentAmount: 370.77,
+                    totalAmount: 1000.0,
+                    primaryLabel: "3x R$ 370,77",
+                    secondaryLabel: "Sem juros",
+                    state: .success,
+                    tertiaryLabel: nil
+                )
+            ],
+            translations: .init(
+                headerTitle: "Escolha o parcelamento",
+                interestFreeLabel: "Sem acréscimo",
+                totalLabel: "Total"
+            )
+        ),
+        cardDisplayInfo: .init(
+            issuerName: "Bradesco",
+            paymentTypeId: "credit_card",
+            lastFourDigits: "1234"
         )
-    }
+    )
 }

--- a/Tests/SnapshotTests/MercadoPagoCheckout/InstallmentsViewTests.swift
+++ b/Tests/SnapshotTests/MercadoPagoCheckout/InstallmentsViewTests.swift
@@ -14,7 +14,7 @@ import XCTest
 final class InstallmentsViewTests: XCTestCase {
     func test_installmentScreen_radioButton() {
         var paymentData = MPPaymentData(transactionAmount: 1000, token: "")
-        var installmentsData = Self.validInstallmentsData
+        var installmentsData = Self.validMPInstallmentsData
         let view = InstallmentScreen(
             paymentData: Binding(get: { paymentData }, set: { paymentData = $0 }),
             installmentsData: Binding(get: { installmentsData }, set: { installmentsData = $0 }),
@@ -30,7 +30,7 @@ final class InstallmentsViewTests: XCTestCase {
 
     func test_installmentScreen_chevron() {
         var paymentData = MPPaymentData(transactionAmount: 1000, token: "")
-        var installmentsData = Self.validInstallmentsData
+        var installmentsData = Self.validMPInstallmentsData
         let view = InstallmentScreen(
             paymentData: Binding(get: { paymentData }, set: { paymentData = $0 }),
             installmentsData: Binding(get: { installmentsData }, set: { installmentsData = $0 }),
@@ -46,7 +46,7 @@ final class InstallmentsViewTests: XCTestCase {
 
     // MARK: - Fixture
 
-    private static let validInstallmentsData = InstallmentsData(
+    private static let validMPInstallmentsData = MPInstallmentsData(
         installment: .init(
             selectionType: "radio_button",
             quotas: [
@@ -80,8 +80,8 @@ final class InstallmentsViewTests: XCTestCase {
             ],
             translations: .init(
                 headerTitle: "Escolha o parcelamento",
-
-                totalLabel: "Total"
+                totalLabel: "Total",
+                payButtonLabel: "Pagar"
             )
         ),
         cardDisplayInfo: .init(


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
https://mercadolibre.atlassian.net/browse/CHOBK-3918

## Description
- Added `interactionMode` field to public `Installment` model to expose the BFF interaction type (`chevron` or `radio_button`)
- Introduced `CardFormTranslationsResponse` DTO with installments-specific translations: header title, total label, and pay button label
- Added `MPInstallmentsData` internal domain model combining `CardPaymentBrickCardData.Installment` with `CardDisplayInfo`
- Refactored `InstallmentScreen` to support two interaction styles via `InstallmentInteractionStyle` protocol — `ChevronStyle` and `RadioButtonStyle` — driven by the BFF `interactionMode`
- Updated `InstallmentScreenViewModel` to map BFF installment data, card display info, and translations into view state
- Fixed snapshot and unit tests to align with the new data model structure

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [x] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>