### PR TITLE
[CHOBK-4044] (Feature): PaymentBrick - Estrutura inicial e navegação

### DIFF
--- a/.mirrorignore
+++ b/.mirrorignore
@@ -6,4 +6,3 @@ ux-reference/
 
 Example/Example.xcodeproj/project.pbxproj.rej
 
-Example/Sources/MainListView.swift

--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
@@ -18,7 +18,7 @@ final class CardFormBrickViewModel<T: MPPaymentData.Kind>: ObservableObject {
 
     private var transactionAmount: Double {
         switch self.configuration.type.kind {
-        case .saveCard:
+        case .saveCard, .payment:
             return .zero
         case let .cardTransaction(order):
             return order.amount
@@ -117,6 +117,9 @@ final class CardFormBrickViewModel<T: MPPaymentData.Kind>: ObservableObject {
                 issuerId: output.issuerId,
                 payer: payer
             ) as? T
+
+        default:
+            return nil
         }
     }
 

--- a/Sources/MercadoPagoCheckout/Bricks/PaymentBrick.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/PaymentBrick.swift
@@ -1,0 +1,66 @@
+//
+//  PaymentBrick.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 28/05/26.
+//
+import MPComponents
+import MPFoundation
+import SwiftUI
+
+struct PaymentBrick<T: MPPaymentData.Kind>: View {
+    private enum Route: Hashable {
+        case cardForm
+        case installments
+        case reviewAndConfirm
+    }
+
+    @State private var route: Route?
+    @ObservedObject private var viewModel: PaymentBrickViewModel<T>
+
+    @Environment(\.checkoutTheme) private var theme: MPTheme
+
+    private var configuration: MPCheckoutConfiguration<T>
+    private let themeDark: MPTheme
+    private let themeLight: MPTheme
+
+    private let onResult: (MercadoPagoCheckoutResult<T>) -> Void
+
+    @MainActor
+    init(
+        configuration: MPCheckoutConfiguration<T>,
+        appearance: MPCheckoutAppearance,
+        onResult: @escaping (MercadoPagoCheckoutResult<T>) -> Void
+    ) {
+        self.configuration = configuration
+        self.themeDark = appearance.themeConfiguration.dark
+        self.themeLight = appearance.themeConfiguration.light
+        self.onResult = onResult
+
+        self.viewModel = PaymentBrickViewModel<T>(configuration: configuration, appearance: appearance)
+    }
+
+    var body: some View {
+        ThemeProvider(
+            light: self.themeLight,
+            dark: self.themeDark
+        ) {
+            NavigationView {
+                ZStack {
+                    switch self.viewModel.screenState {
+                    case .loading:
+                        ZStack {
+                            self.theme.colors.background.primary
+                                .edgesIgnoringSafeArea(.all)
+                            MPProgressIndicator()
+                                .size(.xlarge)
+                        }
+                    case .ready:
+                        PaymentsScreen()
+                    }
+                }
+            }
+            .navigationViewStyle(StackNavigationViewStyle())
+        }
+    }
+}

--- a/Sources/MercadoPagoCheckout/Bricks/PaymentBrickViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/PaymentBrickViewModel.swift
@@ -1,0 +1,51 @@
+//
+//  PaymentBrickViewModel.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 28/05/26.
+//
+
+import Foundation
+import MPAnalytics
+import MPCore
+import SwiftUI
+
+@MainActor
+final class PaymentBrickViewModel<T: MPPaymentData.Kind>: ObservableObject {
+    enum ScreenState {
+        case loading
+        case ready
+    }
+
+    @Published private(set) var screenState: ScreenState = .ready
+
+    // MARK: - Dependencies
+
+    private let configuration: MPCheckoutConfiguration<T>
+    private let appearance: MPCheckoutAppearance
+    private let analytics: AnalyticsInterface
+
+    @Published private(set) var paymentData: MPPaymentData.PaymentTransaction?
+
+    private var transactionAmount: Double {
+        switch self.configuration.type.kind {
+        case let .payment(order):
+            return order.amount
+        default: return .zero
+        }
+    }
+
+    init(
+        configuration: MPCheckoutConfiguration<T>,
+        appearance: MPCheckoutAppearance = MPCheckoutAppearance(),
+        analytics: AnalyticsInterface = CoreDependencyContainer.shared.analytics
+    ) {
+        self.configuration = configuration
+        self.appearance = appearance
+        self.analytics = analytics
+
+        if case let .payment(order) = configuration.type.kind {
+            self.paymentData = .init(orderId: order.orderId, transactionAmount: order.amount)
+        }
+    }
+}

--- a/Sources/MercadoPagoCheckout/Domain/Analytics/CardFormSubmitEventData.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Analytics/CardFormSubmitEventData.swift
@@ -2,16 +2,16 @@ import MPAnalytics
 
 struct CardFormSubmitEventData: AnalyticsEventData {
     let cardBrand: String
-    let transactionAmount: Double?
+    let transactionAmount: Double
     let issuer: String
     let paymentType: String?
 
     func toDictionary() -> [String: any Sendable] {
         var dict: [String: any Sendable] = [
             "card_brand": self.cardBrand,
+            "transaction_amount": self.transactionAmount,
             "issuer": self.issuer
         ]
-        if let transactionAmount { dict["transaction_amount"] = transactionAmount }
         if let paymentType { dict["payment_type"] = paymentType }
         return dict
     }

--- a/Sources/MercadoPagoCheckout/MPOrder.swift
+++ b/Sources/MercadoPagoCheckout/MPOrder.swift
@@ -10,19 +10,60 @@ protocol CheckoutTypeConfiguration: Sendable {
     var amount: Double { get }
 }
 
-/// Configuration specific to the checkout experience.
+/// Represents a payment order to be processed by the MercadoPago checkout.
+///
+/// Pass an `MPOrder` when building a checkout with ``MercadoPagoCheckout/CheckoutType/payment(order:)``
+/// or ``MercadoPagoCheckout/CheckoutType/cardTransaction(order:)``.
+///
+/// ## Payment flow
+///
+/// Use `orderId` when the order was previously created through the MercadoPago Orders API.
+/// The SDK uses it to associate the checkout result with your backend order.
+///
+/// ```swift
+/// let order = MPOrder(orderId: "order-abc123", amount: 199.90)
+///
+/// let checkout = MercadoPagoCheckout.Builder(
+///     checkoutType: .payment(order: order),
+///     checkoutAppearance: .init()
+/// )
+/// .build()
+/// ```
+///
+/// ## Card transaction flow
+///
+/// Provide `amount` and, optionally, `orderId` to associate the charge with an existing order
+/// and `payer` to pre-fill the form.
+///
+/// ```swift
+/// let order = MPOrder(orderId: "order-abc123", amount: 199.90, payer: MPPayer(email: "buyer@email.com"))
+///
+/// let checkout = MercadoPagoCheckout.Builder(
+///     checkoutType: .cardTransaction(order: order),
+///     checkoutAppearance: .init()
+/// )
+/// .build()
+/// ```
 public struct MPOrder: CheckoutTypeConfiguration {
-    /// The transaction amount to be charged. Optional; when `nil` the amount is determined server-side.
-    public var amount: Double
-    /// Payer information pre-filled in the form. Optional.
-    public var payer: MPPayer
+    /// The ID of a previously created order from the MercadoPago Orders API.
+    public var orderId: String
 
-    /// Creates a new card form configuration.
+    /// The total amount to charge the buyer, in the account's default currency.
+    public var amount: Double
+
+    /// Payer details used to pre-fill the checkout form.
+    ///
+    /// Optional. When provided, the payer's email is shown in the form automatically.
+    public var payer: MPPayer?
+
+    /// Creates a new order configuration.
     ///
     /// - Parameters:
-    ///   - amount: The transaction amount.
-    ///   - payer: Pre-filled payer information.
-    public init(amount: Double, payer: MPPayer) {
+    ///   - orderId: ID of a previously created order.
+    ///   - amount: Total amount to charge.
+    ///   - payer: Optional payer details for pre-filling the form.
+    public init(orderId: String = "", amount: Double, payer: MPPayer? = nil) {
+        self.orderId = orderId
         self.amount = amount
         self.payer = payer
     }

--- a/Sources/MercadoPagoCheckout/MercadoPagoCheckout+CheckoutType.swift
+++ b/Sources/MercadoPagoCheckout/MercadoPagoCheckout+CheckoutType.swift
@@ -13,11 +13,13 @@ public extension MercadoPagoCheckout {
     /// is constrained so that:
     /// - ``cardTransaction(order:)`` is only available when `T == MPPaymentData.CardTransaction`
     /// - ``saveCard`` is only available when `T == MPPaymentData.CardSave`
+    /// - ``payment(configuration:)`` is only available when `T == MPPaymentData.PaymentTransaction`
     ///
     /// This propagates the concrete payment data type all the way through to
     /// ``MercadoPagoCheckoutResult`` at the call site.
     struct CheckoutType: Sendable {
         enum Kind: Sendable {
+            case payment(MPOrder)
             case cardTransaction(MPOrder)
             case saveCard
         }
@@ -28,6 +30,7 @@ public extension MercadoPagoCheckout {
             switch self.kind {
             case .cardTransaction: return "card_transaction"
             case .saveCard: return "save_card"
+            case .payment: return "payment"
             }
         }
     }
@@ -49,5 +52,16 @@ public extension MercadoPagoCheckout.CheckoutType where T == MPPaymentData.CardS
     /// ``MPPaymentData/CardSave`` carrying the token.
     static var saveCard: MercadoPagoCheckout<MPPaymentData.CardSave>.CheckoutType {
         .init(kind: .saveCard)
+    }
+}
+
+public extension MercadoPagoCheckout.CheckoutType where T == MPPaymentData.PaymentTransaction {
+    /// A payment selection flow that produces a ``MPPaymentData/PaymentTransaction``.
+    ///
+    /// - Parameter configuration: Configuration values for the payment selection, such as amount and payer.
+    static func payment(
+        order: MPOrder
+    ) -> MercadoPagoCheckout<MPPaymentData.PaymentTransaction>.CheckoutType {
+        .init(kind: .payment(order))
     }
 }

--- a/Sources/MercadoPagoCheckout/MercadoPagoCheckout.swift
+++ b/Sources/MercadoPagoCheckout/MercadoPagoCheckout.swift
@@ -74,11 +74,20 @@ public struct MercadoPagoCheckout<T: MPPaymentData.Kind>: Sendable, Identifiable
     public func show(
         onResult: @escaping (MercadoPagoCheckoutResult<T>) -> Void
     ) -> some View {
-        CardFormBrick<T>(
-            configuration: self.configuration,
-            appearance: self.theme,
-            onResult: onResult
-        )
+        switch self.configuration.type.kind {
+        case .saveCard, .cardTransaction:
+            CardFormBrick<T>(
+                configuration: self.configuration,
+                appearance: self.theme,
+                onResult: onResult
+            )
+        case .payment:
+            PaymentBrick(
+                configuration: self.configuration,
+                appearance: self.theme,
+                onResult: onResult
+            )
+        }
     }
 
     /// Presents the checkout flow modally from a UIKit view controller.
@@ -95,12 +104,8 @@ public struct MercadoPagoCheckout<T: MPPaymentData.Kind>: Sendable, Identifiable
         animated: Bool = true,
         onResult: @escaping (MercadoPagoCheckoutResult<T>) -> Void
     ) {
-        let cardFormBrick = CardFormBrick<T>(
-            configuration: configuration,
-            appearance: theme,
-            onResult: onResult
-        )
-        let hostingController = UIHostingController(rootView: cardFormBrick)
+        let rootView = self.show(onResult: onResult)
+        let hostingController = UIHostingController(rootView: rootView)
         hostingController.modalPresentationStyle = .fullScreen
         viewController.present(hostingController, animated: animated)
     }
@@ -120,12 +125,8 @@ public struct MercadoPagoCheckout<T: MPPaymentData.Kind>: Sendable, Identifiable
         animated: Bool = true,
         onResult: @escaping (MercadoPagoCheckoutResult<T>) -> Void
     ) {
-        let cardFormBrick = CardFormBrick<T>(
-            configuration: configuration,
-            appearance: theme,
-            onResult: onResult
-        )
-        let hostingController = UIHostingController(rootView: cardFormBrick)
+        let rootView = self.show(onResult: onResult)
+        let hostingController = UIHostingController(rootView: rootView)
         navigationController.pushViewController(hostingController, animated: animated)
     }
 }

--- a/Sources/MercadoPagoCheckout/Model/Public/MPPaymentData.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/MPPaymentData.swift
@@ -56,6 +56,14 @@ public enum MPPaymentData {
         }
     }
 
