### PR TITLE
[CHOBK-4052] (Refactor): Rename PaymentMethod to excluded types approach

### DIFF
--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
@@ -79,8 +79,8 @@ final class CardFormBrickViewModel<T: MPPaymentData.Kind>: ObservableObject {
             checkoutType: self.configuration.type.analyticsValue,
             appearance: self.appearance.style.analyticsValue,
             sellerCustomization: self.appearance.sellerCustomization,
-            allowedPaymentTypes: self.configuration.paymentMethod.flatMap(\.acceptedPaymentTypeIds),
-            allowedPaymentMethods: self.configuration.paymentMethod.flatMap(\.acceptedPaymentMethodIds)
+            excludedPaymentTypes: self.configuration.paymentMethod.excludedPaymentTypeIds,
+            excludedPaymentMethods: self.configuration.paymentMethod.excludedPaymentMethodIds
         )
 
         let analytics = self.analytics

--- a/Sources/MercadoPagoCheckout/Data/Model/CardPaymentBrickCardParams.swift
+++ b/Sources/MercadoPagoCheckout/Data/Model/CardPaymentBrickCardParams.swift
@@ -10,6 +10,6 @@ struct CardPaymentBrickCardParams {
     let amount: Double?
     let checkoutType: String
     let processingMode: String
-    let allowCardTypes: [String]
-    let allowCardBrands: [String]
+    let excludedCardTypes: [String]
+    let excludedCardBrands: [String]
 }

--- a/Sources/MercadoPagoCheckout/Data/Network/CardPaymentBrickEndpoint.swift
+++ b/Sources/MercadoPagoCheckout/Data/Network/CardPaymentBrickEndpoint.swift
@@ -50,8 +50,12 @@ extension CardPaymentBrickEndpoint: RequestEndpoint {
                 "amount": params.amount ?? 0
             ]
 
-            result["allow_payment_types"] = params.allowCardTypes.joined(separator: ",")
-            result["allow_payment_methods"] = params.allowCardBrands.joined(separator: ",")
+            if !params.excludedCardTypes.isEmpty {
+                result["excluded_payment_types"] = params.excludedCardTypes.joined(separator: ",")
+            }
+            if !params.excludedCardBrands.isEmpty {
+                result["excluded_payment_methods"] = params.excludedCardBrands.joined(separator: ",")
+            }
             return result
         }
     }

--- a/Sources/MercadoPagoCheckout/Domain/Analytics/CardFormInitializeEventData.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Analytics/CardFormInitializeEventData.swift
@@ -4,16 +4,16 @@ struct CardFormInitializeEventData: AnalyticsEventData {
     let checkoutType: String
     let appearance: String
     let sellerCustomization: [String]
-    let allowedPaymentTypes: [String]
-    let allowedPaymentMethods: [String]
+    let excludedPaymentTypes: [String]
+    let excludedPaymentMethods: [String]
 
     func toDictionary() -> [String: any Sendable] {
         [
             "checkout_type": self.checkoutType,
             "appearance": self.appearance,
             "seller_customization": self.sellerCustomization,
-            "allowed_payment_types": self.allowedPaymentTypes,
-            "allowed_payment_methods": self.allowedPaymentMethods
+            "excluded_payment_types": self.excludedPaymentTypes,
+            "excluded_payment_methods": self.excludedPaymentMethods
         ]
     }
 }

