### PR TITLE
[CHOBK-3977] (Feature): Add orderId to MPOrder and MPPaymentData.CardTransaction

### DIFF
--- a/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Bricks/CardFormBrickViewModel.swift
@@ -106,6 +106,8 @@ final class CardFormBrickViewModel<T: MPPaymentData.Kind>: ObservableObject {
                 paymentMethodId: output.paymentMethodId,
                 paymentTypeId: output.paymentTypeId,
                 issuerId: output.issuerId,
+                orderId: order.orderId,
+                orderStatus: "",
                 payer: payer
             ) as? T
 

--- a/Sources/MercadoPagoCheckout/MPOrder.swift
+++ b/Sources/MercadoPagoCheckout/MPOrder.swift
@@ -17,19 +17,22 @@ public struct MPOrder: CheckoutTypeConfiguration {
     /// Payer information pre-filled in the form. Optional.
     public var payer: MPPayer
 
+    /// The identifier of the order associated with this transaction.
+    public var orderId: String
+
     /// Creates a new card form configuration.
     ///
     /// - Parameters:
     ///   - amount: The transaction amount.
     ///   - payer: Pre-filled payer information.
-    public init(amount: Double, payer: MPPayer) {
+    ///   - orderId: The transaction order id.
+    public init(amount: Double, payer: MPPayer, orderId: String) {
         self.amount = amount
         self.payer = payer
+        self.orderId = orderId
     }
 }
 
 struct SavedCardConfiguration: CheckoutTypeConfiguration {
     var amount: Double = .zero
-
-    init() {}
 }

--- a/Sources/MercadoPagoCheckout/Model/Public/MPPaymentData.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/MPPaymentData.swift
@@ -60,7 +60,6 @@ public enum MPPaymentData {
             self.orderStatus = orderStatus
             self.payer = payer
         }
-
     }
 
     public struct Payer: Equatable, Codable, Sendable {

--- a/Sources/MercadoPagoCheckout/Model/Public/MPPaymentData.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/MPPaymentData.swift
@@ -34,6 +34,8 @@ public enum MPPaymentData {
         public var paymentTypeId: String
         public var issuerId: String?
         public var payer: Payer?
+        public var orderId: String
+        public var orderStatus: String
 
         var token: String
 
@@ -44,7 +46,9 @@ public enum MPPaymentData {
             paymentMethodId: String = "",
             paymentTypeId: String = "",
             issuerId: String? = "",
-            payer: Payer? = nil
+            payer: Payer? = nil,
+            orderId: String = "",
+            orderStatus: String = ""
         ) {
             self.transactionAmount = transactionAmount
             self.token = token
@@ -53,6 +57,8 @@ public enum MPPaymentData {
             self.paymentTypeId = paymentTypeId
             self.issuerId = issuerId
             self.payer = payer
+            self.orderId = orderId
+            self.orderStatus = orderStatus
         }
     }
 

--- a/Sources/MercadoPagoCheckout/Model/Public/MPPaymentData.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/MPPaymentData.swift
@@ -61,18 +61,6 @@ public enum MPPaymentData {
             self.payer = payer
         }
 
-        public init(from decoder: Decoder) throws {
-            let c = try decoder.container(keyedBy: CodingKeys.self)
-            transactionAmount = try c.decodeIfPresent(Double.self, forKey: .transactionAmount)
-            token = try c.decodeIfPresent(String.self, forKey: .token) ?? ""
-            installment = try c.decodeIfPresent(Int.self, forKey: .installment)
-            paymentMethodId = try c.decodeIfPresent(String.self, forKey: .paymentMethodId) ?? ""
-            paymentTypeId = try c.decodeIfPresent(String.self, forKey: .paymentTypeId) ?? ""
-            issuerId = try c.decodeIfPresent(String.self, forKey: .issuerId)
-            orderId = try c.decodeIfPresent(String.self, forKey: .orderId) ?? ""
-            orderStatus = try c.decodeIfPresent(String.self, forKey: .orderStatus) ?? ""
-            payer = try c.decodeIfPresent(Payer.self, forKey: .payer)
-        }
     }
 
     public struct Payer: Equatable, Codable, Sendable {

--- a/Sources/MercadoPagoCheckout/Model/Public/MPPaymentData.swift
+++ b/Sources/MercadoPagoCheckout/Model/Public/MPPaymentData.swift
@@ -46,9 +46,9 @@ public enum MPPaymentData {
             paymentMethodId: String = "",
             paymentTypeId: String = "",
             issuerId: String? = "",
-            payer: Payer? = nil,
             orderId: String = "",
-            orderStatus: String = ""
+            orderStatus: String = "",
+            payer: Payer? = nil
         ) {
             self.transactionAmount = transactionAmount
             self.token = token
@@ -56,9 +56,22 @@ public enum MPPaymentData {
             self.paymentMethodId = paymentMethodId
             self.paymentTypeId = paymentTypeId
             self.issuerId = issuerId
-            self.payer = payer
             self.orderId = orderId
             self.orderStatus = orderStatus
+            self.payer = payer
+        }
+
+        public init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            transactionAmount = try c.decodeIfPresent(Double.self, forKey: .transactionAmount)
+            token = try c.decodeIfPresent(String.self, forKey: .token) ?? ""
+            installment = try c.decodeIfPresent(Int.self, forKey: .installment)
+            paymentMethodId = try c.decodeIfPresent(String.self, forKey: .paymentMethodId) ?? ""
+            paymentTypeId = try c.decodeIfPresent(String.self, forKey: .paymentTypeId) ?? ""
+            issuerId = try c.decodeIfPresent(String.self, forKey: .issuerId)
+            orderId = try c.decodeIfPresent(String.self, forKey: .orderId) ?? ""
+            orderStatus = try c.decodeIfPresent(String.self, forKey: .orderStatus) ?? ""
+            payer = try c.decodeIfPresent(Payer.self, forKey: .payer)
         }
     }
 

--- a/Tests/MercadoPagoCheckoutTests/API/MercadoPagoCheckoutBuilderTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/API/MercadoPagoCheckoutBuilderTests.swift
@@ -21,12 +21,13 @@ final class MercadoPagoCheckoutBuilderTests: XCTestCase {
 
     func test_cardTransaction_init_shouldStoreAmountInCheckoutType() {
         let checkout = MercadoPagoCheckout.Builder(
-            checkoutType: .cardTransaction(order: .init(amount: 100.0, payer: .init(email: "test@mp.com"))),
+            checkoutType: .cardTransaction(order: .init(amount: 100.0, payer: .init(email: "test@mp.com"), orderId: "order-1")),
             checkoutAppearance: .init()
         ).build()
 
         if case let .cardTransaction(order) = checkout.configuration.type.kind {
             XCTAssertEqual(order.amount, 100.0)
+            XCTAssertEqual(order.orderId, "order-1")
         } else {
             XCTFail("Expected .cardTransaction kind")
         }
@@ -34,7 +35,7 @@ final class MercadoPagoCheckoutBuilderTests: XCTestCase {
 
     func test_build_withoutSettingPaymentMethodConfiguration_shouldHaveDefaultConfiguration() {
         let checkout = MercadoPagoCheckout.Builder(
-            checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mp.com"))),
+            checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mp.com"), orderId: "")),
             checkoutAppearance: .init()
         ).build()
 
@@ -54,7 +55,7 @@ final class MercadoPagoCheckoutBuilderTests: XCTestCase {
         ]
 
         let checkout = MercadoPagoCheckout.Builder(
-            checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mp.com"))),
+            checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mp.com"), orderId: "")),
             checkoutAppearance: .init()
         )
         .setPaymentMethodConfiguration(customConfig)
@@ -71,7 +72,7 @@ final class MercadoPagoCheckoutBuilderTests: XCTestCase {
 
     func test_setPaymentMethodConfiguration_withNoArgument_shouldResetToEmpty() {
         let builder = MercadoPagoCheckout.Builder(
-            checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mp.com"))),
+            checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mp.com"), orderId: "")),
             checkoutAppearance: .init()
         )
         builder.setPaymentMethodConfiguration([.card(excludedTypes: [.credit])])
@@ -83,7 +84,7 @@ final class MercadoPagoCheckoutBuilderTests: XCTestCase {
 
     func test_setPaymentMethodConfiguration_shouldBeDiscardableAndReturnSameBuilder() {
         let builder = MercadoPagoCheckout.Builder(
-            checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mp.com"))),
+            checkoutType: .cardTransaction(order: .init(amount: 50.0, payer: .init(email: "test@mp.com"), orderId: "")),
             checkoutAppearance: .init()
         )
 
@@ -125,7 +126,7 @@ final class MercadoPagoCheckoutBuilderTests: XCTestCase {
 
     func test_cardTransaction_checkoutType_analyticsValue() {
         let checkoutType = MercadoPagoCheckout<MPPaymentData.CardTransaction>.CheckoutType.cardTransaction(
-            order: .init(amount: 10.0, payer: .init(email: "a@b.com"))
+            order: .init(amount: 10.0, payer: .init(email: "a@b.com"), orderId: "")
         )
         XCTAssertEqual(checkoutType.analyticsValue, "card_transaction")
     }
@@ -137,7 +138,7 @@ final class MercadoPagoCheckoutBuilderTests: XCTestCase {
 
     func test_cardTransaction_checkoutType_carriesOrderAmount() {
         let checkoutType = MercadoPagoCheckout<MPPaymentData.CardTransaction>.CheckoutType.cardTransaction(
-            order: .init(amount: 77.5, payer: .init(email: "test@mp.com"))
+            order: .init(amount: 77.5, payer: .init(email: "test@mp.com"), orderId: "")
         )
         guard case let .cardTransaction(order) = checkoutType.kind else {
             return XCTFail("Expected .cardTransaction kind")

--- a/Tests/MercadoPagoCheckoutTests/Models/MPPaymentDataTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/Models/MPPaymentDataTests.swift
@@ -80,7 +80,7 @@ final class MPPaymentDataTests: XCTestCase {
     }
 
     func test_cardTransaction_codable_missingOptionalFields_shouldNotFail() throws {
-        let json = #"{"token":"tok","paymentMethodId":"visa","paymentTypeId":"credit_card"}"#.data(using: .utf8)!
+        let json = #"{"token":"tok","paymentMethodId":"visa","paymentTypeId":"credit_card","orderId":"","orderStatus":""}"#.data(using: .utf8)!
         let decoded = try JSONDecoder().decode(MPPaymentData.CardTransaction.self, from: json)
         XCTAssertEqual(decoded.token, "tok")
         XCTAssertNil(decoded.transactionAmount)

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormBrickViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormBrickViewModelTests.swift
@@ -79,4 +79,32 @@ final class CardFormBrickViewModelTests: XCTestCase {
             XCTAssertEqual(sut.repository.fetchCallCount, 2)
         }
     }
+
+    // MARK: - buildPaymentData orderId propagation
+
+    func test_buildPaymentData_cardTransaction_shouldPropagateOrderId() {
+        // Arrange
+        let order = MPOrder(amount: 100.0, payer: .init(email: "test@mp.com"), orderId: "order-42")
+        let configuration = MPCheckoutConfiguration<MPPaymentData.CardTransaction>(
+            type: .cardTransaction(order: order),
+            paymentMethod: [.card()]
+        )
+        let viewModel = CardFormBrickViewModel<MPPaymentData.CardTransaction>(
+            configuration: configuration,
+            initializeUseCase: InitializeCardFormUseCase(repository: MockCardFormInitializationRepository())
+        )
+        let output = CardFormOutput(
+            token: "token",
+            paymentMethodId: "visa",
+            paymentTypeId: "credit_card",
+            issuerId: nil,
+            payer: nil
+        )
+
+        // Act
+        let result = viewModel.buildPaymentData(from: output)
+
+        // Assert
+        XCTAssertEqual(result?.orderId, "order-42")
+    }
 }


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
https://mercadolibre.atlassian.net/browse/CHOBK-3977

## Description
- `MPOrder`: added `orderId: String` as a required property and updated the public `init` to accept it
- `MPPaymentData.CardTransaction`: added `orderId` and `orderStatus` as public fields — this type is SDK output only, so no custom `Codable` decoder is needed
- `CardFormBrickViewModel`: now passes `orderId` from the order and an empty `orderStatus` when building the `CardTransaction` payload
- Tests: updated `MercadoPagoCheckoutBuilderTests`, `MPPaymentDataTests`, and `CardFormBrickViewModelTests` to cover the new fields

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [x] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.