+    public struct PaymentTransaction: Kind, Equatable, Codable, Sendable {
+        public var orderId: String
+        public var orderStatus = ""
+        public var transactionAmount: Double
+
+        var token = ""
+    }
+
     public struct Payer: Equatable, Codable, Sendable {
         public var documentType: String
         public var documentNumber: String

--- a/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/CardFormViewModel.swift
@@ -355,7 +355,7 @@ final class CardFormViewModel: ObservableObject {
         }
     }
 
-    private func trackSubmit(paymentMethodId: String, paymentTypeId: String, transactionAmount: Double?) {
+    private func trackSubmit(paymentMethodId: String, paymentTypeId: String, transactionAmount: Double) {
         let eventData = CardFormSubmitEventData(
             cardBrand: paymentMethodId,
             transactionAmount: transactionAmount,

--- a/Sources/MercadoPagoCheckout/Views/PaymentsScreen.swift
+++ b/Sources/MercadoPagoCheckout/Views/PaymentsScreen.swift
@@ -1,0 +1,19 @@
+//
+//  PaymentMethodsScreen.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 28/05/26.
+//
+import MPComponents
+import SwiftUI
+
+struct PaymentsScreen: View {
+    var body: some View {
+        MPHeader(
+            title: "Escolha como pagar",
+            onBack: {},
+            footer: {},
+            content: {}
+        )
+    }
+}

--- a/Sources/MercadoPagoCheckout/Views/PaymentsViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Views/PaymentsViewModel.swift
@@ -1,0 +1,11 @@
+//
+//  PaymentsViewModel.swift
+//  MercadoPagoSDK
+//
+//  Created by Guilherme Prata Costa on 28/05/26.
+//
+
+import Foundation
+
+@MainActor
+final class PaymentsViewModel<T: MPPaymentData.Kind>: ObservableObject {}

--- a/Tests/MercadoPagoCheckoutTests/Domain/Analytics/CardFormAnalyticsEventDataTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Domain/Analytics/CardFormAnalyticsEventDataTests.swift
@@ -75,11 +75,11 @@ final class CardFormAnalyticsEventDataTests: XCTestCase {
         XCTAssertEqual(dict["payment_type"] as? String, "credit_card")
     }
 
-    func test_cardFormSubmitEventData_toDictionary_withNilOptionals_shouldOmitOptionalKeys() {
+    func test_cardFormSubmitEventData_toDictionary_withNilPaymentType_shouldOmitPaymentType() {
         // Arrange
         let sut = CardFormSubmitEventData(
             cardBrand: "master",
-            transactionAmount: nil,
+            transactionAmount: 0,
             issuer: "Itaú",
             paymentType: nil
         )
@@ -89,8 +89,8 @@ final class CardFormAnalyticsEventDataTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(dict["card_brand"] as? String, "master")
+        XCTAssertEqual(dict["transaction_amount"] as? Double, 0)
         XCTAssertEqual(dict["issuer"] as? String, "Itaú")
-        XCTAssertNil(dict["transaction_amount"])
         XCTAssertNil(dict["payment_type"])
     }
 


### PR DESCRIPTION
## Ticket / Issue

[CHOBK-4044 – PaymentBrick: Navegação das Telas](https://mercadolibre.atlassian.net/browse/CHOBK-4044)

## Description

Cria a fundação do **PaymentBrick** — o novo fluxo de seleção de métodos de pagamento — sem quebrar nenhuma API existente. Esta PR é a base sobre a qual as próximas PRs vão construir: busca de métodos, seleção de parcelamento, revisão e confirmação.

### O que foi adicionado

- **`MPPaymentSelectionConfiguration`** — tipo público de configuração exclusivo do PaymentBrick, desacoplado do `MPOrder` (que continua sendo usado pelo CardFormBrick). Carrega `orderId` e `amount` obrigatórios, com extensões previstas pela RFC nas próximas PRs.
- **`MPPaymentData.PaymentTransaction`** — variante de resultado produzida pelo fluxo, com `orderId`, `orderStatus`, `transactionAmount` e `token`.
- **`CheckoutType.payment(configuration:)`** — factory pública que instancia o PaymentBrick, análoga à `cardTransaction(order:)` do CardFormBrick.
- **`PaymentBrick`** — view orquestradora do fluxo, com estados `loading` / `ready` e enum de rotas preparado para as próximas telas (`cardForm`, `installments`, `reviewAndConfirm`).
- **`PaymentBrickViewModel`** — ViewModel com injeção de analytics, seguindo o mesmo padrão do `CardFormBrickViewModel`.
- **`PaymentsScreen` + `PaymentsViewModel`** — scaffold da tela de seleção de método de pagamento (header estruturado; conteúdo da lista vem nas próximas PRs).
- **`MercadoPagoCheckout.show/present/push`** — roteamento para `PaymentBrick` quando o tipo é `.payment`, unificando os três pontos de entrada do SDK.

### Arquitetura

```
Integrator
└── MercadoPagoCheckout.Builder
      ├── checkoutType: .payment(configuration: MPPaymentSelectionConfiguration)
      └── .build() → MercadoPagoCheckout<MPPaymentData.PaymentTransaction>
                        └── .show(onResult:)
                              └── PaymentBrick
                                    ├── PaymentBrickViewModel  (loading → ready)
                                    └── PaymentsScreen         (scaffold do seletor)
                                          ├── [próxima PR] CardFormBrick
                                          ├── [próxima PR] InstallmentScreen
                                          └── [próxima PR] ReviewConfirmScreen
                                                └── MercadoPagoCheckoutResult<PaymentTransaction>
```

### Como integrar

```swift
// 1. Crie a configuração com a Order gerada pelo backend
let configuration = MPPaymentSelectionConfiguration(
    orderId: "ORDER_ID_DO_BACKEND",
    amount: 150.0
)

// 2. Monte o checkout
let checkout = MercadoPagoCheckout.Builder(
    checkoutType: .payment(configuration: configuration),
    checkoutAppearance: .init()
)
.build()

// 3a. SwiftUI
checkout.show { result in
    switch result {
    case .success(let data):
        print(data.orderId, data.orderStatus)
    case .error(let error):
        print(error)
    case .userCancelled:
        break
    }
}

// 3b. UIKit – modal
checkout.present(from: viewController) { result in ... }

// 3c. UIKit – push
checkout.push(to: navigationController) { result in ... }
```

## Checklist
- [ ] Branch is up to date with `feature/payment-brick-q2`
- [ ] `swiftformat .` was run and the diff is clean
- [ ] `swiftlint lint` passes with no errors
- [ ] Tests were added or updated to cover the change
- [ ] All unit tests pass locally (`swift test`)
- [ ] Coverage stays at or above 80% (`bundle exec fastlane test`)
- [ ] Tested on a physical device or simulator (rotation, no connection, error handling)
- [ ] Accessibility verified for any UI changes
- [ ] No PCI data (PAN, CVV, expiry) appears in logs, screenshots, or this description

## Screenshots / Screen Recording

_Tela de seleção ainda é um scaffold — screenshots virão na PR que implementa a lista de métodos._