### PR TITLE
(Fix): Make transactionAmount required in Installments

### DIFF
--- a/Sources/MercadoPagoCheckout/Domain/Analytics/InstallmentInitializeEventData.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Analytics/InstallmentInitializeEventData.swift
@@ -6,17 +6,16 @@ struct InstallmentInitializeEventData: AnalyticsEventData {
     let paymentType: String
     let selectionType: String
     let quotasCount: Int
-    let transactionAmount: Double?
+    let transactionAmount: Double
 
     func toDictionary() -> [String: any Sendable] {
-        var dict: [String: any Sendable] = [
+        return [
             "checkout_type": self.checkoutType,
             "payment_method_id": self.paymentMethodId,
             "payment_type": self.paymentType,
             "selection_type": self.selectionType,
-            "quotas_count": self.quotasCount
+            "quotas_count": self.quotasCount,
+            "transaction_amount": self.transactionAmount
         ]
-        if let transactionAmount { dict["transaction_amount"] = transactionAmount }
-        return dict
     }
 }

--- a/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
@@ -176,10 +176,12 @@ struct InstallmentScreen: View {
             }
         )
         .onAppear {
-            self.viewModel.trackInitialize(
-                transactionAmount: self.paymentData.transactionAmount,
-                paymentMethodId: self.paymentData.paymentMethodId
-            )
+            if let transactionAmount = paymentData.transactionAmount {
+                self.viewModel.trackInitialize(
+                    transactionAmount: transactionAmount,
+                    paymentMethodId: self.paymentData.paymentMethodId
+                )
+            }
         }
         .onDisappear {
             if !self.hasHandledDismiss {

--- a/Sources/MercadoPagoCheckout/Views/InstallmentScreenViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/InstallmentScreenViewModel.swift
@@ -87,7 +87,7 @@ final class InstallmentsScreenViewModel: ObservableObject {
 
     // MARK: - Analytics
 
-    func trackInitialize(transactionAmount: Double?, paymentMethodId: String) {
+    func trackInitialize(transactionAmount: Double, paymentMethodId: String) {
         let eventData = InstallmentInitializeEventData(
             checkoutType: self.checkoutType,
             paymentMethodId: paymentMethodId,

--- a/Tests/MercadoPagoCheckoutTests/Domain/Analytics/InstallmentAnalyticsEventDataTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Domain/Analytics/InstallmentAnalyticsEventDataTests.swift
@@ -34,27 +34,6 @@ final class InstallmentAnalyticsEventDataTests: XCTestCase {
         XCTAssertEqual(dict["transaction_amount"] as? Double, 500.0)
     }
 
-    func test_installmentInitializeEventData_withNilTransactionAmount_shouldOmitTransactionAmount() {
-        // Arrange
-        let sut = InstallmentInitializeEventData(
-            checkoutType: "card_payment_brick",
-            paymentMethodId: "master",
-            paymentType: "debit_card",
-            selectionType: "chevron",
-            quotasCount: 3,
-            transactionAmount: nil
-        )
-
-        // Act
-        let dict = sut.toDictionary()
-
-        // Assert
-        XCTAssertNil(dict["transaction_amount"])
-        XCTAssertEqual(dict["payment_method_id"] as? String, "master")
-        XCTAssertEqual(dict["payment_type"] as? String, "debit_card")
-        XCTAssertEqual(dict["quotas_count"] as? Int, 3)
-    }
-
     func test_installmentInitializeEventData_withChevronSelectionType_shouldContainChevron() {
         // Arrange
         let sut = InstallmentInitializeEventData(
@@ -63,7 +42,7 @@ final class InstallmentAnalyticsEventDataTests: XCTestCase {
             paymentType: "credit_card",
             selectionType: "chevron",
             quotasCount: 4,
-            transactionAmount: nil
+            transactionAmount: 200.0
         )
 
         // Act

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/InstallmentsScreenViewModelTrackingTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/InstallmentsScreenViewModelTrackingTests.swift
@@ -40,7 +40,7 @@ final class InstallmentsScreenViewModelTrackingTests: XCTestCase {
         let sut = self.makeSUT()
 
         // Act
-        sut.viewModel.trackInitialize(transactionAmount: nil, paymentMethodId: "visa")
+        sut.viewModel.trackInitialize(transactionAmount: 500.0, paymentMethodId: "visa")
         await sut.analytics.mock.waitForSend()
 
         // Assert
@@ -67,25 +67,6 @@ final class InstallmentsScreenViewModelTrackingTests: XCTestCase {
             "quotas_count": 3,
             "transaction_amount": 500.0
         ])))
-    }
-
-    func test_trackInitialize_withNilTransactionAmount_shouldOmitTransactionAmount() async {
-        // Arrange
-        let sut = self.makeSUT()
-
-        // Act
-        sut.viewModel.trackInitialize(transactionAmount: nil, paymentMethodId: "visa")
-        await sut.analytics.mock.waitForSend()
-
-        // Assert
-        let messages = await sut.analytics.mock.getMessages()
-        let hasTransactionAmount = messages.contains { msg in
-            if case let .setEventData(dict) = msg {
-                return dict.keys.contains("transaction_amount")
-            }
-            return false
-        }
-        XCTAssertFalse(hasTransactionAmount)
     }
 
     // MARK: - trackSelected


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
N/A

## Description
- Made `transactionAmount` non-optional in `InstallmentInitializeEventData`, ensuring the analytics initialize event always includes the transaction amount
- Updated `trackInitialize` signature in `InstallmentsScreenViewModel` from `Double?` to `Double`, removing the optional handling path
- Added a guard in `InstallmentScreen.onAppear` to only call `trackInitialize` when `transactionAmount` is present in `paymentData`
- Removed test cases covering the nil `transactionAmount` scenario; updated remaining tests to use concrete values

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [x] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [x] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [x] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [x] I have tested the accessibility of the changes and added them to the screenshots.
- [x] I have added a tag to the pull request that contains the product this pull request is related to.