### PR TITLE
[CHOBK-4044] (Feature): PaymentBrick - Estrutura inicial e navegação

### DIFF
--- a/Sources/MercadoPagoCheckout/Bricks/PaymentBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/PaymentBrick.swift
@@ -1,0 +1,68 @@
+//
+//  PaymentBrick.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 28/05/26.
+//
+import MPComponents
+import MPFoundation
+import SwiftUI
+
+struct PaymentBrick<T: MPPaymentData.Kind>: View {
+    private enum Route: Hashable {
+        case cardForm
+        case installments
+        case reviewAndConfirm
+    }
+
+    @State private var route: Route?
+    @ObservedObject private var viewModel: PaymentBrickViewModel<T>
+
+    @Environment(\.checkoutTheme) private var theme: MPTheme
+
+    private var configuration: MPCheckoutConfiguration<T>
+    private let themeDark: MPTheme
+    private let themeLight: MPTheme
+    private let transactionAmount: Double
+
+    private let onResult: (MercadoPagoCheckoutResult<T>) -> Void
+
+    @MainActor
+    init(
+        configuration: MPCheckoutConfiguration<T>,
+        appearance: MPCheckoutAppearance,
+        onResult: @escaping (MercadoPagoCheckoutResult<T>) -> Void
+    ) {
+        self.configuration = configuration
+        self.themeDark = appearance.themeConfiguration.dark
+        self.themeLight = appearance.themeConfiguration.light
+        self.onResult = onResult
+
+        self.transactionAmount = configuration.type.configuration.amount
+        self.viewModel = PaymentBrickViewModel<T>(configuration: configuration, appearance: appearance)
+    }
+
+    var body: some View {
+        ThemeProvider(
+            light: self.themeLight,
+            dark: self.themeDark
+        ) {
+            NavigationView {
+                ZStack {
+                    switch self.viewModel.screenState {
+                    case .loading:
+                        ZStack {
+                            self.theme.colors.background.primary
+                                .edgesIgnoringSafeArea(.all)
+                            MPProgressIndicator()
+                                .size(.xlarge)
+                        }
+                    case .ready:
+                        PaymentsScreen()
+                    }
+                }
+            }
+            .navigationViewStyle(StackNavigationViewStyle())
+        }
+    }
+}

--- a/Sources/MercadoPagoCheckout/Bricks/PaymentBrickViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/PaymentBrickViewModel.swift
@@ -1,0 +1,36 @@
+//
+//  PaymentBrickViewModel.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 28/05/26.
+//
+
+import Foundation
+import MPAnalytics
+import MPCore
+
+@MainActor
+final class PaymentBrickViewModel<T: MPPaymentData.Kind>: ObservableObject {
+    enum ScreenState {
+        case loading
+        case ready
+    }
+
+    @Published private(set) var screenState: ScreenState = .ready
+
+    // MARK: - Dependencies
+
+    private let configuration: MPCheckoutConfiguration<T>
+    private let appearance: MPCheckoutAppearance
+    private let analytics: AnalyticsInterface
+
+    init(
+        configuration: MPCheckoutConfiguration<T>,
+        appearance: MPCheckoutAppearance = MPCheckoutAppearance(),
+        analytics: AnalyticsInterface = CoreDependencyContainer.shared.analytics
+    ) {
+        self.configuration = configuration
+        self.appearance = appearance
+        self.analytics = analytics
+    }
+}

