### PR TITLE
(Refactor): Change installments initialize track to type view

### DIFF
--- a/Sources/MercadoPagoCheckout/Views/InstallmentScreenViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/InstallmentScreenViewModel.swift
@@ -98,7 +98,7 @@ final class InstallmentsScreenViewModel: ObservableObject {
         )
         let analytics = self.analytics
         Task(priority: .low) {
-            await analytics.trackEvent(InstallmentAnalyticsPath.initialize)
+            await analytics.trackView(InstallmentAnalyticsPath.initialize)
                 .setEventData(eventData)
                 .send()
         }

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/InstallmentsScreenViewModelTrackingTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/InstallmentsScreenViewModelTrackingTests.swift
@@ -45,7 +45,7 @@ final class InstallmentsScreenViewModelTrackingTests: XCTestCase {
 
         // Assert
         let messages = await sut.analytics.mock.getMessages()
-        XCTAssertTrue(messages.contains(.track(path: InstallmentAnalyticsPath.initialize)))
+        XCTAssertTrue(messages.contains(.trackView(InstallmentAnalyticsPath.initialize)))
         XCTAssertTrue(messages.contains(.send))
     }
 


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
No ticket

## Description
- Changed `trackEvent` to `trackView` in `InstallmentsScreenViewModel.trackInitialize` — the initialize screen event should be tracked as a view event, not a generic event
- Updated `InstallmentsScreenViewModelTrackingTests` to assert `.trackView` instead of `.track` for the initialize path

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [x] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.