### PR TITLE
[CHOBK-3927] (Feature): Installments screen analytics tracks

### DIFF
--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -124,6 +124,7 @@ struct CardFormBrick: View {
         InstallmentScreen(
             paymentData: self.$paymentData,
             installmentsData: self.$installmentsData,
+            checkoutType: self.configuration.type.analyticsValue,
             onBack: {
                 self.route = nil
             },

--- a/Sources/MercadoPagoCheckout/Domain/Analytics/InstallmentAnalyticsPath.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Analytics/InstallmentAnalyticsPath.swift
@@ -1,0 +1,6 @@
+enum InstallmentAnalyticsPath {
+    static let initialize = "/checkout_api_native/checkout/installments/initialize"
+    static let selected = "/checkout_api_native/checkout/installments/selected"
+    static let submit = "/checkout_api_native/checkout/installments/submit"
+    static let userCanceledError = "/checkout_api_native/checkout/installments/user_canceled_error"
+}

--- a/Sources/MercadoPagoCheckout/Domain/Analytics/InstallmentCanceledErrorEventData.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Analytics/InstallmentCanceledErrorEventData.swift
@@ -1,0 +1,9 @@
+import MPAnalytics
+
+struct InstallmentCanceledErrorEventData: AnalyticsEventData {
+    let errorType: String
+
+    func toDictionary() -> [String: any Sendable] {
+        ["error_type": self.errorType]
+    }
+}

--- a/Sources/MercadoPagoCheckout/Domain/Analytics/InstallmentInitializeEventData.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Analytics/InstallmentInitializeEventData.swift
@@ -2,6 +2,7 @@ import MPAnalytics
 
 struct InstallmentInitializeEventData: AnalyticsEventData {
     let checkoutType: String
+    let paymentMethodId: String
     let paymentType: String
     let selectionType: String
     let quotasCount: Int
@@ -10,6 +11,7 @@ struct InstallmentInitializeEventData: AnalyticsEventData {
     func toDictionary() -> [String: any Sendable] {
         var dict: [String: any Sendable] = [
             "checkout_type": self.checkoutType,
+            "payment_method_id": self.paymentMethodId,
             "payment_type": self.paymentType,
             "selection_type": self.selectionType,
             "quotas_count": self.quotasCount

--- a/Sources/MercadoPagoCheckout/Domain/Analytics/InstallmentInitializeEventData.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Analytics/InstallmentInitializeEventData.swift
@@ -1,0 +1,20 @@
+import MPAnalytics
+
+struct InstallmentInitializeEventData: AnalyticsEventData {
+    let checkoutType: String
+    let paymentType: String
+    let selectionType: String
+    let quotasCount: Int
+    let transactionAmount: Double?
+
+    func toDictionary() -> [String: any Sendable] {
+        var dict: [String: any Sendable] = [
+            "checkout_type": self.checkoutType,
+            "payment_type": self.paymentType,
+            "selection_type": self.selectionType,
+            "quotas_count": self.quotasCount
+        ]
+        if let transactionAmount { dict["transaction_amount"] = transactionAmount }
+        return dict
+    }
+}

--- a/Sources/MercadoPagoCheckout/Domain/Analytics/InstallmentSelectedEventData.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Analytics/InstallmentSelectedEventData.swift
@@ -1,0 +1,9 @@
+import MPAnalytics
+
+struct InstallmentSelectedEventData: AnalyticsEventData {
+    let installments: Int
+
+    func toDictionary() -> [String: any Sendable] {
+        ["installments": self.installments]
+    }
+}

--- a/Sources/MercadoPagoCheckout/Domain/Analytics/InstallmentSubmitEventData.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Analytics/InstallmentSubmitEventData.swift
@@ -1,0 +1,15 @@
+import MPAnalytics
+
+struct InstallmentSubmitEventData: AnalyticsEventData {
+    let installments: Int
+    let installmentAmount: Double
+    let totalAmount: Double
+
+    func toDictionary() -> [String: any Sendable] {
+        [
+            "installments": self.installments,
+            "installment_amount": self.installmentAmount,
+            "total_amount": self.totalAmount
+        ]
+    }
+}

--- a/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
@@ -134,6 +134,7 @@ struct InstallmentScreen: View {
     init(
         paymentData: Binding<MPPaymentData>,
         installmentsData: Binding<MPInstallmentsData>,
+        checkoutType: String,
         style: (any InstallmentInteractionStyle)? = nil,
         onBack: @escaping () -> Void,
         onDismiss: @escaping () -> Void,
@@ -142,7 +143,7 @@ struct InstallmentScreen: View {
     ) {
         self._paymentData = paymentData
         self._selectedQuota = State(initialValue: installmentsData.wrappedValue.installment.quotas.first)
-        self.viewModel = InstallmentsScreenViewModel(installmentsData: installmentsData)
+        self.viewModel = InstallmentsScreenViewModel(installmentsData: installmentsData, checkoutType: checkoutType)
         self.style = style ?? installmentsData.wrappedValue.installment.resolvedInteractionStyle
         self.onBack = onBack
         self.onDismiss = onDismiss
@@ -165,8 +166,12 @@ struct InstallmentScreen: View {
                 self.footer
             }
         )
+        .onAppear {
+            self.viewModel.trackInitialize(transactionAmount: self.paymentData.transactionAmount)
+        }
         .onDisappear {
             if !self.hasHandledDismiss {
+                self.viewModel.trackCanceledError(errorType: "user_dismissed")
                 self.onDismiss()
             }
         }
@@ -208,6 +213,7 @@ struct InstallmentScreen: View {
 
     private func finishWithSelectedQuota() {
         self.hasHandledDismiss = true
+        self.viewModel.trackSubmit(self.selectedQuota)
         self.paymentData.installment = self.selectedQuota?.installments
         self.onFinish(self.paymentData)
     }
@@ -219,6 +225,7 @@ struct InstallmentScreen: View {
             for: quota,
             selected: self.$selectedQuota,
             onContinue: {
+                self.viewModel.trackSelected(quota)
                 self.continueWithSelectedQuota(for: quota)
             }
         )
@@ -226,12 +233,14 @@ struct InstallmentScreen: View {
 
     private func continueWithSelectedQuota(for installment: CardPaymentBrickCardData.Installment.Quota) {
         self.hasHandledDismiss = true
+        self.viewModel.trackSubmit(installment)
         self.paymentData.installment = installment.installments
         self.onContinue(self.paymentData)
     }
 
     private func handleBack() {
         self.hasHandledDismiss = true
+        self.viewModel.trackCanceledError(errorType: "back_pressed")
         self.onBack()
     }
 }
@@ -244,6 +253,7 @@ struct InstallmentScreen: View {
             MPPaymentData(transactionAmount: 100)
         ),
         installmentsData: .constant(InstallmentMock.visa),
+        checkoutType: "",
         style: .radioButton,
         onBack: {},
         onDismiss: {}
@@ -256,6 +266,7 @@ struct InstallmentScreen: View {
             MPPaymentData(transactionAmount: 100)
         ),
         installmentsData: .constant(InstallmentMock.visa),
+        checkoutType: "",
         style: .chevron,
         onBack: {},
         onDismiss: {}

--- a/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
@@ -167,7 +167,10 @@ struct InstallmentScreen: View {
             }
         )
         .onAppear {
-            self.viewModel.trackInitialize(transactionAmount: self.paymentData.transactionAmount)
+            self.viewModel.trackInitialize(
+                transactionAmount: self.paymentData.transactionAmount,
+                paymentMethodId: self.paymentData.paymentMethodId
+            )
         }
         .onDisappear {
             if !self.hasHandledDismiss {

--- a/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
@@ -14,6 +14,7 @@ import SwiftUI
 protocol InstallmentInteractionStyle {
     var listItemStyle: MPListItemStyle { get }
     var listItemTrailingStyle: MPListItemTrailingStyle? { get }
+    var sendsSelectionEvent: Bool { get }
 
     func footerButtonData(_ label: String, onContinue: @escaping () -> Void) -> MPFixedFooterButtonData?
 
@@ -33,6 +34,10 @@ struct RadioButtonInstallmentStyle: InstallmentInteractionStyle {
 
     var listItemTrailingStyle: MPListItemTrailingStyle? {
         nil
+    }
+
+    var sendsSelectionEvent: Bool {
+        true
     }
 
     func footerButtonData(_ label: String, onContinue: @escaping () -> Void) -> MPFixedFooterButtonData? {
@@ -58,6 +63,10 @@ struct ChevronInstallmentStyle: InstallmentInteractionStyle {
 
     var listItemTrailingStyle: MPListItemTrailingStyle? {
         .textIcon(Image(systemName: "chevron.right"))
+    }
+
+    var sendsSelectionEvent: Bool {
+        false
     }
 
     func footerButtonData(_: String, onContinue _: @escaping () -> Void) -> MPFixedFooterButtonData? {
@@ -224,12 +233,18 @@ struct InstallmentScreen: View {
     // MARK: - Helper Methods
 
     private func bindingForQuota(_ quota: CardPaymentBrickCardData.Installment.Quota) -> Binding<Bool> {
-        self.style.selectionBinding(
+        let inner = self.style.selectionBinding(
             for: quota,
             selected: self.$selectedQuota,
             onContinue: {
-                self.viewModel.trackSelected(quota)
                 self.continueWithSelectedQuota(for: quota)
+            }
+        )
+        return Binding(
+            get: { inner.wrappedValue },
+            set: { newValue in
+                if newValue, self.style.sendsSelectionEvent { self.viewModel.trackSelected(quota) }
+                inner.wrappedValue = newValue
             }
         )
     }

--- a/Sources/MercadoPagoCheckout/Views/InstallmentScreenViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/InstallmentScreenViewModel.swift
@@ -87,9 +87,10 @@ final class InstallmentsScreenViewModel: ObservableObject {
 
     // MARK: - Analytics
 
-    func trackInitialize(transactionAmount: Double?) {
+    func trackInitialize(transactionAmount: Double?, paymentMethodId: String) {
         let eventData = InstallmentInitializeEventData(
             checkoutType: self.checkoutType,
+            paymentMethodId: paymentMethodId,
             paymentType: self.installmentsData.cardDisplayInfo.paymentTypeId,
             selectionType: self.installmentsData.installment.selectionType,
             quotasCount: self.installmentsData.installment.quotas.count,

--- a/Sources/MercadoPagoCheckout/Views/InstallmentScreenViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/InstallmentScreenViewModel.swift
@@ -5,15 +5,28 @@
 //  Created by Danielle Nozaki Ogawa on 28/01/26.
 //
 
+import MPAnalytics
 import MPComponents
+import MPCore
 import MPFoundation
 import SwiftUI
 
+@MainActor
 final class InstallmentsScreenViewModel: ObservableObject {
     @Binding var installmentsData: MPInstallmentsData
 
-    init(installmentsData: Binding<MPInstallmentsData>) {
+    private let checkoutType: String
+    private let analytics: AnalyticsInterface
+    private var analyticsTask: Task<Void, Never>?
+
+    init(
+        installmentsData: Binding<MPInstallmentsData>,
+        checkoutType: String,
+        analytics: AnalyticsInterface = CoreDependencyContainer.shared.analytics
+    ) {
         self._installmentsData = installmentsData
+        self.checkoutType = checkoutType
+        self.analytics = analytics
     }
 
     // MARK: - Computed Properties
@@ -70,5 +83,63 @@ final class InstallmentsScreenViewModel: ObservableObject {
             MPFormatIssuerName.cleanIssuerName(info.issuerName ?? String())
         )
         return "\(issuerName) **** \(info.lastFourDigits)"
+    }
+
+    // MARK: - Analytics
+
+    func trackInitialize(transactionAmount: Double?) {
+        let eventData = InstallmentInitializeEventData(
+            checkoutType: self.checkoutType,
+            paymentType: self.installmentsData.cardDisplayInfo.paymentTypeId,
+            selectionType: self.installmentsData.installment.selectionType,
+            quotasCount: self.installmentsData.installment.quotas.count,
+            transactionAmount: transactionAmount
+        )
+        let analytics = self.analytics
+        Task(priority: .low) {
+            await analytics.trackEvent(InstallmentAnalyticsPath.initialize)
+                .setEventData(eventData)
+                .send()
+        }
+    }
+
+    func trackSelected(_ quota: CardPaymentBrickCardData.Installment.Quota) {
+        let eventData = InstallmentSelectedEventData(installments: quota.installments)
+        self.enqueueAnalytics { [analytics = self.analytics] in
+            await analytics.trackEvent(InstallmentAnalyticsPath.selected)
+                .setEventData(eventData)
+                .send()
+        }
+    }
+
+    func trackSubmit(_ quota: CardPaymentBrickCardData.Installment.Quota?) {
+        guard let quota else { return }
+        let eventData = InstallmentSubmitEventData(
+            installments: quota.installments,
+            installmentAmount: quota.installmentAmount,
+            totalAmount: quota.totalAmount
+        )
+        self.enqueueAnalytics { [analytics = self.analytics] in
+            await analytics.trackEvent(InstallmentAnalyticsPath.submit)
+                .setEventData(eventData)
+                .send()
+        }
+    }
+
+    func trackCanceledError(errorType: String) {
+        let eventData = InstallmentCanceledErrorEventData(errorType: errorType)
+        self.enqueueAnalytics { [analytics = self.analytics] in
+            await analytics.trackEvent(InstallmentAnalyticsPath.userCanceledError)
+                .setEventData(eventData)
+                .send()
+        }
+    }
+
+    private func enqueueAnalytics(_ block: @escaping @Sendable () async -> Void) {
+        let previous = self.analyticsTask
+        self.analyticsTask = Task {
+            await previous?.value
+            await block()
+        }
     }
 }

--- a/Tests/MercadoPagoCheckoutTests/Domain/Analytics/InstallmentAnalyticsEventDataTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Domain/Analytics/InstallmentAnalyticsEventDataTests.swift
@@ -1,0 +1,157 @@
+//
+//  InstallmentAnalyticsEventDataTests.swift
+//  MercadoPagoSDK
+//
+
+import Foundation
+@testable import MercadoPagoCheckout
+import XCTest
+
+@MainActor
+final class InstallmentAnalyticsEventDataTests: XCTestCase {
+    // MARK: - InstallmentInitializeEventData
+
+    func test_installmentInitializeEventData_toDictionary_shouldContainAllKeys() {
+        // Arrange
+        let sut = InstallmentInitializeEventData(
+            checkoutType: "card_payment_brick",
+            paymentType: "credit_card",
+            selectionType: "radio_button",
+            quotasCount: 6,
+            transactionAmount: 500.0
+        )
+
+        // Act
+        let dict = sut.toDictionary()
+
+        // Assert
+        XCTAssertEqual(dict["checkout_type"] as? String, "card_payment_brick")
+        XCTAssertEqual(dict["payment_type"] as? String, "credit_card")
+        XCTAssertEqual(dict["selection_type"] as? String, "radio_button")
+        XCTAssertEqual(dict["quotas_count"] as? Int, 6)
+        XCTAssertEqual(dict["transaction_amount"] as? Double, 500.0)
+    }
+
+    func test_installmentInitializeEventData_withNilTransactionAmount_shouldOmitTransactionAmount() {
+        // Arrange
+        let sut = InstallmentInitializeEventData(
+            checkoutType: "card_payment_brick",
+            paymentType: "debit_card",
+            selectionType: "chevron",
+            quotasCount: 3,
+            transactionAmount: nil
+        )
+
+        // Act
+        let dict = sut.toDictionary()
+
+        // Assert
+        XCTAssertNil(dict["transaction_amount"])
+        XCTAssertEqual(dict["payment_type"] as? String, "debit_card")
+        XCTAssertEqual(dict["quotas_count"] as? Int, 3)
+    }
+
+    func test_installmentInitializeEventData_withChevronSelectionType_shouldContainChevron() {
+        // Arrange
+        let sut = InstallmentInitializeEventData(
+            checkoutType: "card_payment_brick",
+            paymentType: "credit_card",
+            selectionType: "chevron",
+            quotasCount: 4,
+            transactionAmount: nil
+        )
+
+        // Act
+        let dict = sut.toDictionary()
+
+        // Assert
+        XCTAssertEqual(dict["selection_type"] as? String, "chevron")
+    }
+
+    // MARK: - InstallmentSelectedEventData
+
+    func test_installmentSelectedEventData_toDictionary_shouldContainInstallments() {
+        // Arrange
+        let sut = InstallmentSelectedEventData(installments: 3)
+
+        // Act
+        let dict = sut.toDictionary()
+
+        // Assert
+        XCTAssertEqual(dict["installments"] as? Int, 3)
+    }
+
+    func test_installmentSelectedEventData_singleInstallment_shouldReturnOne() {
+        // Arrange
+        let sut = InstallmentSelectedEventData(installments: 1)
+
+        // Act
+        let dict = sut.toDictionary()
+
+        // Assert
+        XCTAssertEqual(dict["installments"] as? Int, 1)
+        XCTAssertEqual(dict.keys.count, 1)
+    }
+
+    // MARK: - InstallmentSubmitEventData
+
+    func test_installmentSubmitEventData_toDictionary_shouldContainAllKeys() {
+        // Arrange
+        let sut = InstallmentSubmitEventData(
+            installments: 3,
+            installmentAmount: 333.34,
+            totalAmount: 1000.0
+        )
+
+        // Act
+        let dict = sut.toDictionary()
+
+        // Assert
+        XCTAssertEqual(dict["installments"] as? Int, 3)
+        XCTAssertEqual(dict["installment_amount"] as? Double, 333.34)
+        XCTAssertEqual(dict["total_amount"] as? Double, 1000.0)
+    }
+
+    func test_installmentSubmitEventData_singleInstallment_shouldContainAllFields() {
+        // Arrange
+        let sut = InstallmentSubmitEventData(
+            installments: 1,
+            installmentAmount: 1000.0,
+            totalAmount: 1000.0
+        )
+
+        // Act
+        let dict = sut.toDictionary()
+
+        // Assert
+        XCTAssertEqual(dict["installments"] as? Int, 1)
+        XCTAssertEqual(dict["installment_amount"] as? Double, 1000.0)
+        XCTAssertEqual(dict["total_amount"] as? Double, 1000.0)
+    }
+
+    // MARK: - InstallmentCanceledErrorEventData
+
+    func test_installmentCanceledErrorEventData_backPressed_shouldContainOnlyErrorType() {
+        // Arrange
+        let sut = InstallmentCanceledErrorEventData(errorType: "back_pressed")
+
+        // Act
+        let dict = sut.toDictionary()
+
+        // Assert
+        XCTAssertEqual(dict["error_type"] as? String, "back_pressed")
+        XCTAssertEqual(dict.keys.count, 1)
+    }
+
+    func test_installmentCanceledErrorEventData_userDismissed_shouldContainOnlyErrorType() {
+        // Arrange
+        let sut = InstallmentCanceledErrorEventData(errorType: "user_dismissed")
+
+        // Act
+        let dict = sut.toDictionary()
+
+        // Assert
+        XCTAssertEqual(dict["error_type"] as? String, "user_dismissed")
+        XCTAssertEqual(dict.keys.count, 1)
+    }
+}

--- a/Tests/MercadoPagoCheckoutTests/Domain/Analytics/InstallmentAnalyticsEventDataTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Domain/Analytics/InstallmentAnalyticsEventDataTests.swift
@@ -15,6 +15,7 @@ final class InstallmentAnalyticsEventDataTests: XCTestCase {
         // Arrange
         let sut = InstallmentInitializeEventData(
             checkoutType: "card_payment_brick",
+            paymentMethodId: "visa",
             paymentType: "credit_card",
             selectionType: "radio_button",
             quotasCount: 6,
@@ -26,6 +27,7 @@ final class InstallmentAnalyticsEventDataTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(dict["checkout_type"] as? String, "card_payment_brick")
+        XCTAssertEqual(dict["payment_method_id"] as? String, "visa")
         XCTAssertEqual(dict["payment_type"] as? String, "credit_card")
         XCTAssertEqual(dict["selection_type"] as? String, "radio_button")
         XCTAssertEqual(dict["quotas_count"] as? Int, 6)
@@ -36,6 +38,7 @@ final class InstallmentAnalyticsEventDataTests: XCTestCase {
         // Arrange
         let sut = InstallmentInitializeEventData(
             checkoutType: "card_payment_brick",
+            paymentMethodId: "master",
             paymentType: "debit_card",
             selectionType: "chevron",
             quotasCount: 3,
@@ -47,6 +50,7 @@ final class InstallmentAnalyticsEventDataTests: XCTestCase {
 
         // Assert
         XCTAssertNil(dict["transaction_amount"])
+        XCTAssertEqual(dict["payment_method_id"] as? String, "master")
         XCTAssertEqual(dict["payment_type"] as? String, "debit_card")
         XCTAssertEqual(dict["quotas_count"] as? Int, 3)
     }
@@ -55,6 +59,7 @@ final class InstallmentAnalyticsEventDataTests: XCTestCase {
         // Arrange
         let sut = InstallmentInitializeEventData(
             checkoutType: "card_payment_brick",
+            paymentMethodId: "visa",
             paymentType: "credit_card",
             selectionType: "chevron",
             quotasCount: 4,

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/InstallmentsScreenViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/InstallmentsScreenViewModelTests.swift
@@ -11,6 +11,7 @@
 import SwiftUI
 import XCTest
 
+@MainActor
 final class InstallmentsScreenViewModelTests: XCTestCase {
     // MARK: - selectedTotalAmount
 
@@ -118,7 +119,10 @@ final class InstallmentsScreenViewModelTests: XCTestCase {
         installmentsData: MPInstallmentsData = .validMPInstallmentsData
     ) -> InstallmentsScreenViewModel {
         var data = installmentsData
-        return InstallmentsScreenViewModel(installmentsData: Binding(get: { data }, set: { data = $0 }))
+        return InstallmentsScreenViewModel(
+            installmentsData: Binding(get: { data }, set: { data = $0 }),
+            checkoutType: "card_payment_brick"
+        )
     }
 }
 

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/InstallmentsScreenViewModelTrackingTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/InstallmentsScreenViewModelTrackingTests.swift
@@ -40,7 +40,7 @@ final class InstallmentsScreenViewModelTrackingTests: XCTestCase {
         let sut = self.makeSUT()
 
         // Act
-        sut.viewModel.trackInitialize(transactionAmount: nil)
+        sut.viewModel.trackInitialize(transactionAmount: nil, paymentMethodId: "visa")
         await sut.analytics.mock.waitForSend()
 
         // Assert
@@ -54,13 +54,14 @@ final class InstallmentsScreenViewModelTrackingTests: XCTestCase {
         let sut = self.makeSUT(checkoutType: "card_payment_brick")
 
         // Act
-        sut.viewModel.trackInitialize(transactionAmount: 500.0)
+        sut.viewModel.trackInitialize(transactionAmount: 500.0, paymentMethodId: "visa")
         await sut.analytics.mock.waitForSend()
 
         // Assert
         let messages = await sut.analytics.mock.getMessages()
         XCTAssertTrue(messages.contains(.setEventData([
             "checkout_type": "card_payment_brick",
+            "payment_method_id": "visa",
             "payment_type": "credit_card",
             "selection_type": "radio_button",
             "quotas_count": 3,
@@ -73,7 +74,7 @@ final class InstallmentsScreenViewModelTrackingTests: XCTestCase {
         let sut = self.makeSUT()
 
         // Act
-        sut.viewModel.trackInitialize(transactionAmount: nil)
+        sut.viewModel.trackInitialize(transactionAmount: nil, paymentMethodId: "visa")
         await sut.analytics.mock.waitForSend()
 
         // Assert

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/InstallmentsScreenViewModelTrackingTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/InstallmentsScreenViewModelTrackingTests.swift
@@ -1,0 +1,231 @@
+//
+//  InstallmentsScreenViewModelTrackingTests.swift
+//  MercadoPagoSDK
+//
+
+import CommonTests
+@testable import MercadoPagoCheckout
+import SwiftUI
+import XCTest
+
+@MainActor
+final class InstallmentsScreenViewModelTrackingTests: XCTestCase {
+    // MARK: - Types
+
+    typealias SUT = (
+        viewModel: InstallmentsScreenViewModel,
+        analytics: MockAnalytics
+    )
+
+    // MARK: - Helpers
+
+    private func makeSUT(
+        checkoutType: String = "card_payment_brick",
+        installmentsData: MPInstallmentsData = .validMPInstallmentsData
+    ) -> SUT {
+        let analytics = MockAnalytics()
+        var data = installmentsData
+        let viewModel = InstallmentsScreenViewModel(
+            installmentsData: Binding(get: { data }, set: { data = $0 }),
+            checkoutType: checkoutType,
+            analytics: analytics
+        )
+        return (viewModel, analytics)
+    }
+
+    // MARK: - trackInitialize
+
+    func test_trackInitialize_shouldTrackInitializePath() async {
+        // Arrange
+        let sut = self.makeSUT()
+
+        // Act
+        sut.viewModel.trackInitialize(transactionAmount: nil)
+        await sut.analytics.mock.waitForSend()
+
+        // Assert
+        let messages = await sut.analytics.mock.getMessages()
+        XCTAssertTrue(messages.contains(.track(path: InstallmentAnalyticsPath.initialize)))
+        XCTAssertTrue(messages.contains(.send))
+    }
+
+    func test_trackInitialize_shouldSendAllFields() async {
+        // Arrange
+        let sut = self.makeSUT(checkoutType: "card_payment_brick")
+
+        // Act
+        sut.viewModel.trackInitialize(transactionAmount: 500.0)
+        await sut.analytics.mock.waitForSend()
+
+        // Assert
+        let messages = await sut.analytics.mock.getMessages()
+        XCTAssertTrue(messages.contains(.setEventData([
+            "checkout_type": "card_payment_brick",
+            "payment_type": "credit_card",
+            "selection_type": "radio_button",
+            "quotas_count": 3,
+            "transaction_amount": 500.0
+        ])))
+    }
+
+    func test_trackInitialize_withNilTransactionAmount_shouldOmitTransactionAmount() async {
+        // Arrange
+        let sut = self.makeSUT()
+
+        // Act
+        sut.viewModel.trackInitialize(transactionAmount: nil)
+        await sut.analytics.mock.waitForSend()
+
+        // Assert
+        let messages = await sut.analytics.mock.getMessages()
+        let hasTransactionAmount = messages.contains { msg in
+            if case let .setEventData(dict) = msg {
+                return dict.keys.contains("transaction_amount")
+            }
+            return false
+        }
+        XCTAssertFalse(hasTransactionAmount)
+    }
+
+    // MARK: - trackSelected
+
+    func test_trackSelected_shouldTrackSelectedPath() async {
+        // Arrange
+        let sut = self.makeSUT()
+        let quota = CardPaymentBrickCardData.Installment.Quota.make(installments: 3)
+
+        // Act
+        sut.viewModel.trackSelected(quota)
+        await sut.analytics.mock.waitForSend()
+
+        // Assert
+        let messages = await sut.analytics.mock.getMessages()
+        XCTAssertTrue(messages.contains(.track(path: InstallmentAnalyticsPath.selected)))
+        XCTAssertTrue(messages.contains(.send))
+    }
+
+    func test_trackSelected_shouldSendInstallmentsCount() async {
+        // Arrange
+        let sut = self.makeSUT()
+        let quota = CardPaymentBrickCardData.Installment.Quota.make(installments: 6)
+
+        // Act
+        sut.viewModel.trackSelected(quota)
+        await sut.analytics.mock.waitForSend()
+
+        // Assert
+        let messages = await sut.analytics.mock.getMessages()
+        XCTAssertTrue(messages.contains(.setEventData(["installments": 6])))
+    }
+
+    // MARK: - trackSubmit
+
+    func test_trackSubmit_shouldTrackSubmitPath() async {
+        // Arrange
+        let sut = self.makeSUT()
+        let quota = CardPaymentBrickCardData.Installment.Quota.make(
+            installments: 3,
+            installmentAmount: 333.34,
+            totalAmount: 1000.0
+        )
+
+        // Act
+        sut.viewModel.trackSubmit(quota)
+        await sut.analytics.mock.waitForSend()
+
+        // Assert
+        let messages = await sut.analytics.mock.getMessages()
+        XCTAssertTrue(messages.contains(.track(path: InstallmentAnalyticsPath.submit)))
+        XCTAssertTrue(messages.contains(.send))
+    }
+
+    func test_trackSubmit_shouldSendInstallmentData() async {
+        // Arrange
+        let sut = self.makeSUT()
+        let quota = CardPaymentBrickCardData.Installment.Quota.make(
+            installments: 3,
+            installmentAmount: 333.34,
+            totalAmount: 1000.0
+        )
+
+        // Act
+        sut.viewModel.trackSubmit(quota)
+        await sut.analytics.mock.waitForSend()
+
+        // Assert
+        let messages = await sut.analytics.mock.getMessages()
+        XCTAssertTrue(messages.contains(.setEventData([
+            "installments": 3,
+            "installment_amount": 333.34,
+            "total_amount": 1000.0
+        ])))
+    }
+
+    // MARK: - trackCanceledError
+
+    func test_trackCanceledError_shouldTrackUserCanceledErrorPath() async {
+        // Arrange
+        let sut = self.makeSUT()
+
+        // Act
+        sut.viewModel.trackCanceledError(errorType: "back_pressed")
+        await sut.analytics.mock.waitForSend()
+
+        // Assert
+        let messages = await sut.analytics.mock.getMessages()
+        XCTAssertTrue(messages.contains(.track(path: InstallmentAnalyticsPath.userCanceledError)))
+        XCTAssertTrue(messages.contains(.send))
+    }
+
+    func test_trackCanceledError_backPressed_shouldSendBackPressedErrorType() async {
+        // Arrange
+        let sut = self.makeSUT()
+
+        // Act
+        sut.viewModel.trackCanceledError(errorType: "back_pressed")
+        await sut.analytics.mock.waitForSend()
+
+        // Assert
+        let messages = await sut.analytics.mock.getMessages()
+        XCTAssertTrue(messages.contains(.setEventData(["error_type": "back_pressed"])))
+    }
+
+    func test_trackCanceledError_userDismissed_shouldSendUserDismissedErrorType() async {
+        // Arrange
+        let sut = self.makeSUT()
+
+        // Act
+        sut.viewModel.trackCanceledError(errorType: "user_dismissed")
+        await sut.analytics.mock.waitForSend()
+
+        // Assert
+        let messages = await sut.analytics.mock.getMessages()
+        XCTAssertTrue(messages.contains(.setEventData(["error_type": "user_dismissed"])))
+    }
+
+    // MARK: - Chevron: selected + submit in same tap
+
+    func test_chevronTap_shouldFireSelectedThenSubmit() async {
+        // Arrange
+        let sut = self.makeSUT()
+        let quota = CardPaymentBrickCardData.Installment.Quota.make(installments: 3)
+
+        // Act — simulates a Chevron tap: selected fires first, then submit
+        sut.viewModel.trackSelected(quota)
+        sut.viewModel.trackSubmit(quota)
+        await sut.analytics.mock.waitForSend(count: 2)
+
+        // Assert — selected arrives before submit
+        let messages = await sut.analytics.mock.getMessages()
+        let sendIndices = messages.indices.filter { messages[$0] == .send }
+        XCTAssertEqual(sendIndices.count, 2)
+
+        let firstGroup = Array(messages[0 ..< sendIndices[0]])
+        XCTAssertTrue(firstGroup.contains(.track(path: InstallmentAnalyticsPath.selected)))
+        XCTAssertFalse(firstGroup.contains(.track(path: InstallmentAnalyticsPath.submit)))
+
+        let secondGroup = Array(messages[(sendIndices[0] + 1) ..< sendIndices[1]])
+        XCTAssertTrue(secondGroup.contains(.track(path: InstallmentAnalyticsPath.submit)))
+        XCTAssertFalse(secondGroup.contains(.track(path: InstallmentAnalyticsPath.selected)))
+    }
+}

--- a/Tests/SnapshotTests/MercadoPagoCheckout/InstallmentsViewTests.swift
+++ b/Tests/SnapshotTests/MercadoPagoCheckout/InstallmentsViewTests.swift
@@ -18,6 +18,7 @@ final class InstallmentsViewTests: XCTestCase {
         let view = InstallmentScreen(
             paymentData: Binding(get: { paymentData }, set: { paymentData = $0 }),
             installmentsData: Binding(get: { installmentsData }, set: { installmentsData = $0 }),
+            checkoutType: "",
             style: .radioButton,
             onBack: {},
             onDismiss: {}
@@ -35,6 +36,7 @@ final class InstallmentsViewTests: XCTestCase {
         let view = InstallmentScreen(
             paymentData: Binding(get: { paymentData }, set: { paymentData = $0 }),
             installmentsData: Binding(get: { installmentsData }, set: { installmentsData = $0 }),
+            checkoutType: "",
             style: .chevron,
             onBack: {},
             onDismiss: {}


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
https://mercadolibre.atlassian.net/browse/CHOBK-3927

## Description
- Added analytics tracking to the Installments screen: initialize, selected (installment chosen), submit, and cancelled/error events
- Introduced `InstallmentAnalyticsPath` with the Melidata path for the installment screen
- Added `InstallmentInitializeEventData`, `InstallmentSelectedEventData`, `InstallmentSubmitEventData`, and `InstallmentCanceledErrorEventData` structs with structured event payloads including `payment_method_id`, installment details, and error context
- Updated `InstallmentScreenViewModel` to fire analytics events at each step of the installment selection flow
- Updated `InstallmentScreen` view to forward necessary context to the ViewModel for tracking
- Minor adjustment to `CardFormBrick` to pass tracking-related data
- Unit tests: `InstallmentAnalyticsEventDataTests` and `InstallmentsScreenViewModelTrackingTests` with full coverage of all track events and payloads

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [x] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<img width="660" height="394" alt="Captura de Tela 2026-05-18 às 12 18 45" src="https://github.com/user-attachments/assets/05c35a50-5b72-449d-a9e1-7ab57a353560" />
<img width="650" height="282" alt="Captura de Tela 2026-05-18 às 12 17 38" src="https://github.com/user-attachments/assets/9c41bfb6-5d2d-47ab-8144-658fe2b76826" />
<img width="672" height="135" alt="Captura de Tela 2026-05-18 às 12 17 03" src="https://github.com/user-attachments/assets/372c526c-a57e-44f8-a4d2-2363a82ecd2a" />
<img width="645" height="151" alt="Captura de Tela 2026-05-18 às 12 16 47" src="https://github.com/user-attachments/assets/3acbcf32-da01-4d49-aae6-0d0fd6956784" />
