### PR TITLE
[CHOBK-4006] (Feature): Installments screen accessibility

### DIFF
--- a/Sources/MercadoPagoCheckout/Data/Model/CardPaymentBrickCardResponse.swift
+++ b/Sources/MercadoPagoCheckout/Data/Model/CardPaymentBrickCardResponse.swift
@@ -42,6 +42,7 @@ struct CardPaymentBrickCardResponse: Codable {
             let secondaryLabel: String
             let state: String
             let tertiaryLabel: String?
+            let accessibilityLabel: String?
 
             enum CodingKeys: String, CodingKey {
                 case installments
@@ -51,6 +52,7 @@ struct CardPaymentBrickCardResponse: Codable {
                 case secondaryLabel = "secondary_label"
                 case state
                 case tertiaryLabel = "tertiary_label"
+                case accessibilityLabel = "accessibility_label"
             }
         }
     }

--- a/Sources/MercadoPagoCheckout/Data/Repositories/RemoteCardPaymentBrickCardRepository.swift
+++ b/Sources/MercadoPagoCheckout/Data/Repositories/RemoteCardPaymentBrickCardRepository.swift
@@ -79,7 +79,8 @@ struct RemoteCardPaymentBrickCardRepository: CardPaymentBrickCardRepository {
                     primaryLabel: $0.primaryLabel,
                     secondaryLabel: $0.secondaryLabel,
                     state: .init($0.state),
-                    tertiaryLabel: $0.tertiaryLabel
+                    tertiaryLabel: $0.tertiaryLabel,
+                    accessibilityLabel: $0.accessibilityLabel
                 )
             },
             translations: CardPaymentBrickCardData.Installment.InstallmentTranslations(

--- a/Sources/MercadoPagoCheckout/Model/Internal/CardPaymentBrickCardData.swift
+++ b/Sources/MercadoPagoCheckout/Model/Internal/CardPaymentBrickCardData.swift
@@ -29,6 +29,7 @@ struct CardPaymentBrickCardData: Equatable {
             let secondaryLabel: String
             let state: QuotaState
             let tertiaryLabel: String?
+            let accessibilityLabel: String?
         }
 
         enum QuotaState: Equatable {

--- a/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
@@ -174,16 +174,21 @@ struct InstallmentScreen: View {
     // MARK: - Computed Properties
 
     private func listItem(for quota: CardPaymentBrickCardData.Installment.Quota) -> AnyView {
-        MPListItem(
-            isSelected: self.bindingForQuota(quota),
-            contentInfo: self.viewModel.contentInfo(for: quota),
-            trailing: MPListItemTrailing(
-                text: quota.secondaryLabel,
-                color: self.viewModel.color(for: quota)
+        AnyView(
+            MPListItem(
+                isSelected: self.bindingForQuota(quota),
+                contentInfo: self.viewModel.contentInfo(for: quota),
+                trailing: MPListItemTrailing(
+                    text: quota.secondaryLabel,
+                    color: self.viewModel.color(for: quota)
+                )
             )
+            .listItemStyle(self.style.listItemStyle)
+            .listItemTrailingStyleIfPresent(self.style.listItemTrailingStyle)
+            .accessibilityElement(children: .ignore)
+            .accessibility(addTraits: .isButton)
+            .accessibility(label: quota.accessibilityLabel.map(Text.init) ?? Text(quota.primaryLabel))
         )
-        .listItemStyle(self.style.listItemStyle)
-        .listItemTrailingStyleIfPresent(self.style.listItemTrailingStyle)
     }
 
     private var footer: some View {
@@ -269,7 +274,8 @@ struct InstallmentScreen: View {
                         primaryLabel: "1x R$ 1.000,00",
                         secondaryLabel: "À vista",
                         state: .none,
-                        tertiaryLabel: nil
+                        tertiaryLabel: nil,
+                        accessibilityLabel: nil
                     ),
                     .init(
                         installments: 3,
@@ -278,7 +284,8 @@ struct InstallmentScreen: View {
                         primaryLabel: "3x R$ 333,34",
                         secondaryLabel: "Sem juros",
                         state: .success,
-                        tertiaryLabel: nil
+                        tertiaryLabel: nil,
+                        accessibilityLabel: nil
                     ),
                     .init(
                         installments: 6,
@@ -287,7 +294,8 @@ struct InstallmentScreen: View {
                         primaryLabel: "6x R$ 175,00",
                         secondaryLabel: "R$ 1.050,00",
                         state: .none,
-                        tertiaryLabel: "CFT: 12,5%  TEA: 18,5%"
+                        tertiaryLabel: "CFT: 12,5%  TEA: 18,5%",
+                        accessibilityLabel: nil
                     )
                 ],
                 translations: .init(

--- a/Tests/MercadoPagoCheckoutTests/Data/RemoteCardPaymentBrickCardRepositoryTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Data/RemoteCardPaymentBrickCardRepositoryTests.swift
@@ -48,7 +48,8 @@ final class RemoteCardPaymentBrickCardRepositoryTests: XCTestCase {
                     "primary_label": "3x R$ 33,34",
                     "secondary_label": "Sem juros",
                     "state": "success",
-                    "tertiary_label": "CFT: 12,5%  TEA: 18,5%"
+                    "tertiary_label": "CFT: 12,5%  TEA: 18,5%",
+                    "accessibility_label": "3 parcelas de R$ 33,34, sem acréscimo"
                 },
                 {
                     "installments": 1,
@@ -273,6 +274,32 @@ final class RemoteCardPaymentBrickCardRepositoryTests: XCTestCase {
 
         // Assert — second quota has no tertiary_label
         XCTAssertNil(result.installment?.quotas.last?.tertiaryLabel)
+    }
+
+    func testFetchCard_whenSuccess_mapsQuotaAccessibilityLabel() async throws {
+        // Arrange
+        let sut = self.makeSUT()
+        await sut.session.mock.setData(self.makeValidResponseData())
+        await sut.session.mock.setResponse(self.makeHTTPResponse())
+
+        // Act
+        let result = try await sut.repository.fetchCard(params: self.makeParams())
+
+        // Assert
+        XCTAssertEqual(result.installment?.quotas.first?.accessibilityLabel, "3 parcelas de R$ 33,34, sem acréscimo")
+    }
+
+    func testFetchCard_whenSuccess_mapsQuotaAccessibilityLabelAbsent() async throws {
+        // Arrange
+        let sut = self.makeSUT()
+        await sut.session.mock.setData(self.makeValidResponseData())
+        await sut.session.mock.setResponse(self.makeHTTPResponse())
+
+        // Act
+        let result = try await sut.repository.fetchCard(params: self.makeParams())
+
+        // Assert — second quota has no accessibility_label
+        XCTAssertNil(result.installment?.quotas.last?.accessibilityLabel)
     }
 
     func testFetchCard_whenSuccess_mapsInstallmentTranslations() async throws {

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/InstallmentsScreenViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/InstallmentsScreenViewModelTests.swift
@@ -133,7 +133,8 @@ extension CardPaymentBrickCardData.Installment.Quota {
         primaryLabel: String = "1x R$ 1.000,00",
         secondaryLabel: String = "À vista",
         state: CardPaymentBrickCardData.Installment.QuotaState = .none,
-        tertiaryLabel: String? = nil
+        tertiaryLabel: String? = nil,
+        accessibilityLabel: String? = nil
     ) -> CardPaymentBrickCardData.Installment.Quota {
         .init(
             installments: installments,
@@ -142,7 +143,8 @@ extension CardPaymentBrickCardData.Installment.Quota {
             primaryLabel: primaryLabel,
             secondaryLabel: secondaryLabel,
             state: state,
-            tertiaryLabel: tertiaryLabel
+            tertiaryLabel: tertiaryLabel,
+            accessibilityLabel: accessibilityLabel
         )
     }
 }

--- a/Tests/SnapshotTests/MercadoPagoCheckout/InstallmentsViewTests.swift
+++ b/Tests/SnapshotTests/MercadoPagoCheckout/InstallmentsViewTests.swift
@@ -59,7 +59,8 @@ final class InstallmentsViewTests: XCTestCase {
                     primaryLabel: "1x R$ 1.000,00",
                     secondaryLabel: "À vista",
                     state: .none,
-                    tertiaryLabel: nil
+                    tertiaryLabel: nil,
+                    accessibilityLabel: nil
                 ),
                 .init(
                     installments: 2,
@@ -68,7 +69,8 @@ final class InstallmentsViewTests: XCTestCase {
                     primaryLabel: "2x R$ 548,20",
                     secondaryLabel: "R$ 1.096,40",
                     state: .none,
-                    tertiaryLabel: nil
+                    tertiaryLabel: nil,
+                    accessibilityLabel: nil
                 ),
                 .init(
                     installments: 3,
@@ -77,7 +79,8 @@ final class InstallmentsViewTests: XCTestCase {
                     primaryLabel: "3x R$ 370,77",
                     secondaryLabel: "Sem juros",
                     state: .success,
-                    tertiaryLabel: nil
+                    tertiaryLabel: nil,
+                    accessibilityLabel: nil
                 )
             ],
             translations: .init(


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
https://mercadolibre.atlassian.net/browse/CHOBK-4006

## Description
- Added `accessibility_label` field to the BFF response model (`CardPaymentBrickCardResponse`) and internal data model (`CardPaymentBrickCardData.Quota`), decoded from `accessibility_label` in the API response
- Mapped `accessibilityLabel` through `RemoteCardPaymentBrickCardRepository` to propagate the BFF label into the domain layer
- Updated `InstallmentScreen` list items to expose a VoiceOver-accessible element: applies `.accessibilityElement(children: .ignore)`, `.accessibility(addTraits: .isButton)`, and `.accessibility(label:)` using the BFF-provided `accessibilityLabel` with fallback to `primaryLabel`

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [x] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
 

https://github.com/user-attachments/assets/0c1818cd-e2d9-4c0b-bae8-6008aae29515

