### PR TITLE
chore(mirror): add Flowbook/ to .mirrorignore

### DIFF
--- a/.mirrorignore
+++ b/.mirrorignore
@@ -1,9 +1,6 @@
 # .mirrorignore
-# Caminhos listados aqui são removidos de todos os pushes para o repo público.
-# O workflow lê este arquivo — nenhuma alteração no workflow é necessária para novas exclusões.
+# Caminhos listados aqui sao removidos de todos os pushes para o repo publico.
+# O workflow le este arquivo - nenhuma alteracao no workflow e necessaria para novas exclusoes.
 ux-reference/
+Flowbook/
 .github/
-
-Example/Example.xcodeproj/project.pbxproj.rej
-
-Example/Sources/MainListView.swift


### PR DESCRIPTION
## O que muda

Adiciona `Flowbook/` ao `.mirrorignore` para garantir que a ferramenta de UX handoff nunca seja espelhada para o repositório público `mercadopago/sdk-ios`.

## Por que

O Flowbook é uma ferramenta interna de UX — um HTML interativo com mockups e fluxos de telas para handoff do time de design. Não é código de SDK público.

O repo Android (`fury_openplatform-sdk-android`) já recebeu a mesma mudança via PR #42.

## Mudança

```diff
 ux-reference/
+Flowbook/
 .github/
```