--- a/Sources/MercadoPagoCheckout/Domain/Analytics/CardFormSubmitEventData.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Analytics/CardFormSubmitEventData.swift
@@ -2,16 +2,16 @@ import MPAnalytics
 
 struct CardFormSubmitEventData: AnalyticsEventData {
     let cardBrand: String
-    let transactionAmount: Double?
+    let transactionAmount: Double
     let issuer: String
     let paymentType: String?
 
     func toDictionary() -> [String: any Sendable] {
         var dict: [String: any Sendable] = [
             "card_brand": self.cardBrand,
+            "transaction_amount": self.transactionAmount,
             "issuer": self.issuer
         ]
-        if let transactionAmount { dict["transaction_amount"] = transactionAmount }
         if let paymentType { dict["payment_type"] = paymentType }
         return dict
     }

--- a/Sources/MercadoPagoCheckout/MPPaymentSelectionConfiguration.swift
+++ b/Sources/MercadoPagoCheckout/MPPaymentSelectionConfiguration.swift
@@ -1,0 +1,44 @@
+//
+//  MPPaymentSelectionConfiguration.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 28/05/26.
+//
+
+/// Configuration for the payment selection checkout experience.
+///
+/// Pass this to ``MercadoPagoCheckout/CheckoutType/payment(configuration:)`` to launch
+/// the PaymentBrick
+///
+/// ## Required fields
+///
+/// `orderId` and `amount` are mandatory.
+///
+/// ## Example
+///
+/// ```swift
+/// let configuration = PaymentSelectionConfiguration(
+///     orderId: "order-123",
+///     amount: 150.0
+/// )
+///
+/// let checkout = MercadoPagoCheckout.Builder(
+///     checkoutType: .payment(configuration: configuration),
+///     checkoutAppearance: .init()
+/// )
+/// .build()
+/// ```
+public struct MPPaymentSelectionConfiguration: CheckoutTypeConfiguration, Sendable {
+    // MARK: - Required
+
+    /// ID of the Order created by the seller via the Order API.
+    public var orderId: String
+
+    /// Transaction amount.
+    public var amount: Double
+
+    public init(orderId: String, amount: Double) {
+        self.orderId = orderId
+        self.amount = amount
+    }
+}

--- a/Sources/MercadoPagoCheckout/MercadoPagoCheckout+CheckoutType.swift
+++ b/Sources/MercadoPagoCheckout/MercadoPagoCheckout+CheckoutType.swift
@@ -13,11 +13,13 @@ public extension MercadoPagoCheckout {
     /// is constrained so that:
     /// - ``cardTransaction(order:)`` is only available when `T == MPPaymentData.CardTransaction`
     /// - ``saveCard`` is only available when `T == MPPaymentData.CardSave`
+    /// - ``payment(configuration:)`` is only available when `T == MPPaymentData.PaymentTransaction`
     ///
     /// This propagates the concrete payment data type all the way through to
     /// ``MercadoPagoCheckoutResult`` at the call site.
     struct CheckoutType: Sendable {
         enum Kind: Sendable {
+            case payment(MPPaymentSelectionConfiguration)
             case cardTransaction(MPOrder)
             case saveCard
         }
@@ -28,6 +30,7 @@ public extension MercadoPagoCheckout {
             switch self.kind {
             case let .cardTransaction(order): return order
             case .saveCard: return SavedCardConfiguration()
+            case let .payment(config): return config
             }
         }
 
@@ -35,6 +38,7 @@ public extension MercadoPagoCheckout {
             switch self.kind {
             case .cardTransaction: return "card_transaction"
             case .saveCard: return "save_card"
+            case .payment: return "payment"
             }
         }
     }
@@ -56,5 +60,16 @@ public extension MercadoPagoCheckout.CheckoutType where T == MPPaymentData.CardS
     /// ``MPPaymentData/CardSave`` carrying the token.
     static var saveCard: MercadoPagoCheckout<MPPaymentData.CardSave>.CheckoutType {
         .init(kind: .saveCard)
+    }
+}
+
+public extension MercadoPagoCheckout.CheckoutType where T == MPPaymentData.PaymentTransaction {
+    /// A payment selection flow that produces a ``MPPaymentData/PaymentTransaction``.
+    ///
+    /// - Parameter configuration: Configuration values for the payment selection, such as amount and payer.
+    static func payment(
+        configuration: MPPaymentSelectionConfiguration
+    ) -> MercadoPagoCheckout<MPPaymentData.PaymentTransaction>.CheckoutType {
+        .init(kind: .payment(configuration))
     }
 }

--- a/Sources/MercadoPagoCheckout/MercadoPagoCheckout.swift
+++ b/Sources/MercadoPagoCheckout/MercadoPagoCheckout.swift
@@ -74,11 +74,20 @@ public struct MercadoPagoCheckout<T: MPPaymentData.Kind>: Sendable, Identifiable
     public func show(
         onResult: @escaping (MercadoPagoCheckoutResult<T>) -> Void
     ) -> some View {
-        CardFormBrick<T>(
-            configuration: self.configuration,
-            appearance: self.theme,
-            onResult: onResult
-        )
+        switch self.configuration.type.kind {
+        case .saveCard, .cardTransaction:
+            CardFormBrick<T>(
+                configuration: self.configuration,
+                appearance: self.theme,
+                onResult: onResult
+            )
+        case .payment:
+            PaymentBrick(
+                configuration: self.configuration,
+                appearance: self.theme,
+                onResult: onResult
+            )
+        }
     }
 
     /// Presents the checkout flow modally from a UIKit view controller.
@@ -95,12 +104,8 @@ public struct MercadoPagoCheckout<T: MPPaymentData.Kind>: Sendable, Identifiable
         animated: Bool = true,
         onResult: @escaping (MercadoPagoCheckoutResult<T>) -> Void
     ) {
-        let cardFormBrick = CardFormBrick<T>(
-            configuration: configuration,
-            appearance: theme,
-            onResult: onResult
-        )
-        let hostingController = UIHostingController(rootView: cardFormBrick)
+        let rootView = self.show(onResult: onResult)
+        let hostingController = UIHostingController(rootView: rootView)
         hostingController.modalPresentationStyle = .fullScreen
         viewController.present(hostingController, animated: animated)
     }