--- a/Sources/MercadoPagoCheckout/MPCheckoutConfiguration.swift
+++ b/Sources/MercadoPagoCheckout/MPCheckoutConfiguration.swift
@@ -12,10 +12,10 @@
 struct MPCheckoutConfiguration<T: MPPaymentData.Kind>: Sendable {
     /// The type of checkout experience to present.
     var type: MercadoPagoCheckout<T>.CheckoutType
-    /// The payment methods available during the checkout flow.
-    var paymentMethod: [MPPaymentMethod]
+    /// The payment method  configuration for the checkout flow.
+    var paymentMethod: [MPPaymentMethodConfig]
 
-    init(type: MercadoPagoCheckout<T>.CheckoutType, paymentMethod: [MPPaymentMethod]) {
+    init(type: MercadoPagoCheckout<T>.CheckoutType, paymentMethod: [MPPaymentMethodConfig]) {
         self.type = type
         self.paymentMethod = paymentMethod
     }

--- a/Sources/MercadoPagoCheckout/MPPaymentMethod.swift
+++ b/Sources/MercadoPagoCheckout/MPPaymentMethod.swift
@@ -5,35 +5,38 @@
 //  Created by Danielle Nozaki Ogawa on 20/02/26.
 //
 
-/// A payment method available during the checkout flow.
-public enum MPPaymentMethod: Sendable {
+/// A payment method configuration for the checkout flow.
+public enum MPPaymentMethodConfig: Sendable {
     /// A credit, debit, or prepaid card payment.
     /// - Parameters:
-    ///   - cardTypes: The card types accepted (e.g. `.credit`, `.debit`, `.prepaid`).
-    ///   - cardBrands: The card brands accepted (e.g. `.visa`, `.mastercard`). Empty means all brands are accepted.
+    ///   - excludedTypes: The card types to exclude (e.g. `.prepaid`). Empty means all types are accepted.
+    ///   - excludedBrands: The card brands to exclude (e.g. `.amex`). Empty means all brands are accepted.
     ///   - installment: Installment options for this payment method. Defaults to ``MPInstallment/init()``.
     case card(
-        allowedTypes: [MPCardType] = MPCardType.defaults,
-        allowedBrands: [MPCardBrand] = MPCardBrand.defaults,
+        excludedTypes: [MPCardType] = [],
+        excludedBrands: [MPCardBrand] = [],
         installment: MPInstallment? = MPInstallment()
     )
-
-    /// The default set of payment methods: card (credit, debit, prepaid), Pix, and Boleto.
-    public static var defaults: [MPPaymentMethod] {
+    
+    public static var defaults: [MPPaymentMethodConfig] {
         [
-            .card(allowedTypes: MPCardType.defaults, allowedBrands: MPCardBrand.defaults)
+            .card(excludedTypes: [], excludedBrands: [])
         ]
     }
 }
 
-extension MPPaymentMethod {
-    var acceptedPaymentTypeIds: [String] {
-        guard case let .card(cardTypes, _, _) = self else { return [] }
-        return cardTypes.map(\.paymentTypeId)
+extension [MPPaymentMethodConfig] {
+    var excludedPaymentTypeIds: [String] {
+        flatMap { method -> [String] in
+            guard case let .card(excludedTypes, _, _) = method else { return [] }
+            return excludedTypes.map(\.paymentTypeId)
+        }
     }
 
-    var acceptedPaymentMethodIds: [String] {
-        guard case let .card(_, cardBrands, _) = self else { return [] }
-        return cardBrands.map(\.paymentMethodId)
+    var excludedPaymentMethodIds: [String] {
+        flatMap { method -> [String] in
+            guard case let .card(_, excludedBrands, _) = method else { return [] }
+            return excludedBrands.map(\.paymentMethodId)
+        }
     }
 }

--- a/Sources/MercadoPagoCheckout/MercadoPagoCheckout+Builder.swift
+++ b/Sources/MercadoPagoCheckout/MercadoPagoCheckout+Builder.swift
@@ -17,17 +17,15 @@ public extension MercadoPagoCheckout {
     ///     checkoutType: .cardTransaction(order: .init(amount: 150.0, payer: .init(email: "..."))),
     ///     checkoutAppearance: .init()
     /// )
-    /// .setPaymentMethods([.card(allowedTypes: [.credit])])
+    /// .setPaymentMethodConfiguration([.card(excludedTypes: [.prepaid])])
     /// .build()
     /// ```
     final class Builder {
         private var checkoutType: CheckoutType
         private var checkoutAppearance: MPCheckoutAppearance
-        private var paymentMethods: [MPPaymentMethod]
+        private var paymentMethodConfigs: [MPPaymentMethodConfig]
 
         /// Creates a new builder with the required checkout type and appearance.
-        ///
-        /// Payment methods default to ``MPPaymentMethod/defaults``.
         ///
         /// - Parameters:
         ///   - checkoutType: The type of checkout experience to present.
@@ -35,16 +33,16 @@ public extension MercadoPagoCheckout {
         public init(checkoutType: CheckoutType, checkoutAppearance: MPCheckoutAppearance) {
             self.checkoutType = checkoutType
             self.checkoutAppearance = checkoutAppearance
-            self.paymentMethods = MPPaymentMethod.defaults
+            self.paymentMethodConfigs = MPPaymentMethodConfig.defaults
         }
 
-        /// Sets the payment methods available during the checkout flow.
+        /// Sets the payment method exclusion configuration for the checkout flow.
         ///
-        /// - Parameter paymentMethods: The payment methods to enable. Defaults to ``MPPaymentMethod/defaults``.
+        /// - Parameter paymentMethodConfigs: The payment method configurations to apply. Defaults to `[]` (no exclusions).
         /// - Returns: The builder instance for chaining.
         @discardableResult
-        public func setPaymentMethods(_ paymentMethods: [MPPaymentMethod] = MPPaymentMethod.defaults) -> Builder {
-            self.paymentMethods = paymentMethods
+        public func setPaymentMethodConfiguration(_ paymentMethodConfigs: [MPPaymentMethodConfig] = []) -> Builder {
+            self.paymentMethodConfigs = paymentMethodConfigs
             return self
         }
 
@@ -57,7 +55,7 @@ public extension MercadoPagoCheckout {
                 theme: self.checkoutAppearance,
                 configuration: .init(
                     type: self.checkoutType,
-                    paymentMethod: self.paymentMethods
+                    paymentMethod: self.paymentMethodConfigs
                 )
             )
         }

--- a/Sources/MercadoPagoCheckout/MercadoPagoCheckout.swift
+++ b/Sources/MercadoPagoCheckout/MercadoPagoCheckout.swift
@@ -26,7 +26,7 @@ import UIKit
 //     checkoutType: .cardTransaction(order: .init(amount: 99.90, payer: .init(email: "..."))),
 //     checkoutAppearance: .init()
 // )
-// .setPaymentMethods([.card(allowedTypes: [.credit, .debit])])
+// .setPaymentMethodConfiguration([.card(excludedTypes: [.prepaid])])
 // .build()
 //
 // // SwiftUI

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -253,8 +253,8 @@ final class CardFormViewModel<T: MPPaymentData.Kind>: ObservableObject {
             amount: self.configuration.type.configuration.amount,
             checkoutType: self.configuration.type.analyticsValue,
             processingMode: ProcessingMode.aggregator.rawValue,
-            allowCardTypes: self.configuration.paymentMethod.flatMap(\.acceptedPaymentTypeIds),
-            allowCardBrands: self.configuration.paymentMethod.flatMap(\.acceptedPaymentMethodIds)
+            excludedCardTypes: self.configuration.paymentMethod.excludedPaymentTypeIds,
+            excludedCardBrands: self.configuration.paymentMethod.excludedPaymentMethodIds
         )
     }
 

--- a/Tests/MercadoPagoCheckoutTests/API/MercadoPagoCheckoutBuilderTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/API/MercadoPagoCheckoutBuilderTests.swift
@@ -10,9 +10,9 @@ import XCTest
 
 /// The `Builder` is the only ergonomic entry point for constructing a
 /// `MercadoPagoCheckout` — consumers of the SDK go through it. Tests below
-/// assert the stored fields and the default payment methods so a silent
-/// regression (e.g. `.defaults` becoming empty) fails here rather than in
-/// production. The generic T parameter is also exercised to confirm that
+/// assert the stored fields and the default payment method configuration so a
+/// silent regression (e.g. configuration not persisting) fails here rather than
+/// in production. The generic T parameter is also exercised to confirm that
 /// `.cardTransaction` produces `MercadoPagoCheckout<CardTransaction>` and
 /// `.saveCard` produces `MercadoPagoCheckout<CardSave>`.
 @MainActor
@@ -32,28 +32,32 @@ final class MercadoPagoCheckoutBuilderTests: XCTestCase {
         }
     }
 
-    func test_cardTransaction_build_withoutSettingPaymentMethods_shouldUseDefaults() {
+    func test_build_withoutSettingPaymentMethodConfiguration_shouldHaveDefaultConfiguration() {
         let checkout = MercadoPagoCheckout.Builder(
             checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mp.com"))),
             checkoutAppearance: .init()
         ).build()
 
-        XCTAssertEqual(
-            checkout.configuration.paymentMethod.count,
-            MPPaymentMethod.defaults.count
-        )
+        XCTAssertEqual(checkout.configuration.paymentMethod.count, 1)
+        if case let .card(excludedTypes, excludedBrands, installment) = checkout.configuration.paymentMethod[0] {
+            XCTAssertTrue(excludedTypes.isEmpty)
+            XCTAssertTrue(excludedBrands.isEmpty)
+            XCTAssertNotNil(installment)
+        } else {
+            XCTFail("Expected .card payment method config")
+        }
     }
 
-    func test_cardTransaction_setPaymentMethods_shouldReplaceDefaults() {
-        let customMethods: [MPPaymentMethod] = [
-            .card(allowedTypes: [.credit], allowedBrands: [.visa])
+    func test_setPaymentMethodConfiguration_shouldStoreConfiguration() {
+        let customConfig: [MPPaymentMethodConfig] = [
+            .card(excludedTypes: [.credit], excludedBrands: [.visa])
         ]
 
         let checkout = MercadoPagoCheckout.Builder(
             checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mp.com"))),
             checkoutAppearance: .init()
         )
-        .setPaymentMethods(customMethods)
+        .setPaymentMethodConfiguration(customConfig)
         .build()
 
         XCTAssertEqual(checkout.configuration.paymentMethod.count, 1)
@@ -61,30 +65,30 @@ final class MercadoPagoCheckoutBuilderTests: XCTestCase {
             XCTAssertEqual(types, [.credit])
             XCTAssertEqual(brands, [.visa])
         } else {
-            XCTFail("Expected .card payment method")
+            XCTFail("Expected .card payment method config")
         }
     }
 
-    func test_cardTransaction_setPaymentMethods_withoutArgument_shouldResetToDefaults() {
+    func test_setPaymentMethodConfiguration_withNoArgument_shouldResetToEmpty() {
         let builder = MercadoPagoCheckout.Builder(
             checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mp.com"))),
             checkoutAppearance: .init()
         )
-        builder.setPaymentMethods([.card(allowedTypes: [.credit])])
-        let checkout = builder.setPaymentMethods().build()
+        builder.setPaymentMethodConfiguration([.card(excludedTypes: [.credit])])
 
-        XCTAssertEqual(
-            checkout.configuration.paymentMethod.count,
-            MPPaymentMethod.defaults.count
-        )
+        let checkout = builder.setPaymentMethodConfiguration().build()
+
+        XCTAssertEqual(checkout.configuration.paymentMethod.count, 0)
     }
 
-    func test_setPaymentMethods_shouldBeDiscardableAndReturnSameBuilder() {
+    func test_setPaymentMethodConfiguration_shouldBeDiscardableAndReturnSameBuilder() {
         let builder = MercadoPagoCheckout.Builder(
             checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mp.com"))),
             checkoutAppearance: .init()
         )
-        let chained = builder.setPaymentMethods([.card(allowedTypes: [.credit])])
+
+        let chained = builder.setPaymentMethodConfiguration([.card(excludedTypes: [.credit])])
+
         XCTAssertTrue(chained === builder)
     }
 
@@ -101,16 +105,20 @@ final class MercadoPagoCheckoutBuilderTests: XCTestCase {
         }
     }
 
-    func test_saveCard_build_withoutSettingPaymentMethods_shouldUseDefaults() {
+    func test_saveCard_build_withoutSettingPaymentMethodConfiguration_shouldHaveDefaultConfiguration() {
         let checkout = MercadoPagoCheckout.Builder(
             checkoutType: .saveCard,
             checkoutAppearance: .init()
         ).build()
 
-        XCTAssertEqual(
-            checkout.configuration.paymentMethod.count,
-            MPPaymentMethod.defaults.count
-        )
+        XCTAssertEqual(checkout.configuration.paymentMethod.count, 1)
+        if case let .card(excludedTypes, excludedBrands, installment) = checkout.configuration.paymentMethod[0] {
+            XCTAssertTrue(excludedTypes.isEmpty)
+            XCTAssertTrue(excludedBrands.isEmpty)
+            XCTAssertNotNil(installment)
+        } else {
+            XCTFail("Expected .card payment method config")
+        }
     }
 
     // MARK: - CheckoutType type-safety

--- a/Tests/MercadoPagoCheckoutTests/API/MercadoPagoCheckoutPaymentMethodTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/API/MercadoPagoCheckoutPaymentMethodTests.swift
@@ -8,90 +8,95 @@
 @testable import MercadoPagoCheckout
 import XCTest
 
-private typealias PaymentMethod = MPPaymentMethod
+private typealias PaymentMethodConfig = MPPaymentMethodConfig
 private typealias CardType = MPCardType
 private typealias CardBrand = MPCardBrand
 
-/// Covers `PaymentMethod.defaults`, the `.card` associated values, and the
-/// per-element extensions `acceptedPaymentTypeIds` / `acceptedPaymentMethodIds` that
+/// Covers `MPPaymentMethodConfig.card` associated values and the
+/// array extensions `excludedPaymentTypeIds` / `excludedPaymentMethodIds` that
 /// feed the BIN fetch request. A drift here silently changes which card
-/// brands/types reach the backend.
+/// brands/types are excluded from the backend request.
 final class MercadoPagoCheckoutPaymentMethodTests: XCTestCase {
-    // MARK: - .defaults
+    // MARK: - Default card (no exclusions)
 
-    func test_defaults_shouldExposeASingleCardEntry() {
-        let defaults = PaymentMethod.defaults
-
-        XCTAssertEqual(defaults.count, 1)
-        guard case .card = defaults[0] else {
-            XCTFail("Expected .card in defaults[0]")
-            return
-        }
-    }
-
-    func test_defaults_cardEntry_shouldIncludeAllDefaultTypesAndBrands() {
-        let defaults = PaymentMethod.defaults
-        guard case let .card(types, brands, _) = defaults[0] else {
+    func test_cardWithNoArguments_shouldHaveEmptyExclusions() {
+        guard case let .card(types, brands, _) = PaymentMethodConfig.card() else {
             XCTFail("Expected .card")
             return
         }
 
-        XCTAssertEqual(types, CardType.defaults)
-        XCTAssertEqual(brands, CardBrand.defaults)
+        XCTAssertEqual(types, [])
+        XCTAssertEqual(brands, [])
     }
 
-    // MARK: - acceptedPaymentTypeIds
+    // MARK: - excludedPaymentTypeIds
 
-    func test_acceptedPaymentTypeIds_shouldFlattenAllCardTypes() {
-        let methods: [PaymentMethod] = [
-            .card(allowedTypes: [.credit, .debit], allowedBrands: [.visa])
+    func test_excludedPaymentTypeIds_shouldFlattenExcludedCardTypes() {
+        let config: [PaymentMethodConfig] = [
+            .card(excludedTypes: [.credit, .debit], excludedBrands: [])
         ]
 
-        let ids = methods.flatMap(\.acceptedPaymentTypeIds)
+        let ids = config.excludedPaymentTypeIds
 
         XCTAssertEqual(ids, ["credit_card", "debit_card"])
     }
 
-    func test_acceptedPaymentTypeIds_forMultipleCardEntries_shouldConcatenate() {
-        let methods: [PaymentMethod] = [
-            .card(allowedTypes: [.credit], allowedBrands: [.visa]),
-            .card(allowedTypes: [.debit], allowedBrands: [.master])
+    func test_excludedPaymentTypeIds_forMultipleCardEntries_shouldConcatenate() {
+        let config: [PaymentMethodConfig] = [
+            .card(excludedTypes: [.credit], excludedBrands: []),
+            .card(excludedTypes: [.debit], excludedBrands: [])
         ]
 
-        let ids = methods.flatMap(\.acceptedPaymentTypeIds)
+        let ids = config.excludedPaymentTypeIds
 
         XCTAssertEqual(ids, ["credit_card", "debit_card"])
     }
 
-    func test_acceptedPaymentTypeIds_whenEmptyList_shouldReturnEmpty() {
-        let ids = [PaymentMethod]().flatMap(\.acceptedPaymentTypeIds)
+    func test_excludedPaymentTypeIds_whenEmptyList_shouldReturnEmpty() {
+        let ids = [PaymentMethodConfig]().excludedPaymentTypeIds
         XCTAssertEqual(ids, [])
     }
 
-    // MARK: - acceptedPaymentMethodIds
+    func test_excludedPaymentTypeIds_whenNoExclusions_shouldReturnEmpty() {
+        let config: [PaymentMethodConfig] = [.card()]
 
-    func test_acceptedPaymentMethodIds_shouldFlattenAllBrands() {
-        let methods: [PaymentMethod] = [
-            .card(allowedTypes: [.credit], allowedBrands: [.visa, .master, .amex])
+        let ids = config.excludedPaymentTypeIds
+
+        XCTAssertEqual(ids, [])
+    }
+
+    // MARK: - excludedPaymentMethodIds
+
+    func test_excludedPaymentMethodIds_shouldFlattenExcludedBrands() {
+        let config: [PaymentMethodConfig] = [
+            .card(excludedTypes: [], excludedBrands: [.visa, .master, .amex])
         ]
 
-        let ids = methods.flatMap(\.acceptedPaymentMethodIds)
+        let ids = config.excludedPaymentMethodIds
 
         XCTAssertEqual(ids, ["visa", "master", "amex"])
     }
 
-    func test_acceptedPaymentMethodIds_withCustomBrand_shouldPreserveIdentifier() {
-        let methods: [PaymentMethod] = [
-            .card(allowedTypes: [.credit], allowedBrands: [.custom("sodexo_refeicao")])
+    func test_excludedPaymentMethodIds_withCustomBrand_shouldPreserveIdentifier() {
+        let config: [PaymentMethodConfig] = [
+            .card(excludedTypes: [], excludedBrands: [.custom("sodexo_refeicao")])
         ]
 
-        let ids = methods.flatMap(\.acceptedPaymentMethodIds)
+        let ids = config.excludedPaymentMethodIds
 
         XCTAssertEqual(ids, ["sodexo_refeicao"])
     }
 
-    func test_acceptedPaymentMethodIds_whenEmptyList_shouldReturnEmpty() {
-        let ids = [PaymentMethod]().flatMap(\.acceptedPaymentMethodIds)
+    func test_excludedPaymentMethodIds_whenEmptyList_shouldReturnEmpty() {
+        let ids = [PaymentMethodConfig]().excludedPaymentMethodIds
+        XCTAssertEqual(ids, [])
+    }
+
+    func test_excludedPaymentMethodIds_whenNoExclusions_shouldReturnEmpty() {
+        let config: [PaymentMethodConfig] = [.card()]
+
+        let ids = config.excludedPaymentMethodIds
+
         XCTAssertEqual(ids, [])
     }
 }

--- a/Tests/MercadoPagoCheckoutTests/Data/RemoteCardPaymentBrickCardRepositoryTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Data/RemoteCardPaymentBrickCardRepositoryTests.swift
@@ -31,8 +31,8 @@ final class RemoteCardPaymentBrickCardRepositoryTests: XCTestCase {
             amount: 300.0,
             checkoutType: "card_payment_brick",
             processingMode: "aggregator",
-            allowCardTypes: [],
-            allowCardBrands: []
+            excludedCardTypes: [],
+            excludedCardBrands: []
         )
     }
 

--- a/Tests/MercadoPagoCheckoutTests/Domain/Analytics/CardFormAnalyticsEventDataTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Domain/Analytics/CardFormAnalyticsEventDataTests.swift
@@ -20,8 +20,8 @@ final class CardFormAnalyticsEventDataTests: XCTestCase {
             checkoutType: "card_form",
             appearance: "system",
             sellerCustomization: ["customized_token"],
-            allowedPaymentTypes: ["credit_card"],
-            allowedPaymentMethods: ["visa"]
+            excludedPaymentTypes: ["credit_card"],
+            excludedPaymentMethods: ["visa"]
         )
 
         // Act
@@ -31,8 +31,8 @@ final class CardFormAnalyticsEventDataTests: XCTestCase {
         XCTAssertEqual(dict["checkout_type"] as? String, "card_form")
         XCTAssertEqual(dict["appearance"] as? String, "system")
         XCTAssertEqual(dict["seller_customization"] as? [String], ["customized_token"])
-        XCTAssertEqual(dict["allowed_payment_types"] as? [String], ["credit_card"])
-        XCTAssertEqual(dict["allowed_payment_methods"] as? [String], ["visa"])
+        XCTAssertEqual(dict["excluded_payment_types"] as? [String], ["credit_card"])
+        XCTAssertEqual(dict["excluded_payment_methods"] as? [String], ["visa"])
     }
 
     func test_cardFormInitializeEventData_toDictionary_withEmptyArrays_shouldContainEmptyArrays() {
@@ -41,8 +41,8 @@ final class CardFormAnalyticsEventDataTests: XCTestCase {
             checkoutType: "card_form",
             appearance: "light",
             sellerCustomization: [],
-            allowedPaymentTypes: [],
-            allowedPaymentMethods: []
+            excludedPaymentTypes: [],
+            excludedPaymentMethods: []
         )
 
         // Act
@@ -50,8 +50,8 @@ final class CardFormAnalyticsEventDataTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(dict["seller_customization"] as? [String], [])
-        XCTAssertEqual(dict["allowed_payment_types"] as? [String], [])
-        XCTAssertEqual(dict["allowed_payment_methods"] as? [String], [])
+        XCTAssertEqual(dict["excluded_payment_types"] as? [String], [])
+        XCTAssertEqual(dict["excluded_payment_methods"] as? [String], [])
     }
 
     // MARK: - CardFormSubmitEventData

--- a/Tests/MercadoPagoCheckoutTests/Mocks/MockCheckoutService.swift
+++ b/Tests/MercadoPagoCheckoutTests/Mocks/MockCheckoutService.swift
@@ -113,8 +113,8 @@ final actor MockCheckoutService: CheckoutServiceProtocol {
     func fetchBinData(
         bin _: String,
         amount _: Double?,
-        acceptedPaymentTypeIds _: [String],
-        acceptedPaymentMethodIds _: [String]
+        excludedPaymentTypeIds _: [String],
+        excludedPaymentMethodIds _: [String]
     ) async throws -> CardBinData {
         self.fetchBinDataCallCount += 1
         if !self.fetchBinDataResults.isEmpty {

--- a/Tests/MercadoPagoCheckoutTests/UseCases/FetchCardPaymentBrickCardUseCaseTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/UseCases/FetchCardPaymentBrickCardUseCaseTests.swift
@@ -30,8 +30,8 @@ final class FetchCardPaymentBrickCardUseCaseTests: XCTestCase {
             amount: 100.0,
             checkoutType: "card_payment_brick",
             processingMode: "aggregator",
-            allowCardTypes: [],
-            allowCardBrands: []
+            excludedCardTypes: [],
+            excludedCardBrands: []
         )
     }
 

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormBrickViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormBrickViewModelTests.swift
@@ -23,7 +23,7 @@ final class CardFormBrickViewModelTests: XCTestCase {
         let useCase = InitializeCardFormUseCase(repository: repository)
         let configuration = MPCheckoutConfiguration<MPPaymentData.CardSave>(
             type: .saveCard,
-            paymentMethod: [.card(allowedTypes: [.credit, .debit, .prepaid])]
+            paymentMethod: [.card()]
         )
         let viewModel = CardFormBrickViewModel<MPPaymentData.CardSave>(
             configuration: configuration,

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormBrickViewModelTrackingTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormBrickViewModelTrackingTests.swift
@@ -28,7 +28,7 @@ final class CardFormBrickViewModelTrackingTests: XCTestCase {
         let analytics = MockAnalytics()
         let configuration = MPCheckoutConfiguration<MPPaymentData.CardSave>(
             type: .saveCard,
-            paymentMethod: [.card(allowedTypes: [.credit, .debit, .prepaid])]
+            paymentMethod: [.card()]
         )
         let viewModel = CardFormBrickViewModel<MPPaymentData.CardSave>(
             configuration: configuration,

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
@@ -196,7 +196,7 @@ final class CardFormViewModelTests: XCTestCase {
         let repository = MockCardPaymentBrickCardRepository()
         let configuration = MPCheckoutConfiguration<MPPaymentData.CardSave>(
             type: .saveCard,
-            paymentMethod: [.card(allowedTypes: [.credit, .debit, .prepaid])]
+            paymentMethod: [.card()]
         )
         let initResult = CardFormInitializationOutputStub.make(identificationTypes: identificationTypes)
         let viewModel = CardFormViewModel<MPPaymentData.CardSave>(
@@ -213,7 +213,7 @@ final class CardFormViewModelTests: XCTestCase {
         let repository = MockCardPaymentBrickCardRepository()
         let configuration = MPCheckoutConfiguration<MPPaymentData.CardTransaction>(
             type: .cardTransaction(order: .init(amount: amount, payer: .init(email: ""))),
-            paymentMethod: [.card(allowedTypes: [.credit, .debit, .prepaid])]
+            paymentMethod: [.card()]
         )
         let initResult = CardFormInitializationOutputStub.make(identificationTypes: [])
         let viewModel = CardFormViewModel<MPPaymentData.CardTransaction>(

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTrackingTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTrackingTests.swift
@@ -98,7 +98,7 @@ final class CardFormViewModelTrackingTests: XCTestCase {
         let analytics = MockAnalytics()
         let configuration = MPCheckoutConfiguration<MPPaymentData.CardSave>(
             type: .saveCard,
-            paymentMethod: [.card(allowedTypes: [.credit, .debit, .prepaid])]
+            paymentMethod: [.card()]
         )
         let initResult = CardFormInitializationOutputStub.make(identificationTypes: identificationTypes)
         let viewModel = CardFormViewModel<MPPaymentData.CardSave>(


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
https://mercadolibre.atlassian.net/browse/CHOBK-4052

## Description
- Renamed `MPPaymentMethod` enum to `MPPaymentMethodConfig` to better reflect its purpose as a configuration object rather than a payment method type
- Changed the card filtering approach from allow-list to deny-list: `allowedTypes`/`allowedBrands` → `excludedTypes`/`excludedBrands`
- Removed `MPPaymentMethod.defaults` — the default is now no exclusions (`[]`), meaning all types and brands are accepted unless explicitly excluded
- Renamed builder method `setPaymentMethods(_:)` → `setPaymentMethodConfiguration(_:)` with updated default parameter `[]`
- Moved array extensions from per-element (`acceptedPaymentTypeIds`/`acceptedPaymentMethodIds`) to array-level (`excludedPaymentTypeIds`/`excludedPaymentMethodIds`), removing `flatMap` call sites
- Updated BFF params: `allow_payment_types`/`allow_payment_methods` → `excluded_payment_types`/`excluded_payment_methods`, now sent conditionally (only when non-empty)
- Updated analytics fields: `allowedPaymentTypes`/`allowedPaymentMethods` → `excludedPaymentTypes`/`excludedPaymentMethods`
- Removed `@ViewBuilder` attribute from `MercadoPagoCheckout.show(onResult:)`
- Updated all unit tests to reflect the new API

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [x] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no connection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.