### PR TITLE
(Fix): Make transactionAmount non-optional in CardFormSubmitEventData

### DIFF
--- a/Sources/MercadoPagoCheckout/Domain/Analytics/CardFormSubmitEventData.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Analytics/CardFormSubmitEventData.swift
@@ -2,16 +2,16 @@ import MPAnalytics
 
 struct CardFormSubmitEventData: AnalyticsEventData {
     let cardBrand: String
-    let transactionAmount: Double?
+    let transactionAmount: Double
     let issuer: String
     let paymentType: String?
 
     func toDictionary() -> [String: any Sendable] {
         var dict: [String: any Sendable] = [
             "card_brand": self.cardBrand,
+            "transaction_amount": self.transactionAmount,
             "issuer": self.issuer
         ]
-        if let transactionAmount { dict["transaction_amount"] = transactionAmount }
         if let paymentType { dict["payment_type"] = paymentType }
         return dict
     }

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -343,7 +343,7 @@ final class CardFormViewModel: ObservableObject {
     private func trackSubmit(paymentData: MPPaymentData, transactionAmount: Double?) {
         let eventData = CardFormSubmitEventData(
             cardBrand: paymentData.paymentMethodId ?? "",
-            transactionAmount: transactionAmount,
+            transactionAmount: transactionAmount ?? 0,
             issuer: self.cardData?.paymentMethods.first?.issuers.first?.name ?? "",
             paymentType: paymentData.paymentTypeId
         )

--- a/Tests/MercadoPagoCheckoutTests/Domain/Analytics/CardFormAnalyticsEventDataTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Domain/Analytics/CardFormAnalyticsEventDataTests.swift
@@ -73,11 +73,11 @@ final class CardFormAnalyticsEventDataTests: XCTestCase {
         XCTAssertEqual(dict["payment_type"] as? String, "credit_card")
     }
 
-    func test_cardFormSubmitEventData_toDictionary_withNilOptionals_shouldOmitOptionalKeys() {
+    func test_cardFormSubmitEventData_toDictionary_withNilPaymentType_shouldOmitPaymentType() {
         // Arrange
         let sut = CardFormSubmitEventData(
             cardBrand: "master",
-            transactionAmount: nil,
+            transactionAmount: 0,
             issuer: "Itaú",
             paymentType: nil
         )
@@ -87,8 +87,8 @@ final class CardFormAnalyticsEventDataTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(dict["card_brand"] as? String, "master")
+        XCTAssertEqual(dict["transaction_amount"] as? Double, 0)
         XCTAssertEqual(dict["issuer"] as? String, "Itaú")
-        XCTAssertNil(dict["transaction_amount"])
         XCTAssertNil(dict["payment_type"])
     }
 


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
N/A

## Description
- Changed `transactionAmount` from `Double?` to `Double` in `CardFormSubmitEventData`, ensuring the field is always present in the analytics event dictionary
- Updated `CardFormViewModel.trackSubmit` to pass `transactionAmount ?? 0` when the value is nil, guaranteeing a non-nil value is always forwarded
- Removed the conditional `if let transactionAmount` guard in `toDictionary()` — `transaction_amount` is now always included in the dictionary
- Updated `CardFormAnalyticsEventDataTests` to reflect the new non-optional contract: renamed test and adjusted assertions to expect `transaction_amount` always present

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [x] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
N/A — no UI changes