@@ -120,12 +125,8 @@ public struct MercadoPagoCheckout<T: MPPaymentData.Kind>: Sendable, Identifiable
         animated: Bool = true,
         onResult: @escaping (MercadoPagoCheckoutResult<T>) -> Void
     ) {
-        let cardFormBrick = CardFormBrick<T>(
-            configuration: configuration,
-            appearance: theme,
-            onResult: onResult
-        )
-        let hostingController = UIHostingController(rootView: cardFormBrick)
+        let rootView = self.show(onResult: onResult)
+        let hostingController = UIHostingController(rootView: rootView)
         navigationController.pushViewController(hostingController, animated: animated)
     }
 }

--- a/Sources/MercadoPagoCheckout/Model/Public/MPPaymentData.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/MPPaymentData.swift
@@ -56,6 +56,14 @@ public enum MPPaymentData {
         }
     }
 
+    public struct PaymentTransaction: Kind, Equatable, Codable, Sendable {
+        public var orderId = ""
+        public var orderStatus = ""
+        public var transactionAmount: Double
+
+        var token = ""
+    }
+
     public struct Payer: Equatable, Codable, Sendable {
         public var documentType: String
         public var documentNumber: String

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -357,6 +357,9 @@ final class CardFormViewModel<T: MPPaymentData.Kind>: ObservableObject {
                     transactionAmount: transactionAmount
                 )
                 paymentData = save
+
+            default:
+                paymentData = MPPaymentData.PaymentTransaction(transactionAmount: transactionAmount, token: cardToken.token)
             }
 
             onSuccess(paymentData)
@@ -399,7 +402,7 @@ final class CardFormViewModel<T: MPPaymentData.Kind>: ObservableObject {
         }
     }
 
