### PR TITLE
SDK-MIRROR: add PR mirroring, CI status, QA checks and UX reference protection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+ux-reference/deliveries/**/*.html   linguist-documentation=true

--- a/.mirrorignore
+++ b/.mirrorignore
@@ -1,0 +1,5 @@
+# .mirrorignore
+# Caminhos listados aqui são removidos de todos os pushes para o repo público.
+# O workflow lê este arquivo — nenhuma alteração no workflow é necessária para novas exclusões.
+ux-reference/
+.github/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: local
+    hooks:
+      - id: ux-reference-immutability
+        name: UX Reference Immutability Check
+        description: Blocks modifications to UX deliveries already merged to main.
+        language: script
+        entry: scripts/ux_reference/check_immutability.sh
+        files: ^ux-reference/deliveries/

--- a/scripts/ux_reference/check_immutability.sh
+++ b/scripts/ux_reference/check_immutability.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STAGED=$(git diff --cached --name-only | grep '^ux-reference/deliveries/' || true)
+[ -z "$STAGED" ] && exit 0
+
+git fetch origin main --quiet 2>/dev/null || true
+
+BLOCKED=""
+while IFS= read -r file; do
+  if git ls-tree -r origin/main --name-only | grep -qF "$file"; then
+    BLOCKED="$BLOCKED\n  Attempted to modify: $file"
+  fi
+done <<< "$STAGED"
+
+if [ -n "$BLOCKED" ]; then
+  echo ""
+  echo "[ux-reference] BLOCKED: Modifications to existing UX deliveries are not allowed."
+  echo -e "$BLOCKED"
+  echo ""
+  echo "  UX deliveries are immutable after merge to main."
+  echo "  To update a screen, create a new dated delivery directory instead."
+  echo ""
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds bidirectional PR mirroring between private (`melisource/fury_openplatform-sdk-ios`) and public (`mercadopago/sdk-ios`) repos via GitHub Actions
- Adds CI status mirroring: polls CircleCI on the public repo and posts results as comments on private PRs
- Adds 4 PR quality gates as required checks: Jira ticket, 500-line size limit, 1 biz-day merge readiness, description + checklist
- Adds UX Reference delivery protection: pre-commit hook blocks modifications to deliveries already merged to main

## Checklist

- [x] `USER_PAT_MAP` and `MIRROR_TARGET_REPO` secrets set on this repo
- [x] `meliguicarvalho` and `capaixao` have Write access on `mercadopago/sdk-ios`
- [ ] Configure required checks in branch protection: `check-jira`, `check-size`, `merge-readiness`, `check-description`

## Test plan

Same as Android — see melisource/fury_openplatform-sdk-android#5 for reference and validated flow.