### PR TITLE
[Feature] Implement generic builder

### DIFF
--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrick.swift
@@ -7,38 +7,41 @@
 import MPComponents
 import SwiftUI
 
-struct CardFormBrick: View {
+struct CardFormBrick<T: MPPaymentData.Kind>: View {
     private enum Route: Hashable {
         case installments
         case reviewAndConfirm
     }
 
     @State private var route: Route?
-    @State private var paymentData: MPPaymentData
-    @ObservedObject private var brickViewModel: CardFormBrickViewModel
+    @State private var cardTransactionData: MPPaymentData.CardTransaction
+    @ObservedObject private var brickViewModel: CardFormBrickViewModel<T>
 
-    private var configuration: MercadoPagoCheckout.CheckoutConfiguration
+    private var configuration: MercadoPagoCheckout<T>.CheckoutConfiguration
     private let themeDark: MPTheme
     private let themeLight: MPTheme
     private let transactionAmount: Double
 
-    private let onResult: (MercadoPagoCheckoutResult) -> Void
+    private let onResult: (MercadoPagoCheckoutResult<T>) -> Void
 
     @Environment(\.presentationMode) var presentationMode
     @Environment(\.checkoutTheme) private var theme: MPTheme
 
+    @MainActor
     init(
-        configuration: MercadoPagoCheckout.CheckoutConfiguration,
-        appearance: MercadoPagoCheckout.CheckoutAppearance,
-        onResult: @escaping (MercadoPagoCheckoutResult) -> Void
+        configuration: MercadoPagoCheckout<T>.CheckoutConfiguration,
+        appearance: MercadoPagoCheckout<T>.CheckoutAppearance,
+        onResult: @escaping (MercadoPagoCheckoutResult<T>) -> Void
     ) {
         self.onResult = onResult
         self.themeDark = appearance.themeConfiguration.dark
         self.themeLight = appearance.themeConfiguration.light
         self.transactionAmount = configuration.type.configuration.amount
         self.configuration = configuration
-        self._paymentData = State(initialValue: MPPaymentData(transactionAmount: self.transactionAmount))
-        self.brickViewModel = CardFormBrickViewModel(configuration: configuration, appearance: appearance)
+        self._cardTransactionData = State(
+            initialValue: .init()
+        )
+        self.brickViewModel = CardFormBrickViewModel<T>(configuration: configuration, appearance: appearance)
     }
 
     var body: some View {
@@ -80,7 +83,7 @@ struct CardFormBrick: View {
         }
     }
 
-    private func cardFormScreen(initResult: CardFormInitializationOutput, viewModel: CardFormViewModel) -> some View {
+    private func cardFormScreen(initResult: CardFormInitializationOutput, viewModel: CardFormViewModel<T>) -> some View {
         CardFormScreen(
             initResult: initResult,
             transactionAmount: self.transactionAmount,
@@ -95,8 +98,10 @@ struct CardFormBrick: View {
                 self.onResult(.userCancelled(.cardForm(context)))
             },
             onSuccess: { paymentData in
-                self.paymentData = paymentData
-                self.completeCheckout()
+                if let transaction = paymentData as? MPPaymentData.CardTransaction {
+                    self.cardTransactionData = transaction
+                }
+                self.completeCheckout(with: paymentData)
             },
             onFailure: { error in
                 self.fail(error)
@@ -106,7 +111,7 @@ struct CardFormBrick: View {
 
     private func installmentScreen() -> some View {
         InstallmentScreen(
-            paymentData: self.$paymentData,
+            paymentData: self.$cardTransactionData,
             installments: InstallmentMock.visa,
             onBack: {
                 self.presentationMode.wrappedValue.dismiss()
@@ -137,9 +142,19 @@ struct CardFormBrick: View {
         self.presentationMode.wrappedValue.dismiss()
     }
 
-    private func completeCheckout() {
+    /// Emits the final success result.
+    ///
+    /// The SDK guarantees by construction that the variant of `paymentData` matches `T`
+    /// (a `cardTransaction` ``CheckoutType`` always yields a ``MPPaymentData/CardTransaction``;
+    /// `saveCard` always yields a ``MPPaymentData/CardSave``). The forced cast is the iOS
+    /// equivalent of Android's `@Suppress("UNCHECKED_CAST")`.
+    private func completeCheckout(with paymentData: any MPPaymentData.Kind) {
+        guard let typed = paymentData as? T else {
+            assertionFailure("CardFormBrick received \(type(of: paymentData)) but was configured for \(T.self).")
+            return
+        }
         self.route = nil
-        self.onResult(.success(self.paymentData))
+        self.onResult(.success(typed))
         self.presentationMode.wrappedValue.dismiss()
     }
 

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
@@ -10,10 +10,10 @@ import MPCore
 import MPFoundation
 
 @MainActor
-final class CardFormBrickViewModel: ObservableObject {
+final class CardFormBrickViewModel<T: MPPaymentData.Kind>: ObservableObject {
     enum ScreenState {
         case loading
-        case ready(CardFormInitializationOutput, CardFormViewModel)
+        case ready(CardFormInitializationOutput, CardFormViewModel<T>)
     }
 
     // MARK: - Published State
@@ -22,16 +22,16 @@ final class CardFormBrickViewModel: ObservableObject {
 
     // MARK: - Dependencies
 
-    private let configuration: MercadoPagoCheckout.CheckoutConfiguration
-    private let appearance: MercadoPagoCheckout.CheckoutAppearance
+    private let configuration: MercadoPagoCheckout<T>.CheckoutConfiguration
+    private let appearance: MercadoPagoCheckout<T>.CheckoutAppearance
     private let initializeUseCase: InitializeCardFormUseCase
     private let analytics: AnalyticsInterface
 
     // MARK: - Init
 
     init(
-        configuration: MercadoPagoCheckout.CheckoutConfiguration,
-        appearance: MercadoPagoCheckout.CheckoutAppearance = MercadoPagoCheckout.CheckoutAppearance(),
+        configuration: MercadoPagoCheckout<T>.CheckoutConfiguration,
+        appearance: MercadoPagoCheckout<T>.CheckoutAppearance = MercadoPagoCheckout<T>.CheckoutAppearance(),
         initializeUseCase: InitializeCardFormUseCase = InitializeCardFormUseCase(),
         analytics: AnalyticsInterface = CoreDependencyContainer.shared.analytics
     ) {
@@ -51,7 +51,7 @@ final class CardFormBrickViewModel: ObservableObject {
                     checkoutType: self.configuration.type
                 )
             }
-            let viewModel = CardFormViewModel(
+            let viewModel = CardFormViewModel<T>(
                 configuration: self.configuration,
                 initResult: result,
                 analytics: self.analytics
@@ -79,8 +79,8 @@ final class CardFormBrickViewModel: ObservableObject {
             checkoutType: self.configuration.type.analyticsValue,
             appearance: self.appearance.style.analyticsValue,
             sellerCustomization: self.appearance.sellerCustomization,
-            allowedPaymentTypes: self.configuration.paymentMethod.acceptedPaymentTypeIds,
-            allowedPaymentMethods: self.configuration.paymentMethod.acceptedPaymentMethodIds
+            allowedPaymentTypes: self.configuration.paymentMethod.flatMap(\.acceptedPaymentTypeIds),
+            allowedPaymentMethods: self.configuration.paymentMethod.flatMap(\.acceptedPaymentMethodIds)
         )
 
         let analytics = self.analytics

--- a/Sources/MercadoPagoCheckout/Domain/UseCases/InitializeCardFormUseCase.swift
+++ b/Sources/MercadoPagoCheckout/Domain/UseCases/InitializeCardFormUseCase.swift
@@ -19,7 +19,7 @@ struct InitializeCardFormUseCase {
     /// Fetches initialization data from the repository,
     /// then applies business rules (button selection, custom text overrides).
     func execute(
-        checkoutType: MercadoPagoCheckout.CheckoutType
+        checkoutType: MercadoPagoCheckout<some MPPaymentData.Kind>.CheckoutType
     ) async throws(MercadoPagoCheckoutError) -> CardFormInitializationOutput {
         do {
             let data = try await repository.fetchInitialization(

--- a/Sources/MercadoPagoCheckout/MercadoPagoCheckout+Builder.swift
+++ b/Sources/MercadoPagoCheckout/MercadoPagoCheckout+Builder.swift
@@ -8,17 +8,19 @@
 public extension MercadoPagoCheckout {
     /// A fluent builder for constructing a ``MercadoPagoCheckout`` instance.
     ///
-    /// Use `Builder` to configure the checkout step-by-step before calling ``build()``.
+    /// The generic parameter `T` of the enclosing ``MercadoPagoCheckout`` is inferred from
+    /// the ``CheckoutType`` passed to ``init(checkoutType:checkoutAppearance:)``, so the
+    /// type flows naturally into ``MercadoPagoCheckoutResult``.
     ///
     /// ```swift
     /// let checkout = MercadoPagoCheckout.Builder(
-    ///     checkoutType: .cardForm(cardFormConfiguration: .init(amount: 150.0)),
+    ///     checkoutType: .cardTransaction(order: .init(amount: 150.0, payer: .init(email: "..."))),
     ///     checkoutAppearance: .init()
     /// )
-    /// .setPaymentMethod([.card(cardTypes: [.credit]), .pix])
+    /// .setPaymentMethods([.card(allowedTypes: [.credit])])
     /// .build()
     /// ```
-    class Builder {
+    final class Builder {
         private var checkoutType: CheckoutType
         private var checkoutAppearance: CheckoutAppearance
         private var paymentMethods: [PaymentMethod]
@@ -50,8 +52,8 @@ public extension MercadoPagoCheckout {
         ///
         /// - Returns: A fully configured `MercadoPagoCheckout` ready to be presented.
         @MainActor
-        public func build() -> MercadoPagoCheckout {
-            MercadoPagoCheckout(
+        public func build() -> MercadoPagoCheckout<T> {
+            MercadoPagoCheckout<T>(
                 theme: self.checkoutAppearance,
                 configuration: .init(
                     type: self.checkoutType,

--- a/Sources/MercadoPagoCheckout/MercadoPagoCheckout+CardFormConfiguration.swift
+++ b/Sources/MercadoPagoCheckout/MercadoPagoCheckout+CardFormConfiguration.swift
@@ -5,14 +5,14 @@
 //  Created by Danielle Nozaki Ogawa on 20/02/26.
 //
 
-extension MercadoPagoCheckout {
-    public protocol CheckoutTypeConfiguration: Sendable {
-        /// The transaction amount to be charged.
-        var amount: Double { get }
-    }
+protocol CheckoutTypeConfiguration: Sendable {
+    /// The transaction amount to be charged.
+    var amount: Double { get }
+}
 
+public extension MercadoPagoCheckout {
     /// Configuration specific to the checkout experience.
-    public struct Order: CheckoutTypeConfiguration {
+    struct Order: CheckoutTypeConfiguration {
         /// The transaction amount to be charged. Optional; when `nil` the amount is determined server-side.
         public var amount: Double
         /// Payer information pre-filled in the form. Optional.
@@ -29,7 +29,9 @@ extension MercadoPagoCheckout {
         }
     }
 
-    struct SavedCardConfiguration: CheckoutTypeConfiguration {
-        var amount: Double = .zero
+    internal struct SavedCardConfiguration: CheckoutTypeConfiguration {
+        public var amount: Double = .zero
+
+        init() {}
     }
 }

--- a/Sources/MercadoPagoCheckout/MercadoPagoCheckout+CheckoutType.swift
+++ b/Sources/MercadoPagoCheckout/MercadoPagoCheckout+CheckoutType.swift
@@ -7,28 +7,54 @@
 
 public extension MercadoPagoCheckout {
     /// The type of checkout experience to launch.
-    // swiftformat:disable:next redundantSendable
-    enum CheckoutType: Sendable {
-        /// A card-based payment form.
-        ///
-        /// - Parameter cardFormConfiguration: Configuration values for the card form, such as amount and payer.
-        case cardTransaction(order: Order)
-        case saveCard
+    ///
+    /// `CheckoutType` is parameterized by the outer ``MercadoPagoCheckout`` generic `T`, which
+    /// represents the concrete ``MPPaymentData`` variant produced by the flow. Each factory
+    /// is constrained so that:
+    /// - ``cardTransaction(order:)`` is only available when `T == MPPaymentData.CardTransaction`
+    /// - ``saveCard`` is only available when `T == MPPaymentData.CardSave`
+    ///
+    /// This propagates the concrete payment data type all the way through to
+    /// ``MercadoPagoCheckoutResult`` at the call site.
+    struct CheckoutType: Sendable {
+        enum Kind: Sendable {
+            case cardTransaction(Order)
+            case saveCard
+        }
 
-        var configuration: CheckoutTypeConfiguration {
-            switch self {
-            case let .cardTransaction(cardFormConfiguration):
-                return cardFormConfiguration
-            case .saveCard:
-                return SavedCardConfiguration()
+        let kind: Kind
+
+        var configuration: any CheckoutTypeConfiguration {
+            switch self.kind {
+            case let .cardTransaction(order): return order
+            case .saveCard: return SavedCardConfiguration()
             }
         }
 
         var analyticsValue: String {
-            switch self {
+            switch self.kind {
             case .cardTransaction: return "card_transaction"
             case .saveCard: return "save_card"
             }
         }
+    }
+}
+
+public extension MercadoPagoCheckout.CheckoutType where T == MPPaymentData.CardTransaction {
+    /// A card-based payment form that produces a ``MPPaymentData/CardTransaction``.
+    ///
+    /// - Parameter order: Configuration values for the transaction, such as amount and payer.
+    static func cardTransaction(
+        order: MercadoPagoCheckout<MPPaymentData.CardTransaction>.Order
+    ) -> MercadoPagoCheckout<MPPaymentData.CardTransaction>.CheckoutType {
+        .init(kind: .cardTransaction(order))
+    }
+}
+
+public extension MercadoPagoCheckout.CheckoutType where T == MPPaymentData.CardSave {
+    /// A flow that saves a card without performing a transaction; produces a
+    /// ``MPPaymentData/CardSave`` carrying the token.
+    static var saveCard: MercadoPagoCheckout<MPPaymentData.CardSave>.CheckoutType {
+        .init(kind: .saveCard)
     }
 }

--- a/Sources/MercadoPagoCheckout/MercadoPagoCheckout+Payer.swift
+++ b/Sources/MercadoPagoCheckout/MercadoPagoCheckout+Payer.swift
@@ -7,7 +7,7 @@
 
 public extension MercadoPagoCheckout {
     /// Information about the payer initiating the checkout.
-    struct Payer: Sendable {
+    struct Payer: Sendable, Decodable {
         /// The payer's email address.
         public var email: String
 

--- a/Sources/MercadoPagoCheckout/MercadoPagoCheckout+PaymentMethod.swift
+++ b/Sources/MercadoPagoCheckout/MercadoPagoCheckout+PaymentMethod.swift
@@ -18,7 +18,7 @@ public extension MercadoPagoCheckout {
             allowedBrands: [CardBrand] = CardBrand.defaults,
             installment: Installment? = Installment()
         )
-        
+
         /// The default set of payment methods: card (credit, debit, prepaid), Pix, and Boleto.
         public static var defaults: [PaymentMethod] {
             [
@@ -28,18 +28,14 @@ public extension MercadoPagoCheckout {
     }
 }
 
-extension [MercadoPagoCheckout.PaymentMethod] {
+extension MercadoPagoCheckout.PaymentMethod {
     var acceptedPaymentTypeIds: [String] {
-        flatMap { method -> [String] in
-            guard case .card(let cardTypes, _, _) = method else { return [] }
-            return cardTypes.map(\.paymentTypeId)
-        }
+        guard case let .card(cardTypes, _, _) = self else { return [] }
+        return cardTypes.map(\.paymentTypeId)
     }
 
     var acceptedPaymentMethodIds: [String] {
-        flatMap { method -> [String] in
-            guard case .card(_, let cardBrands, _) = method else { return [] }
-            return cardBrands.map(\.paymentMethodId)
-        }
+        guard case let .card(_, cardBrands, _) = self else { return [] }
+        return cardBrands.map(\.paymentMethodId)
     }
 }

--- a/Sources/MercadoPagoCheckout/MercadoPagoCheckout.swift
+++ b/Sources/MercadoPagoCheckout/MercadoPagoCheckout.swift
@@ -15,18 +15,23 @@ import UIKit
 // ``Builder`` to assemble an instance fluently, then present it via SwiftUI,
 // UIKit modal, or a `UINavigationController` push.
 //
+// The generic parameter `T` represents the concrete ``MPPaymentData`` variant produced by the
+// flow. It is inferred from the ``CheckoutType`` passed to the ``Builder``, so the
+// ``MercadoPagoCheckoutResult`` delivered to the callback carries the concrete subtype directly.
+//
 // ## Usage
 //
 // ```swift
 // let checkout = MercadoPagoCheckout.Builder(
-//     checkoutType: .cardForm(cardFormConfiguration: .init(amount: 99.90)),
+//     checkoutType: .cardTransaction(order: .init(amount: 99.90, payer: .init(email: "..."))),
 //     checkoutAppearance: .init()
 // )
-// .setPaymentMethod([.card(cardTypes: [.credit, .debit]), .pix])
+// .setPaymentMethods([.card(allowedTypes: [.credit, .debit])])
 // .build()
 //
 // // SwiftUI
 // checkout.show { result in
+//     // result: MercadoPagoCheckoutResult<MPPaymentData.CardTransaction>
 //     print(result)
 // }
 //
@@ -36,7 +41,7 @@ import UIKit
 // }
 // ```
 
-public struct MercadoPagoCheckout: Sendable, Identifiable {
+public struct MercadoPagoCheckout<T: MPPaymentData.Kind>: Sendable, Identifiable {
     /// A unique identifier for this checkout instance.
     public let id = UUID()
 
@@ -67,9 +72,9 @@ public struct MercadoPagoCheckout: Sendable, Identifiable {
     @MainActor
     @ViewBuilder
     public func show(
-        onResult: @escaping (MercadoPagoCheckoutResult) -> Void
+        onResult: @escaping (MercadoPagoCheckoutResult<T>) -> Void
     ) -> some View {
-        CardFormBrick(
+        CardFormBrick<T>(
             configuration: self.configuration,
             appearance: self.theme,
             onResult: onResult
@@ -88,9 +93,9 @@ public struct MercadoPagoCheckout: Sendable, Identifiable {
     public func present(
         from viewController: UIViewController,
         animated: Bool = true,
-        onResult: @escaping (MercadoPagoCheckoutResult) -> Void
+        onResult: @escaping (MercadoPagoCheckoutResult<T>) -> Void
     ) {
-        let cardFormBrick = CardFormBrick(
+        let cardFormBrick = CardFormBrick<T>(
             configuration: configuration,
             appearance: theme,
             onResult: onResult
@@ -113,9 +118,9 @@ public struct MercadoPagoCheckout: Sendable, Identifiable {
     public func push(
         to navigationController: UINavigationController,
         animated: Bool = true,
-        onResult: @escaping (MercadoPagoCheckoutResult) -> Void
+        onResult: @escaping (MercadoPagoCheckoutResult<T>) -> Void
     ) {
-        let cardFormBrick = CardFormBrick(
+        let cardFormBrick = CardFormBrick<T>(
             configuration: configuration,
             appearance: theme,
             onResult: onResult

--- a/Sources/MercadoPagoCheckout/Model/Public/MPPaymentData.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/MPPaymentData.swift
@@ -6,37 +6,63 @@
 //
 import Foundation
 
-public struct MPPaymentData: Equatable, Codable, Sendable {
-    public var transactionAmount: Double?
-    public var token: String
-    public var installment: Int?
-    public var paymentMethodId: String
-    public var paymentTypeId: String
-    public var issuerId: String?
-    public var payer: Payer?
+/// Payment data produced by the checkout flow.
+///
+/// Acts as a sealed namespace: each concrete checkout type (`CardSave`, `CardTransaction`)
+/// produces its own variant. The variant is determined by the ``CheckoutType`` chosen on the
+/// builder and is propagated to ``MercadoPagoCheckoutResult`` at the call site, so consumers
+/// access the concrete fields directly — no nested `switch`, no unreachable branches.
+public enum MPPaymentData {
+    /// Marker protocol adopted by every concrete `MPPaymentData` variant.
+    public protocol Kind: Sendable {}
+
+    /// Payment data emitted by the `saveCard` flow.
+    public struct CardSave: Kind, Equatable, Codable, Sendable {
+        /// The token representing the saved card.
+        public let token: String
+        public var paymentMethodId: String
+        public var paymentTypeId: String
+        public var issuerId: String?
+        public var payer: Payer?
+    }
+
+    /// Payment data emitted by the `cardTransaction` flow.
+    public struct CardTransaction: Kind, Equatable, Codable, Sendable {
+        public var transactionAmount: Double?
+        public var installment: Int?
+        public var paymentMethodId: String
+        public var paymentTypeId: String
+        public var issuerId: String?
+        public var payer: Payer?
+
+        var token: String
+
+        init(
+            transactionAmount: Double = .zero,
+            token: String = "",
+            installment: Int = 1,
+            paymentMethodId: String = "",
+            paymentTypeId: String = "",
+            issuerId: String? = "",
+            payer: Payer? = nil
+        ) {
+            self.transactionAmount = transactionAmount
+            self.token = token
+            self.installment = installment
+            self.paymentMethodId = paymentMethodId
+            self.paymentTypeId = paymentTypeId
+            self.issuerId = issuerId
+            self.payer = payer
+        }
+    }
 
     public struct Payer: Equatable, Codable, Sendable {
         public var documentType: String
         public var documentNumber: String
-    }
-}
 
-extension MPPaymentData {
-    init(
-        transactionAmount: Double? = nil,
-        token: String? = nil,
-        installment: Int? = nil,
-        paymentMethodId: String? = nil,
-        paymentTypeId: String? = nil,
-        issuerId: String? = nil,
-        payer: Payer? = nil
-    ) {
-        self.transactionAmount = transactionAmount
-        self.token = token ?? ""
-        self.installment = installment
-        self.paymentMethodId = paymentMethodId ?? ""
-        self.paymentTypeId = paymentTypeId ?? ""
-        self.issuerId = issuerId
-        self.payer = payer
+        init(documentType: String, documentNumber: String) {
+            self.documentType = documentType
+            self.documentNumber = documentNumber
+        }
     }
 }

--- a/Sources/MercadoPagoCheckout/Model/Public/MercadoPagoCheckoutResult.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/MercadoPagoCheckoutResult.swift
@@ -1,14 +1,18 @@
 //
-//  CardFormResult.swift
+//  MercadoPagoCheckoutResult.swift
 //  MercadoPagoSDK
 //
 //  Created by Guilherme Prata Costa on 30/01/26.
 //
 import Foundation
 
-@frozen
-public enum MercadoPagoCheckoutResult: Sendable {
-    case success(MPPaymentData)
+/// The outcome of a checkout flow.
+///
+/// The associated payment data type `T` is propagated from the ``CheckoutType`` configured
+/// on the builder, so `case success(T)` carries the concrete payment data variant directly —
+/// no nested `switch`, no unreachable branches.
+public enum MercadoPagoCheckoutResult<T: MPPaymentData.Kind>: Sendable {
+    case success(T)
     case error(MercadoPagoCheckoutError)
     case userCancelled(UserCancelledContext)
 }

--- a/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormScreen.swift
@@ -8,14 +8,14 @@ import CoreMethods
 import MPComponents
 import SwiftUI
 
-struct CardFormScreen: View {
+struct CardFormScreen<T: MPPaymentData.Kind>: View {
     private let onBack: (CardFormUserCancelledContext) -> Void
     private let onDismiss: (CardFormUserCancelledContext) -> Void
-    private let onSuccess: (MPPaymentData) -> Void
+    private let onSuccess: (any MPPaymentData.Kind) -> Void
     private let onFailure: (MercadoPagoCheckoutError) -> Void
-    private let transactionAmount: Double?
+    private let transactionAmount: Double
 
-    @ObservedObject private var viewModel: CardFormViewModel
+    @ObservedObject private var viewModel: CardFormViewModel<T>
     private let initResult: CardFormInitializationOutput
 
     // MARK: States View
@@ -35,11 +35,11 @@ struct CardFormScreen: View {
 
     init(
         initResult: CardFormInitializationOutput,
-        transactionAmount: Double?,
-        viewModel: CardFormViewModel,
+        transactionAmount: Double,
+        viewModel: CardFormViewModel<T>,
         onBack: @escaping (CardFormUserCancelledContext) -> Void = { _ in },
         onDismiss: @escaping (CardFormUserCancelledContext) -> Void = { _ in },
-        onSuccess: @escaping (MPPaymentData) -> Void = { _ in },
+        onSuccess: @escaping (any MPPaymentData.Kind) -> Void = { _ in },
         onFailure: @escaping (MercadoPagoCheckoutError) -> Void = { _ in }
     ) {
         self.onBack = onBack

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -11,10 +11,10 @@ import MPCore
 import SwiftUI
 
 @MainActor
-final class CardFormViewModel: ObservableObject {
+final class CardFormViewModel<T: MPPaymentData.Kind>: ObservableObject {
     // MARK: - Dependencies
 
-    private let configuration: MercadoPagoCheckout.CheckoutConfiguration
+    private let configuration: MercadoPagoCheckout<T>.CheckoutConfiguration
     private let service: CheckoutServiceProtocol
     private let fetchCardUseCase: FetchCardPaymentBrickCardUseCase
     private let analytics: AnalyticsInterface
@@ -79,7 +79,7 @@ final class CardFormViewModel: ObservableObject {
     // MARK: - Init
 
     init(
-        configuration: MercadoPagoCheckout.CheckoutConfiguration,
+        configuration: MercadoPagoCheckout<T>.CheckoutConfiguration,
         initResult: CardFormInitializationOutput,
         service: CheckoutServiceProtocol = CheckoutService(),
         fetchCardUseCase: FetchCardPaymentBrickCardUseCase = FetchCardPaymentBrickCardUseCase(),
@@ -253,25 +253,25 @@ final class CardFormViewModel: ObservableObject {
             amount: self.configuration.type.configuration.amount,
             checkoutType: self.configuration.type.analyticsValue,
             processingMode: ProcessingMode.aggregator.rawValue,
-            allowCardTypes: self.configuration.paymentMethod.acceptedPaymentTypeIds,
-            allowCardBrands: self.configuration.paymentMethod.acceptedPaymentMethodIds
+            allowCardTypes: self.configuration.paymentMethod.flatMap(\.acceptedPaymentTypeIds),
+            allowCardBrands: self.configuration.paymentMethod.flatMap(\.acceptedPaymentMethodIds)
         )
     }
 
     // MARK: - Payment Data
 
-    private func createPaymentData(
-        _ amount: Double?,
+    private func buildCardTransaction(
+        amount: Double,
         cardToken: CardToken,
         cardFormData: CardFormData
-    ) throws(MercadoPagoCheckoutError) -> MPPaymentData {
-        var payer: MPPaymentData.Payer? {
+    ) throws(MercadoPagoCheckoutError) -> MPPaymentData.CardTransaction {
+        let payer: MPPaymentData.Payer? = {
             guard let selectTypeDocument else { return nil }
             return .init(
                 documentType: selectTypeDocument.id,
                 documentNumber: cardFormData.documentHolder.filter { $0.isLetter || $0.isNumber }
             )
-        }
+        }()
 
         guard let paymentMethod = cardData?.paymentMethods.first else {
             throw MercadoPagoCheckoutError(
@@ -292,10 +292,39 @@ final class CardFormViewModel: ObservableObject {
         )
     }
 
+    private func buildCardSave(
+        cardToken: CardToken,
+        cardFormData: CardFormData
+    ) throws(MercadoPagoCheckoutError) -> MPPaymentData.CardSave {
+        let payer: MPPaymentData.Payer? = {
+            guard let selectTypeDocument else { return nil }
+            return .init(
+                documentType: selectTypeDocument.id,
+                documentNumber: cardFormData.documentHolder.filter { $0.isLetter || $0.isNumber }
+            )
+        }()
+
+        guard let paymentMethod = cardData?.paymentMethods.first else {
+            throw MercadoPagoCheckoutError(
+                code: .unknown,
+                localizedDescription: "Couldn't create payment data: card data is missing",
+                location: .paymentMethods
+            )
+        }
+
+        return .init(
+            token: cardToken.token,
+            paymentMethodId: paymentMethod.id,
+            paymentTypeId: paymentMethod.paymentTypeId,
+            issuerId: paymentMethod.issuers.first?.id,
+            payer: payer
+        )
+    }
+
     func submitCardData(
         cardForm: CardFormData,
-        transactionAmount: Double?,
-        onSuccess: (MPPaymentData) -> Void,
+        transactionAmount: Double,
+        onSuccess: (any MPPaymentData.Kind) -> Void,
         onFailure: (MercadoPagoCheckoutError) -> Void
     ) async {
         self.isTokenizing = true
@@ -303,8 +332,34 @@ final class CardFormViewModel: ObservableObject {
 
         do {
             let cardToken = try await self.createCardToken(cardForm: cardForm)
-            let paymentData = try self.createPaymentData(transactionAmount, cardToken: cardToken, cardFormData: cardForm)
-            self.trackSubmit(paymentData: paymentData, transactionAmount: transactionAmount)
+            print(self.cardData?.paymentMethods)
+
+            let paymentData: any MPPaymentData.Kind
+            switch self.configuration.type.kind {
+            case .cardTransaction:
+                let transaction = try self.buildCardTransaction(
+                    amount: transactionAmount,
+                    cardToken: cardToken,
+                    cardFormData: cardForm
+                )
+                self.trackSubmit(
+                    paymentMethodId: transaction.paymentMethodId,
+                    paymentTypeId: transaction.paymentTypeId,
+                    transactionAmount: transactionAmount
+                )
+                paymentData = transaction
+
+            case .saveCard:
+                let save = try self.buildCardSave(cardToken: cardToken, cardFormData: cardForm)
+                let paymentMethod = self.cardData?.paymentMethods.first
+                self.trackSubmit(
+                    paymentMethodId: save.paymentMethodId,
+                    paymentTypeId: save.paymentTypeId,
+                    transactionAmount: transactionAmount
+                )
+                paymentData = save
+            }
+
             onSuccess(paymentData)
         } catch {
             guard !Task.isCancelled else { return }
@@ -345,12 +400,12 @@ final class CardFormViewModel: ObservableObject {
         }
     }
 
-    private func trackSubmit(paymentData: MPPaymentData, transactionAmount: Double?) {
+    private func trackSubmit(paymentMethodId: String, paymentTypeId: String, transactionAmount: Double?) {
         let eventData = CardFormSubmitEventData(
-            cardBrand: paymentData.paymentMethodId ?? "",
+            cardBrand: paymentMethodId,
             transactionAmount: transactionAmount,
             issuer: self.cardData?.paymentMethods.first?.issuers.first?.name ?? "",
-            paymentType: paymentData.paymentTypeId
+            paymentType: paymentTypeId
         )
         self.enqueueAnalytics { [analytics = self.analytics] in
             await analytics.trackEvent(CardFormAnalyticsPath.submit)

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -332,7 +332,6 @@ final class CardFormViewModel<T: MPPaymentData.Kind>: ObservableObject {
 
         do {
             let cardToken = try await self.createCardToken(cardForm: cardForm)
-            print(self.cardData?.paymentMethods)
 
             let paymentData: any MPPaymentData.Kind
             switch self.configuration.type.kind {
@@ -351,7 +350,7 @@ final class CardFormViewModel<T: MPPaymentData.Kind>: ObservableObject {
 
             case .saveCard:
                 let save = try self.buildCardSave(cardToken: cardToken, cardFormData: cardForm)
-                let paymentMethod = self.cardData?.paymentMethods.first
+
                 self.trackSubmit(
                     paymentMethodId: save.paymentMethodId,
                     paymentTypeId: save.paymentTypeId,

--- a/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/InstallmentScreen.swift
@@ -19,10 +19,10 @@ struct InstallmentScreen: View {
 
     private let onBack: () -> Void
     private let onContinue: () -> Void
-    @Binding private var paymentData: MPPaymentData
+    @Binding private var paymentData: MPPaymentData.CardTransaction
 
     init(
-        paymentData: Binding<MPPaymentData>,
+        paymentData: Binding<MPPaymentData.CardTransaction>,
         installments: Installment,
         onBack: @escaping () -> Void,
         onContinue: @escaping () -> Void
@@ -75,7 +75,12 @@ struct InstallmentScreen: View {
 #Preview {
     InstallmentScreen(
         paymentData: .constant(
-            MPPaymentData(transactionAmount: 100)
+            MPPaymentData.CardTransaction(
+                transactionAmount: 100,
+                token: "",
+                paymentMethodId: "",
+                paymentTypeId: ""
+            )
         ),
         installments: InstallmentMock.visa,
         onBack: {},

--- a/Tests/MercadoPagoCheckoutTests/API/MercadoPagoCheckoutBuilderTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/API/MercadoPagoCheckoutBuilderTests.swift
@@ -12,61 +12,50 @@ import XCTest
 /// `MercadoPagoCheckout` — consumers of the SDK go through it. Tests below
 /// assert the stored fields and the default payment methods so a silent
 /// regression (e.g. `.defaults` becoming empty) fails here rather than in
-/// production.
+/// production. The generic T parameter is also exercised to confirm that
+/// `.cardTransaction` produces `MercadoPagoCheckout<CardTransaction>` and
+/// `.saveCard` produces `MercadoPagoCheckout<CardSave>`.
 @MainActor
 final class MercadoPagoCheckoutBuilderTests: XCTestCase {
-    // MARK: - Init + defaults
+    // MARK: - cardTransaction flow
 
-    func test_init_shouldStoreCheckoutTypeAndAppearance() {
-        // Arrange
-        let appearance = MercadoPagoCheckout.CheckoutAppearance()
-        let checkoutType: MercadoPagoCheckout.CheckoutType = .cardTransaction(
-            order: .init(amount: 100.0, payer: .init(email: "test@mercadopago.com"))
-        )
-
-        // Act
+    func test_cardTransaction_init_shouldStoreAmountInCheckoutType() {
         let checkout = MercadoPagoCheckout.Builder(
-            checkoutType: checkoutType,
-            checkoutAppearance: appearance
+            checkoutType: .cardTransaction(order: .init(amount: 100.0, payer: .init(email: "test@mp.com"))),
+            checkoutAppearance: .init()
         ).build()
 
-        // Assert
-        if case let .cardTransaction(cardFormConfiguration) = checkout.configuration.type {
-            XCTAssertEqual(cardFormConfiguration.amount, 100.0)
+        if case let .cardTransaction(order) = checkout.configuration.type.kind {
+            XCTAssertEqual(order.amount, 100.0)
         } else {
-            XCTFail("Expected .cardForm checkout type")
+            XCTFail("Expected .cardTransaction kind")
         }
     }
 
-    func test_build_withoutSettingPaymentMethods_shouldUseDefaults() {
-        // Arrange / Act
+    func test_cardTransaction_build_withoutSettingPaymentMethods_shouldUseDefaults() {
         let checkout = MercadoPagoCheckout.Builder(
-            checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mercadopago.com"))),
-            checkoutAppearance: MercadoPagoCheckout.CheckoutAppearance()
+            checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mp.com"))),
+            checkoutAppearance: .init()
         ).build()
 
-        // Assert -- default is the same list exposed by PaymentMethod.defaults
-        let expectedCount = MercadoPagoCheckout.PaymentMethod.defaults.count
-        XCTAssertEqual(checkout.configuration.paymentMethod.count, expectedCount)
+        XCTAssertEqual(
+            checkout.configuration.paymentMethod.count,
+            MercadoPagoCheckout<MPPaymentData.CardTransaction>.PaymentMethod.defaults.count
+        )
     }
 
-    // MARK: - setPaymentMethods chaining
-
-    func test_setPaymentMethods_shouldReplaceDefaults() {
-        // Arrange -- custom list with only credit card
-        let customMethods: [MercadoPagoCheckout.PaymentMethod] = [
+    func test_cardTransaction_setPaymentMethods_shouldReplaceDefaults() {
+        let customMethods: [MercadoPagoCheckout<MPPaymentData.CardTransaction>.PaymentMethod] = [
             .card(allowedTypes: [.credit], allowedBrands: [.visa])
         ]
 
-        // Act
         let checkout = MercadoPagoCheckout.Builder(
-            checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mercadopago.com"))),
-            checkoutAppearance: MercadoPagoCheckout.CheckoutAppearance()
+            checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mp.com"))),
+            checkoutAppearance: .init()
         )
         .setPaymentMethods(customMethods)
         .build()
 
-        // Assert
         XCTAssertEqual(checkout.configuration.paymentMethod.count, 1)
         if case let .card(types, brands, _) = checkout.configuration.paymentMethod[0] {
             XCTAssertEqual(types, [.credit])
@@ -76,53 +65,77 @@ final class MercadoPagoCheckoutBuilderTests: XCTestCase {
         }
     }
 
-    func test_setPaymentMethods_withoutArgument_shouldResetToDefaults() {
-        // Arrange -- first override, then reset
+    func test_cardTransaction_setPaymentMethods_withoutArgument_shouldResetToDefaults() {
         let builder = MercadoPagoCheckout.Builder(
-            checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mercadopago.com"))),
-            checkoutAppearance: MercadoPagoCheckout.CheckoutAppearance()
+            checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mp.com"))),
+            checkoutAppearance: .init()
         )
         builder.setPaymentMethods([.card(allowedTypes: [.credit])])
-
-        // Act -- reset via default argument
         let checkout = builder.setPaymentMethods().build()
 
-        // Assert
-        let expectedCount = MercadoPagoCheckout.PaymentMethod.defaults.count
-        XCTAssertEqual(checkout.configuration.paymentMethod.count, expectedCount)
+        XCTAssertEqual(
+            checkout.configuration.paymentMethod.count,
+            MercadoPagoCheckout<MPPaymentData.CardTransaction>.PaymentMethod.defaults.count
+        )
     }
 
     func test_setPaymentMethods_shouldBeDiscardableAndReturnSameBuilder() {
-        // Arrange
         let builder = MercadoPagoCheckout.Builder(
-            checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mercadopago.com"))),
-            checkoutAppearance: MercadoPagoCheckout.CheckoutAppearance()
+            checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mp.com"))),
+            checkoutAppearance: .init()
         )
-
-        // Act -- return value is the same reference, enabling chaining
         let chained = builder.setPaymentMethods([.card(allowedTypes: [.credit])])
-
-        // Assert
         XCTAssertTrue(chained === builder)
     }
 
-    // MARK: - Payment method identity in configuration
+    // MARK: - saveCard flow
 
-    func test_build_shouldPropagateCheckoutTypeToConfiguration() {
-        // Arrange
-        let config = MercadoPagoCheckout.Order(amount: 77.5, payer: .init(email: "test@mercadopago.com"))
-
-        // Act
+    func test_saveCard_build_kindIsSaveCard() {
         let checkout = MercadoPagoCheckout.Builder(
-            checkoutType: .cardTransaction(order: config),
-            checkoutAppearance: MercadoPagoCheckout.CheckoutAppearance()
+            checkoutType: .saveCard,
+            checkoutAppearance: .init()
         ).build()
 
-        // Assert
-        if case let .cardTransaction(cardFormConfiguration) = checkout.configuration.type {
-            XCTAssertEqual(cardFormConfiguration.amount, 77.5)
-        } else {
-            XCTFail("Expected .cardForm")
+        if case .saveCard = checkout.configuration.type.kind {} else {
+            XCTFail("Expected .saveCard kind")
         }
+    }
+
+    func test_saveCard_build_withoutSettingPaymentMethods_shouldUseDefaults() {
+        let checkout = MercadoPagoCheckout.Builder(
+            checkoutType: .saveCard,
+            checkoutAppearance: .init()
+        ).build()
+
+        XCTAssertEqual(
+            checkout.configuration.paymentMethod.count,
+            MercadoPagoCheckout<MPPaymentData.CardSave>.PaymentMethod.defaults.count
+        )
+    }
+
+    // MARK: - CheckoutType type-safety
+
+    func test_cardTransaction_checkoutType_analyticsValue() {
+        let checkoutType = MercadoPagoCheckout<MPPaymentData.CardTransaction>.CheckoutType.cardTransaction(
+            order: .init(amount: 10.0, payer: .init(email: "a@b.com"))
+        )
+        XCTAssertEqual(checkoutType.analyticsValue, "card_transaction")
+    }
+
+    func test_saveCard_checkoutType_analyticsValue() {
+        let checkoutType = MercadoPagoCheckout<MPPaymentData.CardSave>.CheckoutType.saveCard
+        XCTAssertEqual(checkoutType.analyticsValue, "save_card")
+    }
+
+    func test_cardTransaction_checkoutType_configurationAmount() {
+        let checkoutType = MercadoPagoCheckout<MPPaymentData.CardTransaction>.CheckoutType.cardTransaction(
+            order: .init(amount: 77.5, payer: .init(email: "test@mp.com"))
+        )
+        XCTAssertEqual(checkoutType.configuration.amount, 77.5)
+    }
+
+    func test_saveCard_checkoutType_configurationAmountIsZero() {
+        let checkoutType = MercadoPagoCheckout<MPPaymentData.CardSave>.CheckoutType.saveCard
+        XCTAssertEqual(checkoutType.configuration.amount, .zero)
     }
 }

--- a/Tests/MercadoPagoCheckoutTests/API/MercadoPagoCheckoutPayerTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/API/MercadoPagoCheckoutPayerTests.swift
@@ -8,19 +8,21 @@
 @testable import MercadoPagoCheckout
 import XCTest
 
+private typealias Payer = MercadoPagoCheckout<MPPaymentData.CardTransaction>.Payer
+
 /// Thin struct, but it's public API — verify the public init stores the email
 /// so a future Codable / stored-property addition doesn't silently break
 /// consumers that depend on the single-field shape.
 final class MercadoPagoCheckoutPayerTests: XCTestCase {
     func test_init_shouldStoreEmail() {
-        let payer = MercadoPagoCheckout.Payer(email: "maria@example.com")
+        let payer = Payer(email: "maria@example.com")
         XCTAssertEqual(payer.email, "maria@example.com")
     }
 
     func test_init_shouldAcceptEmptyString() {
         // Arrange -- constructor does not validate; emptiness is a valid state
         // for "email was intentionally cleared."
-        let payer = MercadoPagoCheckout.Payer(email: "")
+        let payer = Payer(email: "")
         XCTAssertEqual(payer.email, "")
     }
 }

--- a/Tests/MercadoPagoCheckoutTests/API/MercadoPagoCheckoutPaymentMethodTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/API/MercadoPagoCheckoutPaymentMethodTests.swift
@@ -8,20 +8,20 @@
 @testable import MercadoPagoCheckout
 import XCTest
 
+private typealias PaymentMethod = MercadoPagoCheckout<MPPaymentData.CardTransaction>.PaymentMethod
+private typealias CardType = MercadoPagoCheckout<MPPaymentData.CardTransaction>.CardType
+private typealias CardBrand = MercadoPagoCheckout<MPPaymentData.CardTransaction>.CardBrand
+
 /// Covers `PaymentMethod.defaults`, the `.card` associated values, and the
-/// array extensions `acceptedPaymentTypeIds` / `acceptedPaymentMethodIds` that
+/// per-element extensions `acceptedPaymentTypeIds` / `acceptedPaymentMethodIds` that
 /// feed the BIN fetch request. A drift here silently changes which card
 /// brands/types reach the backend.
 final class MercadoPagoCheckoutPaymentMethodTests: XCTestCase {
     // MARK: - .defaults
 
     func test_defaults_shouldExposeASingleCardEntry() {
-        // Arrange / Act
-        let defaults = MercadoPagoCheckout.PaymentMethod.defaults
+        let defaults = PaymentMethod.defaults
 
-        // Assert -- Fase 2 baseline: only .card is in defaults. If Pix/Boleto are added
-        // later, this test fails loudly and the maintainer must decide whether to update
-        // consumers that assume card-only.
         XCTAssertEqual(defaults.count, 1)
         guard case .card = defaults[0] else {
             XCTFail("Expected .card in defaults[0]")
@@ -30,82 +30,68 @@ final class MercadoPagoCheckoutPaymentMethodTests: XCTestCase {
     }
 
     func test_defaults_cardEntry_shouldIncludeAllDefaultTypesAndBrands() {
-        // Arrange / Act
-        let defaults = MercadoPagoCheckout.PaymentMethod.defaults
+        let defaults = PaymentMethod.defaults
         guard case let .card(types, brands, _) = defaults[0] else {
             XCTFail("Expected .card")
             return
         }
 
-        // Assert
-        XCTAssertEqual(types, MercadoPagoCheckout.CardType.defaults)
-        XCTAssertEqual(brands, MercadoPagoCheckout.CardBrand.defaults)
+        XCTAssertEqual(types, CardType.defaults)
+        XCTAssertEqual(brands, CardBrand.defaults)
     }
 
     // MARK: - acceptedPaymentTypeIds
 
     func test_acceptedPaymentTypeIds_shouldFlattenAllCardTypes() {
-        // Arrange
-        let methods: [MercadoPagoCheckout.PaymentMethod] = [
+        let methods: [PaymentMethod] = [
             .card(allowedTypes: [.credit, .debit], allowedBrands: [.visa])
         ]
 
-        // Act
-        let ids = methods.acceptedPaymentTypeIds
+        let ids = methods.flatMap(\.acceptedPaymentTypeIds)
 
-        // Assert -- backend expects "credit_card" / "debit_card" / "prepaid_card"
         XCTAssertEqual(ids, ["credit_card", "debit_card"])
     }
 
     func test_acceptedPaymentTypeIds_forMultipleCardEntries_shouldConcatenate() {
-        // Arrange -- unusual but representable: two .card methods
-        let methods: [MercadoPagoCheckout.PaymentMethod] = [
+        let methods: [PaymentMethod] = [
             .card(allowedTypes: [.credit], allowedBrands: [.visa]),
             .card(allowedTypes: [.debit], allowedBrands: [.master])
         ]
 
-        // Act
-        let ids = methods.acceptedPaymentTypeIds
+        let ids = methods.flatMap(\.acceptedPaymentTypeIds)
 
-        // Assert -- flatMap preserves order across entries
         XCTAssertEqual(ids, ["credit_card", "debit_card"])
     }
 
     func test_acceptedPaymentTypeIds_whenEmptyList_shouldReturnEmpty() {
-        let ids: [String] = [].acceptedPaymentTypeIds
+        let ids = [PaymentMethod]().flatMap(\.acceptedPaymentTypeIds)
         XCTAssertEqual(ids, [])
     }
 
     // MARK: - acceptedPaymentMethodIds
 
     func test_acceptedPaymentMethodIds_shouldFlattenAllBrands() {
-        // Arrange
-        let methods: [MercadoPagoCheckout.PaymentMethod] = [
+        let methods: [PaymentMethod] = [
             .card(allowedTypes: [.credit], allowedBrands: [.visa, .master, .amex])
         ]
 
-        // Act
-        let ids = methods.acceptedPaymentMethodIds
+        let ids = methods.flatMap(\.acceptedPaymentMethodIds)
 
-        // Assert -- each brand maps to its paymentMethodId
         XCTAssertEqual(ids, ["visa", "master", "amex"])
     }
 
     func test_acceptedPaymentMethodIds_withCustomBrand_shouldPreserveIdentifier() {
-        // Arrange
-        let methods: [MercadoPagoCheckout.PaymentMethod] = [
+        let methods: [PaymentMethod] = [
             .card(allowedTypes: [.credit], allowedBrands: [.custom("sodexo_refeicao")])
         ]
 
-        // Act
-        let ids = methods.acceptedPaymentMethodIds
+        let ids = methods.flatMap(\.acceptedPaymentMethodIds)
 
-        // Assert
         XCTAssertEqual(ids, ["sodexo_refeicao"])
     }
 
     func test_acceptedPaymentMethodIds_whenEmptyList_shouldReturnEmpty() {
-        let ids: [String] = [].acceptedPaymentMethodIds
+        let ids = [PaymentMethod]().flatMap(\.acceptedPaymentMethodIds)
         XCTAssertEqual(ids, [])
     }
 }

--- a/Tests/MercadoPagoCheckoutTests/Domain/Analytics/CardFormAnalyticsEventDataTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Domain/Analytics/CardFormAnalyticsEventDataTests.swift
@@ -8,6 +8,8 @@ import Foundation
 @testable import MPFoundation
 import XCTest
 
+private typealias CheckoutAppearance = MercadoPagoCheckout<MPPaymentData.CardTransaction>.CheckoutAppearance
+
 @MainActor
 final class CardFormAnalyticsEventDataTests: XCTestCase {
     // MARK: - CardFormInitializeEventData
@@ -232,7 +234,7 @@ final class CardFormAnalyticsEventDataTests: XCTestCase {
 
     func test_checkoutAppearance_defaultTheme_hasCustomTheme_shouldBeFalse() {
         // Arrange
-        let appearance = MercadoPagoCheckout.CheckoutAppearance()
+        let appearance = CheckoutAppearance()
 
         // Assert
         XCTAssertFalse(appearance.hasCustomTheme)
@@ -240,7 +242,7 @@ final class CardFormAnalyticsEventDataTests: XCTestCase {
 
     func test_checkoutAppearance_defaultTheme_sellerCustomization_shouldBeEmpty() {
         // Arrange
-        let appearance = MercadoPagoCheckout.CheckoutAppearance()
+        let appearance = CheckoutAppearance()
 
         // Assert
         XCTAssertEqual(appearance.sellerCustomization, [])

--- a/Tests/MercadoPagoCheckoutTests/Models/CardBrandTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Models/CardBrandTests.swift
@@ -10,18 +10,8 @@ import XCTest
 
 private typealias CardBrand = MercadoPagoCheckout<MPPaymentData.CardTransaction>.CardBrand
 
-/// The `CardBrand` type has two mappings that must stay in sync:
-/// `init(paymentMethodId:)` decodes the backend identifier into a case, and
-/// the `paymentMethodId` property encodes it back. Both directions are
-/// anchored to explicit string literals below — testing only the roundtrip
-/// would miss a symmetric drift (both sides renamed to the same wrong id),
-/// which would still round-trip cleanly while sending the wrong value to
-/// the backend.
 final class CardBrandTests: XCTestCase {
-    /// Canonical mapping between the Swift case and the backend identifier.
-    /// Drive both directions from this table so a rename on one side fails
-    /// loudly without needing a matching rename on the other.
-    private static let brandIdentifierTable: [(MercadoPagoCheckout.CardBrand, String)] = [
+    private static let brandIdentifierTable: [(CardBrand, String)] = [
         (.visa, "visa"),
         (.master, "master"),
         (.amex, "amex"),
@@ -31,7 +21,6 @@ final class CardBrandTests: XCTestCase {
         (.discover, "discover"),
         (.jcb, "jcb"),
         (.maestro, "maestro"),
-        // .unionPay is camelCased in Swift but lowercase in the backend
         (.unionPay, "unionpay"),
         (.cabal, "cabal"),
         (.naranja, "naranja")
@@ -54,7 +43,7 @@ final class CardBrandTests: XCTestCase {
     func test_init_shouldMapIdentifierToExpectedCase_forEveryBrand() {
         for (expectedBrand, id) in Self.brandIdentifierTable {
             XCTAssertEqual(
-                MercadoPagoCheckout.CardBrand(paymentMethodId: id),
+                CardBrand(paymentMethodId: id),
                 expectedBrand,
                 "decode mismatch for \"\(id)\" — expected \(expectedBrand)"
             )
@@ -64,23 +53,18 @@ final class CardBrandTests: XCTestCase {
     // MARK: - Custom fallback
 
     func test_init_withUnknownPaymentMethodId_shouldReturnCustomCase() {
-        // Arrange / Act
-        let brand = MercadoPagoCheckout.CardBrand(paymentMethodId: "sodexo_refeicao")
-
-        // Assert
+        let brand = CardBrand(paymentMethodId: "sodexo_refeicao")
         XCTAssertEqual(brand, .custom("sodexo_refeicao"))
     }
 
     func test_paymentMethodId_forCustomCase_shouldReturnProvidedIdentifier() {
-        XCTAssertEqual(MercadoPagoCheckout.CardBrand.custom("alelo").paymentMethodId, "alelo")
+        XCTAssertEqual(CardBrand.custom("alelo").paymentMethodId, "alelo")
     }
 
     // MARK: - `.defaults` inventory
 
     func test_defaults_shouldContainExpectedBrands() {
-        // Guardrail: deleting a brand from `.defaults` would silently stop
-        // showing that brand in seller-facing UI. Explicit check catches it.
-        let identifiers = MercadoPagoCheckout.CardBrand.defaults.map(\.paymentMethodId)
+        let identifiers = CardBrand.defaults.map(\.paymentMethodId)
         let expected = Set(Self.brandIdentifierTable.map(\.1))
         XCTAssertEqual(Set(identifiers), expected)
     }

--- a/Tests/MercadoPagoCheckoutTests/Models/CardBrandTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Models/CardBrandTests.swift
@@ -8,6 +8,8 @@
 @testable import MercadoPagoCheckout
 import XCTest
 
+private typealias CardBrand = MercadoPagoCheckout<MPPaymentData.CardTransaction>.CardBrand
+
 /// The `CardBrand` type has two mappings that must stay in sync:
 /// `init(paymentMethodId:)` decodes the backend identifier into a case, and
 /// the `paymentMethodId` property encodes it back. Both directions are

--- a/Tests/MercadoPagoCheckoutTests/Models/MPPaymentDataTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Models/MPPaymentDataTests.swift
@@ -60,7 +60,7 @@ final class MPPaymentDataTests: XCTestCase {
         XCTAssertEqual(data.installment, 3)
         XCTAssertEqual(data.paymentMethodId, "visa")
         XCTAssertEqual(data.paymentTypeId, "credit_card")
-        XCTAssertNil(data.issuerId)
+        XCTAssertEqual(data.issuerId, "")
         XCTAssertNil(data.payer)
     }
 

--- a/Tests/MercadoPagoCheckoutTests/Models/MPPaymentDataTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Models/MPPaymentDataTests.swift
@@ -8,101 +8,115 @@
 @testable import MercadoPagoCheckout
 import XCTest
 
-/// Tests the two parts of `MPPaymentData` that carry real logic: the internal
-/// convenience init (with its nil-to-empty-string fallbacks) and the Codable
-/// contract that backs wire/JSON persistence. Synthesized Equatable and
-/// memberwise init are intentionally not retested.
 final class MPPaymentDataTests: XCTestCase {
-    // MARK: - Convenience init (internal, with defaults)
+    // MARK: - CardSave
 
-    func test_init_withNoArguments_shouldUseDefaults() {
-        // Arrange / Act
-        let data = MPPaymentData()
-
-        // Assert
-        XCTAssertNil(data.transactionAmount)
-        XCTAssertEqual(data.token, "")
-        XCTAssertEqual(data.paymentMethodId, "")
-        XCTAssertEqual(data.paymentTypeId, "")
+    func test_cardSave_storesToken() {
+        let data = MPPaymentData.CardSave(
+            token: "tok_save_abc",
+            paymentMethodId: "visa",
+            paymentTypeId: "credit_card"
+        )
+        XCTAssertEqual(data.token, "tok_save_abc")
+        XCTAssertEqual(data.paymentMethodId, "visa")
     }
 
-    func test_init_shouldReplaceNilTokenWithEmptyString() {
-        XCTAssertEqual(MPPaymentData(token: nil).token, "")
+    func test_cardSave_codable_roundtrip() throws {
+        let original = MPPaymentData.CardSave(
+            token: "tok_save",
+            paymentMethodId: "master",
+            paymentTypeId: "debit_card",
+            issuerId: "42"
+        )
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(MPPaymentData.CardSave.self, from: encoded)
+        XCTAssertEqual(decoded, original)
     }
 
-    func test_init_shouldReplaceNilPaymentMethodIdWithEmptyString() {
-        XCTAssertEqual(MPPaymentData(paymentMethodId: nil).paymentMethodId, "")
+    func test_cardSave_equatable_sameValues_shouldBeEqual() {
+        let a = MPPaymentData.CardSave(token: "x", paymentMethodId: "visa", paymentTypeId: "credit_card")
+        let b = MPPaymentData.CardSave(token: "x", paymentMethodId: "visa", paymentTypeId: "credit_card")
+        XCTAssertEqual(a, b)
     }
 
-    func test_init_shouldReplaceNilPaymentTypeIdWithEmptyString() {
-        XCTAssertEqual(MPPaymentData(paymentTypeId: nil).paymentTypeId, "")
+    func test_cardSave_equatable_differentToken_shouldNotBeEqual() {
+        let a = MPPaymentData.CardSave(token: "x", paymentMethodId: "visa", paymentTypeId: "credit_card")
+        let b = MPPaymentData.CardSave(token: "y", paymentMethodId: "visa", paymentTypeId: "credit_card")
+        XCTAssertNotEqual(a, b)
     }
 
-    // MARK: - Codable — wire contract with backend
+    // MARK: - CardTransaction
 
-    func test_codable_roundtrip_shouldPreserveAllFields() throws {
-        // Arrange
-        let original = MPPaymentData(
+    func test_cardTransaction_defaultsAndFields() {
+        let data = MPPaymentData.CardTransaction(
+            transactionAmount: 150.0,
+            token: "tok_txn",
+            installment: 3,
+            paymentMethodId: "visa",
+            paymentTypeId: "credit_card"
+        )
+        XCTAssertEqual(data.transactionAmount, 150.0)
+        XCTAssertEqual(data.token, "tok_txn")
+        XCTAssertEqual(data.installment, 3)
+        XCTAssertEqual(data.paymentMethodId, "visa")
+        XCTAssertEqual(data.paymentTypeId, "credit_card")
+        XCTAssertNil(data.issuerId)
+        XCTAssertNil(data.payer)
+    }
+
+    func test_cardTransaction_codable_roundtrip() throws {
+        let original = MPPaymentData.CardTransaction(
             transactionAmount: 1500.75,
             token: "tok_123",
             installment: 6,
             paymentMethodId: "master",
             paymentTypeId: "credit_card",
             issuerId: "10",
-            payer: MPPaymentData.Payer(documentType: "DNI", documentNumber: "40123456")
+            payer: .init(documentType: "DNI", documentNumber: "40123456")
         )
-
-        // Act
-        let data = try JSONEncoder().encode(original)
-        let decoded = try JSONDecoder().decode(MPPaymentData.self, from: data)
-
-        // Assert
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(MPPaymentData.CardTransaction.self, from: encoded)
         XCTAssertEqual(decoded, original)
     }
 
-    func test_codable_encode_shouldProduceExpectedKeys() throws {
-        // Arrange -- key names are part of the backend wire contract; renaming
-        // a property without custom CodingKeys silently changes the payload.
-        let data = MPPaymentData(transactionAmount: 10.0, token: "t", paymentMethodId: "visa")
-
-        // Act
-        let json = try JSONEncoder().encode(data)
-        let dict = try XCTUnwrap(JSONSerialization.jsonObject(with: json) as? [String: Any])
-
-        // Assert
-        XCTAssertEqual(dict["transactionAmount"] as? Double, 10.0)
-        XCTAssertEqual(dict["token"] as? String, "t")
-        XCTAssertEqual(dict["paymentMethodId"] as? String, "visa")
-        XCTAssertEqual(dict["paymentTypeId"] as? String, "")
-    }
-
-    func test_codable_decode_shouldAcceptMissingOptionalFields() throws {
-        // Arrange -- backend may omit optional fields; decode must not fail.
-        let json = #"{"token":"tok_abc","paymentMethodId":"visa","paymentTypeId":"credit_card"}"#
-            .data(using: .utf8)!
-
-        // Act
-        let decoded = try JSONDecoder().decode(MPPaymentData.self, from: json)
-
-        // Assert
-        XCTAssertEqual(decoded.token, "tok_abc")
+    func test_cardTransaction_codable_missingOptionalFields_shouldNotFail() throws {
+        let json = #"{"token":"tok","paymentMethodId":"visa","paymentTypeId":"credit_card"}"#.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(MPPaymentData.CardTransaction.self, from: json)
+        XCTAssertEqual(decoded.token, "tok")
         XCTAssertNil(decoded.transactionAmount)
         XCTAssertNil(decoded.installment)
         XCTAssertNil(decoded.issuerId)
         XCTAssertNil(decoded.payer)
     }
 
-    // MARK: - Payer — Codable contract (nested type)
+    func test_cardTransaction_equatable_sameValues_shouldBeEqual() {
+        let a = MPPaymentData.CardTransaction(token: "t", paymentMethodId: "visa", paymentTypeId: "credit_card")
+        let b = MPPaymentData.CardTransaction(token: "t", paymentMethodId: "visa", paymentTypeId: "credit_card")
+        XCTAssertEqual(a, b)
+    }
 
-    func test_payer_codable_roundtrip_shouldPreserveFields() throws {
-        // Arrange
+    // MARK: - Payer (nested inside CardTransaction)
+
+    func test_payer_codable_roundtrip() throws {
         let original = MPPaymentData.Payer(documentType: "DNI", documentNumber: "40123456")
-
-        // Act
-        let data = try JSONEncoder().encode(original)
-        let decoded = try JSONDecoder().decode(MPPaymentData.Payer.self, from: data)
-
-        // Assert
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(MPPaymentData.Payer.self, from: encoded)
         XCTAssertEqual(decoded, original)
+    }
+
+    // MARK: - Type identity: CardSave ≠ CardTransaction
+
+    func test_cardSave_isNotCardTransaction() {
+        let save: any MPPaymentData.Kind = MPPaymentData.CardSave(
+            token: "t", paymentMethodId: "visa", paymentTypeId: "credit_card"
+        )
+        XCTAssertNil(save as? MPPaymentData.CardTransaction)
+    }
+
+    func test_cardTransaction_isNotCardSave() {
+        let txn: any MPPaymentData.Kind = MPPaymentData.CardTransaction(
+            token: "t", paymentMethodId: "visa", paymentTypeId: "credit_card"
+        )
+        XCTAssertNil(txn as? MPPaymentData.CardSave)
     }
 }

--- a/Tests/MercadoPagoCheckoutTests/Rules/CardFormRulesTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Rules/CardFormRulesTests.swift
@@ -9,6 +9,8 @@
 @testable import MPFoundation
 import XCTest
 
+private typealias CardType = MercadoPagoCheckout<MPPaymentData.CardTransaction>.CardType
+
 final class CardFormRulesTests: XCTestCase {
     // MARK: - Default Validation Data Helpers
 
@@ -377,7 +379,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardType_initFromCreditPaymentTypeId_shouldReturnCredit() {
         // Act
-        let type_ = MercadoPagoCheckout.CardType(paymentTypeId: "credit_card")
+        let type_ = CardType(paymentTypeId: "credit_card")
 
         // Assert
         XCTAssertEqual(type_, .credit)
@@ -385,7 +387,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardType_initFromDebitPaymentTypeId_shouldReturnDebit() {
         // Act
-        let type_ = MercadoPagoCheckout.CardType(paymentTypeId: "debit_card")
+        let type_ = CardType(paymentTypeId: "debit_card")
 
         // Assert
         XCTAssertEqual(type_, .debit)
@@ -393,7 +395,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardType_initFromPrepaidPaymentTypeId_shouldReturnPrepaid() {
         // Act
-        let type_ = MercadoPagoCheckout.CardType(paymentTypeId: "prepaid_card")
+        let type_ = CardType(paymentTypeId: "prepaid_card")
 
         // Assert
         XCTAssertEqual(type_, .prepaid)
@@ -401,7 +403,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardType_initFromUnknownPaymentTypeId_shouldReturnNil() {
         // Act
-        let type_ = MercadoPagoCheckout.CardType(paymentTypeId: "unknown_type")
+        let type_ = CardType(paymentTypeId: "unknown_type")
 
         // Assert
         XCTAssertNil(type_)
@@ -409,7 +411,7 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardType_initFromNilPaymentTypeId_shouldReturnNil() {
         // Act
-        let type_ = MercadoPagoCheckout.CardType(paymentTypeId: nil)
+        let type_ = CardType(paymentTypeId: nil)
 
         // Assert
         XCTAssertNil(type_)
@@ -417,8 +419,8 @@ final class CardFormRulesTests: XCTestCase {
 
     func test_cardType_paymentTypeIdRoundtrip_shouldMatchOriginal() {
         // Arrange / Act / Assert
-        for cardType in [MercadoPagoCheckout.CardType.credit, .debit, .prepaid] {
-            let roundtripped = MercadoPagoCheckout.CardType(paymentTypeId: cardType.paymentTypeId)
+        for cardType in [CardType.credit, .debit, .prepaid] {
+            let roundtripped = CardType(paymentTypeId: cardType.paymentTypeId)
             XCTAssertEqual(roundtripped, cardType)
         }
     }

--- a/Tests/MercadoPagoCheckoutTests/UseCases/InitializeCardFormUseCaseTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/UseCases/InitializeCardFormUseCaseTests.swift
@@ -37,7 +37,7 @@ final class InitializeCardFormUseCaseTests: XCTestCase {
 
     private func makeConfig(
         amount _: Double = .zero
-    ) -> MercadoPagoCheckout.CheckoutType {
+    ) -> MercadoPagoCheckout<MPPaymentData.CardSave>.CheckoutType {
         return .saveCard
     }
 

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormBrickViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormBrickViewModelTests.swift
@@ -12,7 +12,7 @@ final class CardFormBrickViewModelTests: XCTestCase {
     // MARK: - Types
 
     typealias SUT = (
-        viewModel: CardFormBrickViewModel,
+        viewModel: CardFormBrickViewModel<MPPaymentData.CardSave>,
         repository: MockCardFormInitializationRepository
     )
 
@@ -21,11 +21,14 @@ final class CardFormBrickViewModelTests: XCTestCase {
     private func makeSUT() -> SUT {
         let repository = MockCardFormInitializationRepository()
         let useCase = InitializeCardFormUseCase(repository: repository)
-        let configuration = MercadoPagoCheckout.CheckoutConfiguration(
+        let configuration = MercadoPagoCheckout<MPPaymentData.CardSave>.CheckoutConfiguration(
             type: .saveCard,
             paymentMethod: [.card(allowedTypes: [.credit, .debit, .prepaid])]
         )
-        let viewModel = CardFormBrickViewModel(configuration: configuration, initializeUseCase: useCase)
+        let viewModel = CardFormBrickViewModel<MPPaymentData.CardSave>(
+            configuration: configuration,
+            initializeUseCase: useCase
+        )
         return (viewModel, repository)
     }
 

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormBrickViewModelTrackingTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormBrickViewModelTrackingTests.swift
@@ -13,7 +13,7 @@ final class CardFormBrickViewModelTrackingTests: XCTestCase {
     // MARK: - Types
 
     typealias SUT = (
-        viewModel: CardFormBrickViewModel,
+        viewModel: CardFormBrickViewModel<MPPaymentData.CardSave>,
         repository: MockCardFormInitializationRepository,
         analytics: MockAnalytics
     )
@@ -21,16 +21,16 @@ final class CardFormBrickViewModelTrackingTests: XCTestCase {
     // MARK: - Helpers
 
     private func makeSUT(
-        appearance: MercadoPagoCheckout.CheckoutAppearance = MercadoPagoCheckout.CheckoutAppearance()
+        appearance: MercadoPagoCheckout<MPPaymentData.CardSave>.CheckoutAppearance = .init()
     ) -> SUT {
         let repository = MockCardFormInitializationRepository()
         let useCase = InitializeCardFormUseCase(repository: repository)
         let analytics = MockAnalytics()
-        let configuration = MercadoPagoCheckout.CheckoutConfiguration(
+        let configuration = MercadoPagoCheckout<MPPaymentData.CardSave>.CheckoutConfiguration(
             type: .saveCard,
             paymentMethod: [.card(allowedTypes: [.credit, .debit, .prepaid])]
         )
-        let viewModel = CardFormBrickViewModel(
+        let viewModel = CardFormBrickViewModel<MPPaymentData.CardSave>(
             configuration: configuration,
             appearance: appearance,
             initializeUseCase: useCase,

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
@@ -17,7 +17,13 @@ final class CardFormViewModelTests: XCTestCase {
     // MARK: - Types
 
     typealias SUT = (
-        viewModel: CardFormViewModel,
+        viewModel: CardFormViewModel<MPPaymentData.CardSave>,
+        service: MockCheckoutService,
+        repository: MockCardPaymentBrickCardRepository
+    )
+
+    typealias TransactionSUT = (
+        viewModel: CardFormViewModel<MPPaymentData.CardTransaction>,
         service: MockCheckoutService,
         repository: MockCardPaymentBrickCardRepository
     )
@@ -162,6 +168,12 @@ final class CardFormViewModelTests: XCTestCase {
         await self.waitForChange(sut.viewModel.$cardData)
     }
 
+    private func setupCardData(_ sut: TransactionSUT) async {
+        await sut.repository.setResult(.success(CardDataStub.visa))
+        sut.viewModel.onCardNumberChange("12345678")
+        await self.waitForChange(sut.viewModel.$cardData)
+    }
+
     private func waitForChange<T>(
         _ publisher: Published<T>.Publisher,
         timeout: TimeInterval = 1.0
@@ -182,12 +194,12 @@ final class CardFormViewModelTests: XCTestCase {
     ) -> SUT {
         let service = MockCheckoutService()
         let repository = MockCardPaymentBrickCardRepository()
-        let configuration = MercadoPagoCheckout.CheckoutConfiguration(
+        let configuration = MercadoPagoCheckout<MPPaymentData.CardSave>.CheckoutConfiguration(
             type: .saveCard,
             paymentMethod: [.card(allowedTypes: [.credit, .debit, .prepaid])]
         )
         let initResult = CardFormInitializationOutputStub.make(identificationTypes: identificationTypes)
-        let viewModel = CardFormViewModel(
+        let viewModel = CardFormViewModel<MPPaymentData.CardSave>(
             configuration: configuration,
             initResult: initResult,
             service: service,
@@ -196,15 +208,15 @@ final class CardFormViewModelTests: XCTestCase {
         return (viewModel, service, repository)
     }
 
-    private func makeSUTWithAmount(_ amount: Double) -> SUT {
+    private func makeSUTWithAmount(_ amount: Double) -> TransactionSUT {
         let service = MockCheckoutService()
         let repository = MockCardPaymentBrickCardRepository()
-        let configuration = MercadoPagoCheckout.CheckoutConfiguration(
+        let configuration = MercadoPagoCheckout<MPPaymentData.CardTransaction>.CheckoutConfiguration(
             type: .cardTransaction(order: .init(amount: amount, payer: .init(email: ""))),
             paymentMethod: [.card(allowedTypes: [.credit, .debit, .prepaid])]
         )
         let initResult = CardFormInitializationOutputStub.make(identificationTypes: [])
-        let viewModel = CardFormViewModel(
+        let viewModel = CardFormViewModel<MPPaymentData.CardTransaction>(
             configuration: configuration,
             initResult: initResult,
             service: service,
@@ -751,23 +763,46 @@ final class CardFormViewModelTests: XCTestCase {
 
     // MARK: - submitCardData
 
-    func test_submitCardData_whenServiceSucceeds_shouldCallOnSuccessWithToken() async {
+    func test_submitCardData_saveCard_whenServiceSucceeds_shouldProduceCardSaveWithToken() async {
         // Arrange
         let sut = self.makeSUT()
         await self.setupCardData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
-        var capturedPaymentData: MPPaymentData?
+        var capturedPaymentData: (any MPPaymentData.Kind)?
 
         // Act
         await sut.viewModel.submitCardData(
             cardForm: CardFormDataStub.validForm,
-            transactionAmount: nil,
+            transactionAmount: .zero,
             onSuccess: { capturedPaymentData = $0 },
             onFailure: { XCTFail("Expected success, got error: \($0)") }
         )
 
-        // Assert
-        XCTAssertEqual(capturedPaymentData?.token, CardTokenStub.valid.token)
+        // Assert — saveCard branch produces MPPaymentData.CardSave, never CardTransaction
+        let save = capturedPaymentData as? MPPaymentData.CardSave
+        XCTAssertNotNil(save)
+        XCTAssertEqual(save?.token, CardTokenStub.valid.token)
+    }
+
+    func test_submitCardData_cardTransaction_whenServiceSucceeds_shouldProduceCardTransactionWithToken() async {
+        // Arrange
+        let sut = self.makeSUTWithAmount(100.0)
+        await self.setupCardData(sut)
+        await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
+        var capturedPaymentData: (any MPPaymentData.Kind)?
+
+        // Act
+        await sut.viewModel.submitCardData(
+            cardForm: CardFormDataStub.validForm,
+            transactionAmount: 100.0,
+            onSuccess: { capturedPaymentData = $0 },
+            onFailure: { XCTFail("Expected success, got error: \($0)") }
+        )
+
+        // Assert — cardTransaction branch produces MPPaymentData.CardTransaction
+        let txn = capturedPaymentData as? MPPaymentData.CardTransaction
+        XCTAssertNotNil(txn)
+        XCTAssertEqual(txn?.token, CardTokenStub.valid.token)
     }
 
     func test_submitCardData_whenServiceFails_shouldCallOnFailure() async {
@@ -780,7 +815,7 @@ final class CardFormViewModelTests: XCTestCase {
         // Act
         await sut.viewModel.submitCardData(
             cardForm: CardFormDataStub.validForm,
-            transactionAmount: nil,
+            transactionAmount: .zero,
             onSuccess: { _ in XCTFail("Expected failure") },
             onFailure: { capturedError = $0 }
         )
@@ -798,12 +833,12 @@ final class CardFormViewModelTests: XCTestCase {
         // Act
         await sut.viewModel.submitCardData(
             cardForm: CardFormDataStub.validForm,
-            transactionAmount: nil,
+            transactionAmount: .zero,
             onSuccess: { _ in XCTFail("Expected failure due to missing card data") },
             onFailure: { capturedError = $0 }
         )
 
-        // Assert — verifies the exact contract of createPaymentData's throw path
+        // Assert — buildCardSave/buildCardTransaction both require cardData
         XCTAssertEqual(capturedError?.code, .unknown)
         XCTAssertEqual(capturedError?.locationDescription, "paymentMethods")
     }
@@ -817,7 +852,7 @@ final class CardFormViewModelTests: XCTestCase {
         // Act
         await sut.viewModel.submitCardData(
             cardForm: CardFormDataStub.validForm,
-            transactionAmount: nil,
+            transactionAmount: .zero,
             onSuccess: { _ in },
             onFailure: { _ in }
         )
@@ -837,7 +872,7 @@ final class CardFormViewModelTests: XCTestCase {
         // Act
         await sut.viewModel.submitCardData(
             cardForm: cardForm,
-            transactionAmount: nil,
+            transactionAmount: .zero,
             onSuccess: { _ in },
             onFailure: { XCTFail("Expected success, got error: \($0)") }
         )
@@ -858,7 +893,7 @@ final class CardFormViewModelTests: XCTestCase {
         // Act
         await sut.viewModel.submitCardData(
             cardForm: cardForm,
-            transactionAmount: nil,
+            transactionAmount: .zero,
             onSuccess: { _ in },
             onFailure: { XCTFail("Expected success, got error: \($0)") }
         )
@@ -881,7 +916,7 @@ final class CardFormViewModelTests: XCTestCase {
         // Act
         await sut.viewModel.submitCardData(
             cardForm: cardForm,
-            transactionAmount: nil,
+            transactionAmount: .zero,
             onSuccess: { _ in },
             onFailure: { XCTFail("Expected success, got error: \($0)") }
         )
@@ -900,7 +935,7 @@ final class CardFormViewModelTests: XCTestCase {
         // Act
         await sut.viewModel.submitCardData(
             cardForm: CardFormDataStub.validForm,
-            transactionAmount: nil,
+            transactionAmount: .zero,
             onSuccess: { _ in },
             onFailure: { XCTFail("Expected success, got error: \($0)") }
         )
@@ -910,34 +945,35 @@ final class CardFormViewModelTests: XCTestCase {
         XCTAssertEqual(captured?.documentType, IdentificationTypeStub.cpf.id)
     }
 
-    func test_submitCardData_whenDocumentTypeIsSelected_shouldIncludePayer() async {
-        // Arrange
+    func test_submitCardData_saveCard_whenDocumentTypeIsSelected_shouldIncludePayer() async {
+        // Arrange — saveCard flow also populates payer from identification type
         let sut = self.makeSUT(identificationTypes: [IdentificationTypeStub.cpf])
         await self.setupCardData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
         var cardForm = CardFormDataStub.validForm
         cardForm.documentHolder = "12345678900"
-        var capturedPaymentData: MPPaymentData?
+        var capturedPaymentData: (any MPPaymentData.Kind)?
 
         // Act
         await sut.viewModel.submitCardData(
             cardForm: cardForm,
-            transactionAmount: 200.0,
+            transactionAmount: .zero,
             onSuccess: { capturedPaymentData = $0 },
             onFailure: { XCTFail("Expected success, got error: \($0)") }
         )
 
         // Assert
-        XCTAssertEqual(capturedPaymentData?.payer?.documentType, IdentificationTypeStub.cpf.id)
-        XCTAssertEqual(capturedPaymentData?.payer?.documentNumber, "12345678900")
+        let save = capturedPaymentData as? MPPaymentData.CardSave
+        XCTAssertEqual(save?.payer?.documentType, IdentificationTypeStub.cpf.id)
+        XCTAssertEqual(save?.payer?.documentNumber, "12345678900")
     }
 
-    func test_submitCardData_whenDocumentTypeIsSelected_shouldSetTransactionAmountAndInstallment() async {
-        // Arrange
-        let sut = self.makeSUT(identificationTypes: [IdentificationTypeStub.cpf])
+    func test_submitCardData_cardTransaction_shouldSetTransactionAmountAndInstallment() async {
+        // Arrange — only cardTransaction carries transactionAmount and installment
+        let sut = self.makeSUTWithAmount(350.0)
         await self.setupCardData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
-        var capturedPaymentData: MPPaymentData?
+        var capturedPaymentData: (any MPPaymentData.Kind)?
 
         // Act
         await sut.viewModel.submitCardData(
@@ -948,9 +984,10 @@ final class CardFormViewModelTests: XCTestCase {
         )
 
         // Assert
-        XCTAssertEqual(capturedPaymentData?.transactionAmount, 350.0)
-        XCTAssertEqual(capturedPaymentData?.installment, 1)
-        XCTAssertEqual(capturedPaymentData?.token, CardTokenStub.valid.token)
+        let txn = capturedPaymentData as? MPPaymentData.CardTransaction
+        XCTAssertEqual(txn?.transactionAmount, 350.0)
+        XCTAssertEqual(txn?.installment, 1)
+        XCTAssertEqual(txn?.token, CardTokenStub.valid.token)
     }
 
     func test_submitCardData_whenCardDataIsAvailable_shouldIncludePaymentMethodAndTypeIds() async {
@@ -960,19 +997,20 @@ final class CardFormViewModelTests: XCTestCase {
         sut.viewModel.onCardNumberChange("12345678")
         await self.waitForChange(sut.viewModel.$cardData)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
-        var capturedPaymentData: MPPaymentData?
+        var capturedPaymentData: (any MPPaymentData.Kind)?
 
         // Act
         await sut.viewModel.submitCardData(
             cardForm: CardFormDataStub.validForm,
-            transactionAmount: 100.0,
+            transactionAmount: .zero,
             onSuccess: { capturedPaymentData = $0 },
             onFailure: { XCTFail("Expected success, got error: \($0)") }
         )
 
         // Assert
-        XCTAssertEqual(capturedPaymentData?.paymentMethodId, "visa")
-        XCTAssertEqual(capturedPaymentData?.paymentTypeId, "credit_card")
+        let save = capturedPaymentData as? MPPaymentData.CardSave
+        XCTAssertEqual(save?.paymentMethodId, "visa")
+        XCTAssertEqual(save?.paymentTypeId, "credit_card")
     }
 
     func test_submitCardData_whenCardDataHasIssuer_shouldIncludeIssuerId() async {
@@ -982,18 +1020,19 @@ final class CardFormViewModelTests: XCTestCase {
         sut.viewModel.onCardNumberChange("12345678")
         await self.waitForChange(sut.viewModel.$cardData)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
-        var capturedPaymentData: MPPaymentData?
+        var capturedPaymentData: (any MPPaymentData.Kind)?
 
         // Act
         await sut.viewModel.submitCardData(
             cardForm: CardFormDataStub.validForm,
-            transactionAmount: 100.0,
+            transactionAmount: .zero,
             onSuccess: { capturedPaymentData = $0 },
             onFailure: { XCTFail("Expected success, got error: \($0)") }
         )
 
         // Assert
-        XCTAssertEqual(capturedPaymentData?.issuerId, "24")
+        let save = capturedPaymentData as? MPPaymentData.CardSave
+        XCTAssertEqual(save?.issuerId, "24")
     }
 
     func test_retryBinFetch_whenCalledTwice_withNetworkError_shouldShowSnackbarBothTimes() async {

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTrackingTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTrackingTests.swift
@@ -14,7 +14,7 @@ final class CardFormViewModelTrackingTests: XCTestCase {
     // MARK: - Types
 
     typealias SUT = (
-        viewModel: CardFormViewModel,
+        viewModel: CardFormViewModel<MPPaymentData.CardSave>,
         service: MockCheckoutService,
         repository: MockCardPaymentBrickCardRepository,
         analytics: MockAnalytics
@@ -96,12 +96,12 @@ final class CardFormViewModelTrackingTests: XCTestCase {
         let service = MockCheckoutService()
         let repository = MockCardPaymentBrickCardRepository()
         let analytics = MockAnalytics()
-        let configuration = MercadoPagoCheckout.CheckoutConfiguration(
+        let configuration = MercadoPagoCheckout<MPPaymentData.CardSave>.CheckoutConfiguration(
             type: .saveCard,
             paymentMethod: [.card(allowedTypes: [.credit, .debit, .prepaid])]
         )
         let initResult = CardFormInitializationOutputStub.make(identificationTypes: identificationTypes)
-        let viewModel = CardFormViewModel(
+        let viewModel = CardFormViewModel<MPPaymentData.CardSave>(
             configuration: configuration,
             initResult: initResult,
             service: service,
@@ -283,7 +283,7 @@ final class CardFormViewModelTrackingTests: XCTestCase {
         // Act
         await sut.viewModel.submitCardData(
             cardForm: CardFormDataStub.valid,
-            transactionAmount: nil,
+            transactionAmount: .zero,
             onSuccess: { _ in },
             onFailure: { _ in }
         )
@@ -336,7 +336,7 @@ final class CardFormViewModelTrackingTests: XCTestCase {
         // Act
         await sut.viewModel.submitCardData(
             cardForm: CardFormDataStub.valid,
-            transactionAmount: nil,
+            transactionAmount: .zero,
             onSuccess: { _ in },
             onFailure: { _ in }
         )
@@ -437,7 +437,7 @@ final class CardFormViewModelTrackingTests: XCTestCase {
 
         await sut.viewModel.submitCardData(
             cardForm: CardFormDataStub.valid,
-            transactionAmount: nil,
+            transactionAmount: .zero,
             onSuccess: { _ in },
             onFailure: { _ in }
         )

--- a/Tests/SnapshotTests/MercadoPagoCheckout/InstallmentsViewTests.swift
+++ b/Tests/SnapshotTests/MercadoPagoCheckout/InstallmentsViewTests.swift
@@ -14,7 +14,7 @@ import XCTest
 @MainActor
 final class InstallmentsViewTests: XCTestCase {
     func test_installmentScreen() {
-        var paymentData = MPPaymentData(transactionAmount: 1000, token: "")
+        var paymentData = MPPaymentData.CardTransaction(transactionAmount: 1000, token: "", paymentMethodId: "", paymentTypeId: "")
         let view = InstallmentScreen(
             paymentData: Binding(get: { paymentData }, set: { paymentData = $0 }),
             installments: Self.validInstallments,


### PR DESCRIPTION
## Description

`MercadoPagoCheckoutResult.Success` previously delivered `MPPaymentData` as the base type. Even though the integrator already knew which `CheckoutType` they had configured in the builder, they were forced to write a nested switch on `paymentData` to access type-specific fields — including unreachable branches that would never execute.

More critically, adding a new payment method (e.g. Pix) to `MPPaymentData` would silently break every consumer that handled Success without an else branch, with no warning or deprecation path.

This PR propagates the type parameter `T` from `CheckoutType` through the builder and into the callback, so `result.paymentData` is already the concrete subtype at the call site — no cast, no nested switch.

## What changed

`MPPaymentData` is now a sealed namespace with two concrete variants:
- `MPPaymentData.CardSave` — produced by the `saveCard` flow (token + payment method info)
- `MPPaymentData.CardTransaction` — produced by the `cardTransaction` flow (full fields)

`MercadoPagoCheckoutResult<T: MPPaymentData.Kind>` — generic in T:
- `success(T)` carries the concrete payment data type
- `error` and `userCancelled` are available for any T

`MercadoPagoCheckout<T>` / `Builder` — T is inferred automatically from the `CheckoutType` passed to the constructor

`CardFormBrick<T>` — single `as? T` cast (Swift equivalent of `@Suppress("UNCHECKED_CAST")`); safe by SDK contract

## Integrator impact

Before:
```swift
let checkout = MercadoPagoCheckout.Builder(checkoutType: .cardTransaction(order: ...)).build()
checkout.show { result in
    switch result {
    case .success(let data):
        if let txn = data as? MPPaymentData.CardTransaction {
            print(txn.token) // forced cast
        }
    }
}
```

After:
```swift
let checkout = MercadoPagoCheckout.Builder(checkoutType: .cardTransaction(order: ...)).build()
checkout.show { result in
    switch result {
    case .success(let data): print(data.token)  // direct access
    case .error(let e): ...
    case .userCancelled(let ctx): ...
    }
}
```

## Checklist
- [ ] I have tested my changes creating a local version
- [ ] New and existing unit tests pass locally
- [ ] I have run swiftlint and fixed any possible issues