### PR TITLE
(Fix): Show snackbar immediately on BIN fetch network error

### DIFF
--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -111,7 +111,8 @@ struct CardFormScreen: View {
                         liveErrorMessage: self.cardForm.cardNumberLiveErrors,
                         keyboard: .numberPad,
                         onEditingChanged: { isEditing in
-                            if !isEditing, self.editedFields.contains(.cardNumber) || !self.cardForm.$cardNumber.isEmpty {
+                            if !isEditing, !self.didTapBack,
+                               self.editedFields.contains(.cardNumber) || !self.cardForm.$cardNumber.isEmpty {
                                 self.viewModel.cardNumberEditingEnded(isValid: self.cardForm.$cardNumber.isEmpty)
                             }
                         },

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -184,6 +184,7 @@ final class CardFormViewModel: ObservableObject {
         self.cardData = nil
         self.cardAcceptanceError = nil
         self.binNetworkError = nil
+        self.showSnackbar = false
 
         guard let bin else { return }
 
@@ -228,6 +229,7 @@ final class CardFormViewModel: ObservableObject {
             guard let code = error.serviceError?.errorCode.flatMap(CheckoutAPIErrorCode.init),
                   CheckoutAPIErrorCode.binValidation.contains(code) else {
                 self.binNetworkError = error
+                if error.isRetriable { self.showSnackbar = true }
                 return
             }
             switch code {


### PR DESCRIPTION
## O que foi feito

- `CardFormViewModel.onCardNumberChange`: limpa `showSnackbar` junto com os outros estados do BIN, evitando que um snackbar antigo persista quando o usuário digita um novo BIN.
- `CardFormViewModel.fetchBinData`: agora dispara `showSnackbar = true` imediatamente no catch quando o erro de rede é retentável (mesma condição já usada no `retryBinFetch`). Antes, o snackbar só aparecia depois que o campo perdia foco, o que dava a sensação de que o erro só surgia "quando o teclado abaixava".
- `CardFormScreen` (campo do número do cartão): `onEditingChanged` agora ignora o evento de perda de foco quando `didTapBack == true`, evitando uma chamada extra de BIN no caminho de saída da tela.

## Como testar

- [ ] Abrir CardFormBrick e digitar 8 dígitos com BIN que retorna 500/timeout/conexão → snackbar aparece **imediatamente** com o teclado aberto, sem precisar tirar foco do campo.
- [ ] Apagar/redigitar o BIN → snackbar antigo some no momento do reset.
- [ ] Disparar erro de BIN, tocar back → não acontece nova chamada de BIN no caminho de saída.
- [ ] Validar erros de validação (PAYMENT_METHOD_UNAVAILABLE etc.) continuam exibindo o erro inline no campo, sem snackbar.

## Checklist

- [x] I have tested my changes creating a local version
- [x] New and existing unit tests pass locally
- [x] I have run swiftlint and fixed any possible issues