### PR TITLE
[CHOBK 3919] Pay Button

### DIFF
--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -118,7 +118,12 @@ struct CardFormBrick: View {
             onBack: {
                 self.presentationMode.wrappedValue.dismiss()
             },
-            onContinue: {
+            onFinish: { paymentData in
+                self.paymentData = paymentData
+                self.completeCheckout()
+            },
+            onContinue: { paymentData in
+                self.paymentData = paymentData
                 self.route = .reviewAndConfirm
             }
         )

--- a/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
@@ -125,7 +125,8 @@ struct InstallmentScreen: View {
 
     private let style: any InstallmentInteractionStyle
     private let onBack: () -> Void
-    private let onContinue: () -> Void
+    private let onFinish: (MPPaymentData) -> Void
+    private let onContinue: (MPPaymentData) -> Void
     @Binding private var paymentData: MPPaymentData
 
     init(
@@ -133,12 +134,14 @@ struct InstallmentScreen: View {
         installmentsData: Binding<MPInstallmentsData>,
         style: (any InstallmentInteractionStyle)? = nil,
         onBack: @escaping () -> Void,
-        onContinue: @escaping () -> Void = {}
+        onFinish: @escaping (MPPaymentData) -> Void = { _ in },
+        onContinue: @escaping (MPPaymentData) -> Void = { _ in }
     ) {
         self._paymentData = paymentData
         self.viewModel = InstallmentsScreenViewModel(installmentsData: installmentsData)
         self.style = style ?? installmentsData.wrappedValue.installment.resolvedInteractionStyle
         self.onBack = onBack
+        self.onFinish = onFinish
         self.onContinue = onContinue
     }
 
@@ -179,8 +182,18 @@ struct InstallmentScreen: View {
             title: self.viewModel.totalLabel,
             amount: self.viewModel.selectedTotalAmount(self.selectedQuota),
             subtitle: self.viewModel.footerDescription(),
-            buttonData: self.style.footerButtonData(self.viewModel.payButtonLabel, onContinue: self.onContinue)
+            buttonData: self.style.footerButtonData(
+                self.viewModel.payButtonLabel,
+                onContinue: {
+                    self.finishWithSelectedQuota()
+                }
+            )
         )
+    }
+
+    private func finishWithSelectedQuota() {
+        self.paymentData.installment = self.selectedQuota?.installments
+        self.onFinish(self.paymentData)
     }
 
     // MARK: - Helper Methods
@@ -189,8 +202,15 @@ struct InstallmentScreen: View {
         self.style.selectionBinding(
             for: quota,
             selected: self.$selectedQuota,
-            onContinue: self.onContinue
+            onContinue: {
+                self.continueWithSelectedQuota(for: quota)
+            }
         )
+    }
+
+    private func continueWithSelectedQuota(for installment: CardPaymentBrickCardData.Installment.Quota) {
+        self.paymentData.installment = installment.installments
+        self.onContinue(self.paymentData)
     }
 }
 

--- a/Tests/MercadoPagoCheckoutTests/Views/InstallmentInteractionStyleTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Views/InstallmentInteractionStyleTests.swift
@@ -1,5 +1,5 @@
 //
-//  InstallmentsScreenViewTests.swift
+//  InstallmentInteractionStyleTests.swift
 //  MercadoPagoSDK
 //
 
@@ -8,7 +8,7 @@
 import SwiftUI
 import XCTest
 
-final class InstallmentsScreenViewTests: XCTestCase {
+final class InstallmentInteractionStyleTests: XCTestCase {
     // MARK: - RadioButtonInstallmentStyle: footerButtonData
 
     func test_radioButton_footerButtonData_shouldReturnNonNilButtonData() {

--- a/Tests/MercadoPagoCheckoutTests/Views/InstallmentsScreenViewTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Views/InstallmentsScreenViewTests.swift
@@ -1,0 +1,287 @@
+//
+//  InstallmentsScreenViewTests.swift
+//  MercadoPagoSDK
+//
+
+@testable import MercadoPagoCheckout
+@testable import MPComponents
+import SwiftUI
+import XCTest
+
+final class InstallmentsScreenViewTests: XCTestCase {
+    // MARK: - RadioButtonInstallmentStyle: footerButtonData
+
+    func test_radioButton_footerButtonData_shouldReturnNonNilButtonData() {
+        // Arrange
+        let sut = RadioButtonInstallmentStyle()
+
+        // Act
+        let result = sut.footerButtonData("Pagar", onContinue: {})
+
+        // Assert
+        XCTAssertNotNil(result)
+    }
+
+    func test_radioButton_footerButtonData_shouldContainCorrectLabel() {
+        // Arrange
+        let sut = RadioButtonInstallmentStyle()
+        let label = "Pagar R$ 100,00"
+
+        // Act
+        let result = sut.footerButtonData(label, onContinue: {})
+
+        // Assert
+        XCTAssertEqual(result?.text, label)
+    }
+
+    func test_radioButton_footerButtonData_whenOnClickCalled_shouldInvokeOnContinueCallback() async {
+        // Arrange
+        let sut = RadioButtonInstallmentStyle()
+        var callbackInvoked = false
+        let buttonData = sut.footerButtonData("Pagar") {
+            callbackInvoked = true
+        }
+
+        // Act
+        await buttonData?.onClick()
+
+        // Assert
+        XCTAssertTrue(callbackInvoked)
+    }
+
+    // MARK: - RadioButtonInstallmentStyle: selectionBinding
+
+    func test_radioButton_selectionBinding_getter_whenMatchingQuotaSelected_shouldReturnTrue() {
+        // Arrange
+        let sut = RadioButtonInstallmentStyle()
+        let quota = CardPaymentBrickCardData.Installment.Quota.make(installments: 3)
+        var selected: CardPaymentBrickCardData.Installment.Quota? = quota
+        let binding = Binding(get: { selected }, set: { selected = $0 })
+
+        // Act
+        let result = sut.selectionBinding(for: quota, selected: binding, onContinue: {})
+
+        // Assert
+        XCTAssertTrue(result.wrappedValue)
+    }
+
+    func test_radioButton_selectionBinding_getter_whenDifferentQuotaSelected_shouldReturnFalse() {
+        // Arrange
+        let sut = RadioButtonInstallmentStyle()
+        let quota = CardPaymentBrickCardData.Installment.Quota.make(installments: 3)
+        let otherQuota = CardPaymentBrickCardData.Installment.Quota.make(installments: 6)
+        var selected: CardPaymentBrickCardData.Installment.Quota? = otherQuota
+        let binding = Binding(get: { selected }, set: { selected = $0 })
+
+        // Act
+        let result = sut.selectionBinding(for: quota, selected: binding, onContinue: {})
+
+        // Assert
+        XCTAssertFalse(result.wrappedValue)
+    }
+
+    func test_radioButton_selectionBinding_getter_whenNothingSelected_shouldReturnFalse() {
+        // Arrange
+        let sut = RadioButtonInstallmentStyle()
+        let quota = CardPaymentBrickCardData.Installment.Quota.make(installments: 1)
+        var selected: CardPaymentBrickCardData.Installment.Quota? = nil
+        let binding = Binding(get: { selected }, set: { selected = $0 })
+
+        // Act
+        let result = sut.selectionBinding(for: quota, selected: binding, onContinue: {})
+
+        // Assert
+        XCTAssertFalse(result.wrappedValue)
+    }
+
+    func test_radioButton_selectionBinding_setterToTrue_shouldUpdateSelectedQuota() {
+        // Arrange
+        let sut = RadioButtonInstallmentStyle()
+        let quota = CardPaymentBrickCardData.Installment.Quota.make(installments: 3)
+        var selected: CardPaymentBrickCardData.Installment.Quota? = nil
+        let binding = Binding(get: { selected }, set: { selected = $0 })
+
+        // Act
+        let result = sut.selectionBinding(for: quota, selected: binding, onContinue: {})
+        result.wrappedValue = true
+
+        // Assert
+        XCTAssertEqual(selected, quota)
+    }
+
+    func test_radioButton_selectionBinding_setterToFalse_shouldNotChangeSelectedQuota() {
+        // Arrange
+        let sut = RadioButtonInstallmentStyle()
+        let existingQuota = CardPaymentBrickCardData.Installment.Quota.make(installments: 1)
+        let quota = CardPaymentBrickCardData.Installment.Quota.make(installments: 3)
+        var selected: CardPaymentBrickCardData.Installment.Quota? = existingQuota
+        let binding = Binding(get: { selected }, set: { selected = $0 })
+
+        // Act
+        let result = sut.selectionBinding(for: quota, selected: binding, onContinue: {})
+        result.wrappedValue = false
+
+        // Assert
+        XCTAssertEqual(selected, existingQuota)
+    }
+
+    func test_radioButton_selectionBinding_setterToTrue_shouldNotCallOnContinue() {
+        // Arrange
+        let sut = RadioButtonInstallmentStyle()
+        let quota = CardPaymentBrickCardData.Installment.Quota.make(installments: 1)
+        var selected: CardPaymentBrickCardData.Installment.Quota? = nil
+        let binding = Binding(get: { selected }, set: { selected = $0 })
+        var callbackInvoked = false
+
+        // Act
+        let result = sut.selectionBinding(for: quota, selected: binding) {
+            callbackInvoked = true
+        }
+        result.wrappedValue = true
+
+        // Assert
+        XCTAssertFalse(callbackInvoked)
+    }
+
+    // MARK: - ChevronInstallmentStyle: footerButtonData
+
+    func test_chevron_footerButtonData_shouldReturnNil() {
+        // Arrange
+        let sut = ChevronInstallmentStyle()
+
+        // Act
+        let result = sut.footerButtonData("Pagar", onContinue: {})
+
+        // Assert
+        XCTAssertNil(result)
+    }
+
+    // MARK: - ChevronInstallmentStyle: selectionBinding
+
+    func test_chevron_selectionBinding_getter_shouldAlwaysReturnFalse() {
+        // Arrange
+        let sut = ChevronInstallmentStyle()
+        let quota = CardPaymentBrickCardData.Installment.Quota.make(installments: 3)
+        var selected: CardPaymentBrickCardData.Installment.Quota? = quota
+        let binding = Binding(get: { selected }, set: { selected = $0 })
+
+        // Act
+        let result = sut.selectionBinding(for: quota, selected: binding, onContinue: {})
+
+        // Assert
+        XCTAssertFalse(result.wrappedValue)
+    }
+
+    func test_chevron_selectionBinding_setterToTrue_shouldCallOnContinue() {
+        // Arrange
+        let sut = ChevronInstallmentStyle()
+        let quota = CardPaymentBrickCardData.Installment.Quota.make(installments: 3)
+        var selected: CardPaymentBrickCardData.Installment.Quota? = nil
+        let binding = Binding(get: { selected }, set: { selected = $0 })
+        var callbackInvoked = false
+
+        // Act
+        let result = sut.selectionBinding(for: quota, selected: binding) {
+            callbackInvoked = true
+        }
+        result.wrappedValue = true
+
+        // Assert
+        XCTAssertTrue(callbackInvoked)
+    }
+
+    func test_chevron_selectionBinding_setterToFalse_shouldNotCallOnContinue() {
+        // Arrange
+        let sut = ChevronInstallmentStyle()
+        let quota = CardPaymentBrickCardData.Installment.Quota.make(installments: 3)
+        var selected: CardPaymentBrickCardData.Installment.Quota? = nil
+        let binding = Binding(get: { selected }, set: { selected = $0 })
+        var callbackInvoked = false
+
+        // Act
+        let result = sut.selectionBinding(for: quota, selected: binding) {
+            callbackInvoked = true
+        }
+        result.wrappedValue = false
+
+        // Assert
+        XCTAssertFalse(callbackInvoked)
+    }
+
+    func test_chevron_selectionBinding_setterToTrue_shouldNotUpdateSelectedQuota() {
+        // Arrange
+        let sut = ChevronInstallmentStyle()
+        let quota = CardPaymentBrickCardData.Installment.Quota.make(installments: 3)
+        var selected: CardPaymentBrickCardData.Installment.Quota? = nil
+        let binding = Binding(get: { selected }, set: { selected = $0 })
+
+        // Act
+        let result = sut.selectionBinding(for: quota, selected: binding, onContinue: {})
+        result.wrappedValue = true
+
+        // Assert
+        XCTAssertNil(selected)
+    }
+
+    // MARK: - resolvedInteractionStyle
+
+    func test_resolvedInteractionStyle_whenChevron_shouldReturnChevronStyle() {
+        // Arrange
+        let installment = CardPaymentBrickCardData.Installment.make(selectionType: "chevron")
+
+        // Act
+        let style = installment.resolvedInteractionStyle
+
+        // Assert
+        XCTAssertTrue(style is ChevronInstallmentStyle)
+    }
+
+    func test_resolvedInteractionStyle_whenRadioButton_shouldReturnRadioButtonStyle() {
+        // Arrange
+        let installment = CardPaymentBrickCardData.Installment.make(selectionType: "radio_button")
+
+        // Act
+        let style = installment.resolvedInteractionStyle
+
+        // Assert
+        XCTAssertTrue(style is RadioButtonInstallmentStyle)
+    }
+
+    func test_resolvedInteractionStyle_whenUnknownType_shouldFallbackToRadioButtonStyle() {
+        // Arrange
+        let installment = CardPaymentBrickCardData.Installment.make(selectionType: "unknown_type")
+
+        // Act
+        let style = installment.resolvedInteractionStyle
+
+        // Assert
+        XCTAssertTrue(style is RadioButtonInstallmentStyle)
+    }
+
+    func test_resolvedInteractionStyle_whenChevronUppercase_shouldBeCaseInsensitive() {
+        // Arrange
+        let installment = CardPaymentBrickCardData.Installment.make(selectionType: "CHEVRON")
+
+        // Act
+        let style = installment.resolvedInteractionStyle
+
+        // Assert
+        XCTAssertTrue(style is ChevronInstallmentStyle)
+    }
+}
+
+// MARK: - Test Fixtures
+
+private extension CardPaymentBrickCardData.Installment {
+    static func make(
+        selectionType: String = "radio_button",
+        quotas: [Quota] = [],
+        translations: InstallmentTranslations = .init(
+            headerTitle: String(),
+            totalLabel: String(),
+            payButtonLabel: String()
+        )
+    ) -> CardPaymentBrickCardData.Installment {
+        .init(selectionType: selectionType, quotas: quotas, translations: translations)
+    }
+}


### PR DESCRIPTION
  ## Ticket or Issue link
  https://mercadolibre.atlassian.net/browse/CHOBK-3919

  ## Description
  - Added `onFinish` and `onContinue` callbacks to `InstallmentScreen` to handle the two selection flows: pay button tap (radio button style) and row tap
   (chevron style)
  - `RadioButtonInstallmentStyle`: footer Pay button calls `onFinish` with the selected quota's installment data
  - `ChevronInstallmentStyle`: row tap immediately triggers `onContinue`, no footer button rendered
  - `CardFormBrick` wires both callbacks — `onFinish` completes the checkout flow, `onContinue` navigates to the review-and-confirm route
  - Added `InstallmentsScreenViewTests` with unit tests covering button action, navigation, and selection behavior

  ## Checklist
  - [x] I have tested my changes creating a local version (More info in README file).
  - [x] I have added tests that prove my solution is effective and works
  - [ ] New and existing unit tests pass locally with my changes.
  - [ ] Verify that you are merged with the latest in develop.
  - [ ] I have run `swiftlint` and fixed any possible issues of my code.
  - [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
  - [ ] I have tested the accessibility of the changes and added them to the screenshots.
  - [ ] I have added a tag to the pull request that contains the product this pull request is related to.

  ## Screenshots or videos (if applies)
  <p float="center">
      <img width="200" src="">
      <img width="200" src="">
  </p>