### PR TITLE
[CHOBK-3922] (Feature): User cancelled context for installments

### DIFF
--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -89,17 +89,26 @@ struct CardFormBrick: View {
             viewModel: viewModel,
             onBack: { context in
                 viewModel.cancel(context: context, reason: .backButton)
-                self.cancelCheckout(context: .cardForm(context))
+                let updatedContext = CardFormUserCancelledContext(
+                    fields: context.fields,
+                    installmentsWasPresented: self.brickViewModel.installmentsWasPresented
+                )
+                self.cancelCheckout(context: .cardForm(updatedContext))
             },
             onDismiss: { context in
                 viewModel.cancel(context: context, reason: .dismissedScreen)
+                let updatedContext = CardFormUserCancelledContext(
+                    fields: context.fields,
+                    installmentsWasPresented: self.brickViewModel.installmentsWasPresented
+                )
                 self.route = nil
-                self.onResult(.userCancelled(.cardForm(context)))
+                self.onResult(.userCancelled(.cardForm(updatedContext)))
             },
             onSuccess: { paymentData, installmentsData in
                 self.paymentData = paymentData
                 if let installmentsData {
                     self.installmentsData = installmentsData
+                    self.brickViewModel.markInstallmentsPresented()
                     self.route = .installments
                 } else {
                     self.completeCheckout()

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -116,7 +116,10 @@ struct CardFormBrick: View {
             paymentData: self.$paymentData,
             installmentsData: self.$installmentsData,
             onBack: {
-                self.presentationMode.wrappedValue.dismiss()
+                self.route = nil
+            },
+            onDismiss: {
+                self.cancelCheckout(context: .installments)
             },
             onFinish: { paymentData in
                 self.paymentData = paymentData

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
@@ -19,6 +19,7 @@ final class CardFormBrickViewModel: ObservableObject {
     // MARK: - Published State
 
     @Published private(set) var screenState: ScreenState = .loading
+    @Published private(set) var installmentsWasPresented = false
 
     // MARK: - Dependencies
 
@@ -39,6 +40,10 @@ final class CardFormBrickViewModel: ObservableObject {
         self.appearance = appearance
         self.initializeUseCase = initializeUseCase
         self.analytics = analytics
+    }
+
+    func markInstallmentsPresented() {
+        self.installmentsWasPresented = true
     }
 
     // MARK: - Initialization

--- a/Sources/MercadoPagoCheckout/Model/Public/CardFormUserCancelledContext.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/CardFormUserCancelledContext.swift
@@ -7,9 +7,12 @@
 public struct CardFormUserCancelledContext: Sendable, Equatable {
     /// The state of each field at the time of cancellation.
     public let fields: [FieldState]
+    /// Whether the installments screen was presented before the user cancelled.
+    public let installmentsWasPresented: Bool
 
-    public init(fields: [FieldState]) {
+    public init(fields: [FieldState], installmentsWasPresented: Bool = false) {
         self.fields = fields
+        self.installmentsWasPresented = installmentsWasPresented
     }
 }
 

--- a/Sources/MercadoPagoCheckout/Model/Public/UserCancelledContext.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/UserCancelledContext.swift
@@ -10,4 +10,5 @@
 public enum UserCancelledContext: Sendable, Equatable {
     /// The user cancelled during the card form flow.
     case cardForm(CardFormUserCancelledContext)
+    case installments
 }

--- a/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
@@ -122,9 +122,11 @@ struct InstallmentScreen: View {
 
     @ObservedObject private var viewModel: InstallmentsScreenViewModel
     @State var selectedQuota: CardPaymentBrickCardData.Installment.Quota?
+    @State private var hasHandledDismiss = false
 
     private let style: any InstallmentInteractionStyle
     private let onBack: () -> Void
+    private let onDismiss: () -> Void
     private let onFinish: (MPPaymentData) -> Void
     private let onContinue: (MPPaymentData) -> Void
     @Binding private var paymentData: MPPaymentData
@@ -134,6 +136,7 @@ struct InstallmentScreen: View {
         installmentsData: Binding<MPInstallmentsData>,
         style: (any InstallmentInteractionStyle)? = nil,
         onBack: @escaping () -> Void,
+        onDismiss: @escaping () -> Void,
         onFinish: @escaping (MPPaymentData) -> Void = { _ in },
         onContinue: @escaping (MPPaymentData) -> Void = { _ in }
     ) {
@@ -141,6 +144,7 @@ struct InstallmentScreen: View {
         self.viewModel = InstallmentsScreenViewModel(installmentsData: installmentsData)
         self.style = style ?? installmentsData.wrappedValue.installment.resolvedInteractionStyle
         self.onBack = onBack
+        self.onDismiss = onDismiss
         self.onFinish = onFinish
         self.onContinue = onContinue
     }
@@ -149,7 +153,7 @@ struct InstallmentScreen: View {
         MPHeader(
             title: self.viewModel.headerTitle,
             onBack: {
-                self.presentationMode.wrappedValue.dismiss()
+                self.handleBack()
             },
             content: {
                 ForEach(self.viewModel.quotas) { quota in
@@ -160,6 +164,11 @@ struct InstallmentScreen: View {
                 self.footer
             }
         )
+        .onDisappear {
+            if !self.hasHandledDismiss {
+                self.onDismiss()
+            }
+        }
     }
 
     // MARK: - Computed Properties
@@ -192,6 +201,7 @@ struct InstallmentScreen: View {
     }
 
     private func finishWithSelectedQuota() {
+        self.hasHandledDismiss = true
         self.paymentData.installment = self.selectedQuota?.installments
         self.onFinish(self.paymentData)
     }
@@ -209,8 +219,14 @@ struct InstallmentScreen: View {
     }
 
     private func continueWithSelectedQuota(for installment: CardPaymentBrickCardData.Installment.Quota) {
+        self.hasHandledDismiss = true
         self.paymentData.installment = installment.installments
         self.onContinue(self.paymentData)
+    }
+
+    private func handleBack() {
+        self.hasHandledDismiss = true
+        self.onBack()
     }
 }
 
@@ -223,7 +239,8 @@ struct InstallmentScreen: View {
         ),
         installmentsData: .constant(InstallmentMock.visa),
         style: .radioButton,
-        onBack: {}
+        onBack: {},
+        onDismiss: {}
     )
 }
 
@@ -234,7 +251,8 @@ struct InstallmentScreen: View {
         ),
         installmentsData: .constant(InstallmentMock.visa),
         style: .chevron,
-        onBack: {}
+        onBack: {},
+        onDismiss: {}
     )
 }
 

--- a/Tests/SnapshotTests/MercadoPagoCheckout/InstallmentsViewTests.swift
+++ b/Tests/SnapshotTests/MercadoPagoCheckout/InstallmentsViewTests.swift
@@ -19,7 +19,8 @@ final class InstallmentsViewTests: XCTestCase {
             paymentData: Binding(get: { paymentData }, set: { paymentData = $0 }),
             installmentsData: Binding(get: { installmentsData }, set: { installmentsData = $0 }),
             style: .radioButton,
-            onBack: {}
+            onBack: {},
+            onDismiss: {}
         )
 
         assertSnapshot(
@@ -35,7 +36,8 @@ final class InstallmentsViewTests: XCTestCase {
             paymentData: Binding(get: { paymentData }, set: { paymentData = $0 }),
             installmentsData: Binding(get: { installmentsData }, set: { installmentsData = $0 }),
             style: .chevron,
-            onBack: {}
+            onBack: {},
+            onDismiss: {}
         )
 
         assertSnapshot(


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
https://mercadolibre.atlassian.net/browse/CHOBK-3922

## Description
- Added `installmentsWasPresented: Bool` to `CardFormUserCancelledContext`, allowing SDK consumers to know whether the installments screen was shown before the user cancelled
- Added `.installments` case to `UserCancelledContext` enum, enabling proper cancellation reporting when the user dismisses the installments screen
- Added `installmentsWasPresented` state tracking to `CardFormBrickViewModel` via `markInstallmentsPresented()`, called when navigation to the installments screen occurs
- Updated `InstallmentScreen` with an `onDismiss` callback and `hasHandledDismiss` flag to distinguish between explicit back/finish actions and swipe-to-dismiss, preventing double-triggering
- Fixed `CardFormBrick`: installments `onBack` now correctly navigates back via `route = nil` instead of dismissing the full presentation
- Updated snapshot tests to pass the new required `onDismiss` parameter to `InstallmentScreen`

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [x] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>