-    private func trackSubmit(paymentMethodId: String, paymentTypeId: String, transactionAmount: Double?) {
+    private func trackSubmit(paymentMethodId: String, paymentTypeId: String, transactionAmount: Double) {
         let eventData = CardFormSubmitEventData(
             cardBrand: paymentMethodId,
             transactionAmount: transactionAmount,

--- a/Sources/MercadoPagoCheckout/Views/PaymentsScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/PaymentsScreen.swift
@@ -1,0 +1,19 @@
+//
+//  PaymentMethodsScreen.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 28/05/26.
+//
+import MPComponents
+import SwiftUI
+
+struct PaymentsScreen: View {
+    var body: some View {
+        MPHeader(
+            title: "Escolha como pagar",
+            onBack: {},
+            footer: {},
+            content: {}
+        )
+    }
+}

--- a/Sources/MercadoPagoCheckout/Views/PaymentsViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/PaymentsViewModel.swift
@@ -1,0 +1,11 @@
+//
+//  PaymentsViewModel.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 28/05/26.
+//
+
+import Foundation
+
+@MainActor
+final class PaymentsViewModel<T: MPPaymentData.Kind>: ObservableObject {}

--- a/Tests/MercadoPagoCheckoutTests/Domain/Analytics/CardFormAnalyticsEventDataTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Domain/Analytics/CardFormAnalyticsEventDataTests.swift
@@ -75,11 +75,11 @@ final class CardFormAnalyticsEventDataTests: XCTestCase {
         XCTAssertEqual(dict["payment_type"] as? String, "credit_card")
     }
 
-    func test_cardFormSubmitEventData_toDictionary_withNilOptionals_shouldOmitOptionalKeys() {
+    func test_cardFormSubmitEventData_toDictionary_withNilPaymentType_shouldOmitPaymentType() {
         // Arrange
         let sut = CardFormSubmitEventData(
             cardBrand: "master",
-            transactionAmount: nil,
+            transactionAmount: 0,
             issuer: "Itaú",
             paymentType: nil
         )
@@ -89,8 +89,8 @@ final class CardFormAnalyticsEventDataTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(dict["card_brand"] as? String, "master")
+        XCTAssertEqual(dict["transaction_amount"] as? Double, 0)
         XCTAssertEqual(dict["issuer"] as? String, "Itaú")
-        XCTAssertNil(dict["transaction_amount"])
         XCTAssertNil(dict["payment_type"])
     }
 


### PR DESCRIPTION
## Ticket / Issue

[CHOBK-4044 – PaymentBrick: Navegação das Telas](https://mercadolibre.atlassian.net/browse/CHOBK-4044)

## Description

Cria a fundação do **PaymentBrick** — o novo fluxo de seleção de métodos de pagamento — sem quebrar nenhuma API existente. Esta PR é a base sobre a qual as próximas PRs vão construir: busca de métodos, seleção de parcelamento, revisão e confirmação.

### O que foi adicionado

- **`MPPaymentSelectionConfiguration`** — tipo público de configuração exclusivo do PaymentBrick, desacoplado do `MPOrder` (que continua sendo usado pelo CardFormBrick). Carrega `orderId` e `amount` obrigatórios, com extensões previstas pela RFC nas próximas PRs.
- **`MPPaymentData.PaymentTransaction`** — variante de resultado produzida pelo fluxo, com `orderId`, `orderStatus`, `transactionAmount` e `token`.
- **`CheckoutType.payment(configuration:)`** — factory pública que instancia o PaymentBrick, análoga à `cardTransaction(order:)` do CardFormBrick.
- **`PaymentBrick`** — view genérica orquestradora do fluxo, com estados `loading` / `ready` e enum de rotas preparado para as próximas telas (`cardForm`, `installments`, `reviewAndConfirm`).
- **`PaymentBrickViewModel`** — ViewModel com injeção de analytics, seguindo o mesmo padrão do `CardFormBrickViewModel`.
- **`PaymentsScreen` + `PaymentsViewModel`** — scaffold da tela de seleção de método de pagamento (header estruturado; conteúdo da lista vem nas próximas PRs).
- **`MercadoPagoCheckout.show/present/push`** — roteamento para `PaymentBrick` quando o tipo é `.payment`, unificando os três pontos de entrada do SDK.

### Arquitetura

```
Integrator
└── MercadoPagoCheckout.Builder
      ├── checkoutType: .payment(configuration: MPPaymentSelectionConfiguration)
      └── .build() → MercadoPagoCheckout<MPPaymentData.PaymentTransaction>
                        └── .show(onResult:)
                              └── PaymentBrick
                                    ├── PaymentBrickViewModel  (loading → ready)
                                    └── PaymentsScreen         (scaffold do seletor)
                                          ├── [próxima PR] CardFormBrick
                                          ├── [próxima PR] InstallmentScreen
                                          └── [próxima PR] ReviewConfirmScreen
                                                └── MercadoPagoCheckoutResult<PaymentTransaction>
```

### Como integrar

```swift
// 1. Crie a configuração com a Order gerada pelo backend
let configuration = MPPaymentSelectionConfiguration(
    orderId: "ORDER_ID_DO_BACKEND",
    amount: 150.0
)

// 2. Monte o checkout
let checkout = MercadoPagoCheckout.Builder(
    checkoutType: .payment(configuration: configuration),
    checkoutAppearance: .init()
)
.build()

// 3a. SwiftUI
checkout.show { result in
    switch result {
    case .success(let data):
        print(data.orderId, data.orderStatus)
    case .error(let error):
        print(error)
    case .userCancelled:
        break
    }
}

// 3b. UIKit – modal
checkout.present(from: viewController) { result in ... }

// 3c. UIKit – push
checkout.push(to: navigationController) { result in ... }
```

## Checklist
- [ ] Branch is up to date with `main`
- [ ] `swiftformat .` was run and the diff is clean
- [ ] `swiftlint lint` passes with no errors
- [ ] Tests were added or updated to cover the change
- [ ] All unit tests pass locally (`swift test`)
- [ ] Coverage stays at or above 80% (`bundle exec fastlane test`)
- [ ] Tested on a physical device or simulator (rotation, no connection, error handling)
- [ ] Accessibility verified for any UI changes
- [ ] No PCI data (PAN, CVV, expiry) appears in logs, screenshots, or this description

## Screenshots / Screen Recording

_Tela de seleção ainda é um scaffold — screenshots virão na PR que implementa a lista de métodos._