### PR TITLE
docs(SMFINTECH-32897): add selector-de-meios specs

### DIFF
--- a/meli/SMFINTECH-32897/features/001-selector-de-meios/1-functional/spec.md
+++ b/meli/SMFINTECH-32897/features/001-selector-de-meios/1-functional/spec.md
@@ -1,0 +1,298 @@
+# PaymentBrick Nativo — Selector de Meios — Functional Spec
+
+**Status**: approved
+**Owner**: Danielle Ogawa
+**Jira**: [SMFINTECH-32897](https://mercadolibre.atlassian.net/browse/SMFINTECH-32897)
+**RFC**: [[RFC] PaymentBrick MLA](https://grid.adminml.com/d/01KRE8MW8TVD33X6FDMP0W733W/view)
+**Created**: 2026-05-22
+**Last Updated**: 2026-05-22T15:12:22Z
+
+> **Payment Flows**: Os fluxos de pagamento (Selecionar Meio — Novo Cartão, Cartão Salvo e Meios Offline) foram extraídos para spec dedicada → [`003-payment-flows/1-functional/spec.md`](../003-payment-flows/1-functional/spec.md)
+
+> **CVV Screen**: Tudo relacionado à tela de CVV foi extraído para spec dedicada → [`002-cvv-screen/1-functional/spec.md`](../002-cvv-screen/1-functional/spec.md)
+
+> **Revisa e Confirma**: US-5, E2E-5 e tela de Revisa e Confirma foram extraídos para spec dedicada → [`20260622-payment-review-confirm/1-functional/spec.md`](../../20260622-payment-review-confirm/1-functional/spec.md)
+
+---
+
+> **Purpose**: Esta spec define o PaymentBrick Nativo — componente SDK de seleção de meios de pagamento para apps nativos Android e iOS. O Brick oferece ao seller uma tela de checkout pronta e integrada à Order API, eliminando a necessidade de implementar lógica de pagamento no cliente.
+
+---
+
+## Problem Statement
+
+Sellers que desenvolvem apps nativos (Android/iOS) não contam com nenhuma solução SDK de checkout pronta. Precisam implementar todo o fluxo de pagamento por conta própria: formulários de cartão, tokenização, integração com APIs de meios de pagamento, tela de revisão — com lógica de negócio espalhada pelo cliente.
+
+O Checkout Bricks web resolve parte desse problema para a web, mas apenas retorna dados do pagamento (token de cartão, meio escolhido) para que o seller processe a transação no seu próprio backend — sem integração com a Order API do lado do Brick.
+
+O PaymentBrick Nativo vai além: oferece a UI de checkout em SDK **e** integração direta com a Order API. O seller configura os dados de pagamento na criação da Order (server-side), e o SDK processa o pagamento sem expor configurações sensíveis no cliente.
+
+**Impacto atual:**
+- Sellers nativos gastam tempo e esforço reimplementando a mesma lógica de pagamento em cada app
+- Experiência de checkout inconsistente entre sellers, aumentando dropout por má UX
+- Dados sensíveis de pagamento expostos no cliente quando o seller implementa por conta própria
+- Mercado Pago perde presença e conversão em canais mobile nativos
+
+---
+
+## Objectives
+
+1. **Disponibilizar SDK de checkout nativo** (Android e iOS) com tela de seleção de meios de pagamento pronta
+2. **Integrar com a Order API** no modelo Order Builder Mode — configurações sensíveis nunca trafegam pelo cliente
+3. **Aumentar conversão em checkouts nativos** reduzindo dropout por fricção no pagamento
+4. **Expandir a presença do MercadoPago** em canais mobile nativos de sellers
+
+---
+
+## Scope
+
+### In Scope — Q2.26 (MLA — Argentina)
+
+- **Checkout type `payment`**: tela seletora de meios de pagamento como entrega principal do quarter
+- **Cartões salvos**: exibição dos cartões do comprador via `customer_id` (Customers API)
+- **Novo cartão**: formulário de cartão com tokenização interna — `card_token` nunca exposto ao seller
+- **Pagamentos offline**: Rapipago e Pago Fácil (hardcoded no BFF nesta entrega)
+- **Tela de Revisa e Confirma**: endpoint dedicado `GET /review_confirm` com labels variáveis por tipo de meio
+- **Integração com Order API** no modelo Order Builder Mode
+- **Plataformas**: Android e iOS
+- **Site**: MLA (Argentina)
+
+### Out of Scope
+
+- **Meios ecosistêmicos**: saldo em conta, cartões MP/ML (Q3.26)
+- **Linha de crédito**: Cuotas sin Tarjeta (Q3.26)
+- **Status Screen**: tela de resultado pós-pagamento (Q3.26) — seller recebe dados de boleto via callback nesta entrega
+- **Sites MLB, MLM e demais**: estrutura já desenhada para multi-site, entrega futura
+- **Consulta dinâmica de métodos offline**: Rapipago/Pago Fácil retornados como hardcoded no BFF nesta entrega
+- **CTA de salvamento de cartão com UX dedicado**: salvamento automático pós-pagamento é Extra Mile (ver seção de Edge Cases)
+
+---
+
+## User Stories
+
+### US-1: Seller inicializa o PaymentBrick no app nativo
+
+**As a** seller que desenvolve um app nativo (Android ou iOS)
+**I want** inicializar o PaymentBrick com o `order_id` da minha Order e a `public_key`
+**So that** o comprador veja a tela de seleção de meios de pagamento sem que eu implemente nenhuma lógica de checkout no cliente
+
+**Acceptance Criteria:**
+- [ ] AC-1: O `payment` é iniciado com `order_id` e, opcionalmente, `customer_id` + `card_ids`
+- [ ] AC-2: O SDK chama `GET /initialization` e renderiza a tela com os meios disponíveis retornados pelo BFF
+- [ ] AC-3: Enquanto aguarda a resposta, o SDK exibe estado de loading (a definir com UX: skeleton ou spinner)
+- [ ] AC-4: O seller configura os filtros de exclusão (`excludedTypes`, `excludedMethods` e campo de exclusão por grupo — nome TBD) via builder do `payment`; o SDK repassa esses valores ao BFF, que aplica o filtro server-side antes de retornar os meios disponíveis
+- [ ] AC-5: Em caso de erro na inicialização (Order não encontrada, expirada ou falha crítica no BFF), o SDK devolve o erro ao seller via `onError` — a responsabilidade de exibir feedback ao usuário é do seller
+- [ ] AC-6: O seller pode configurar comportamentos do checkout: limitar número mínimo (`minInstallments`) e máximo (`maxInstallments`) de parcelas — enviados ao BFF na inicialização para filtrar as opções retornadas —, ocultar a tela de Revisa e Confirma (`showReviewConfirm`) e ocultar a Status Screen (`showStatusScreen`)
+
+**Priority:** High
+**Complexity:** L
+
+---
+
+### US-5: Comprador revisa e confirma o pagamento
+
+**As a** comprador que chegou à etapa de confirmação
+**I want** ver um resumo do que vou pagar antes de confirmar
+**So that** eu tenha controle sobre o pagamento antes de finalizar
+
+**Acceptance Criteria:**
+- [ ] AC-1: Ao avançar para a etapa de revisão, o SDK realiza um `GET /review_confirm` ao BFF passando o tipo de meio selecionado; o BFF retorna os labels e campos da tela de acordo com o tipo
+- [ ] AC-2: A tela de Revisa e Confirma exibe o meio selecionado, o valor total e os campos do pagador relevantes por tipo
+- [ ] AC-3: Para pagamentos offline (ticket), o campo de email é exibido e editável
+- [ ] AC-4: Para cartões, apenas o meio de pagamento é exibido (sem campos adicionais do pagador)
+- [ ] AC-5: O comprador pode alterar o meio de pagamento a partir desta tela — o SDK retorna à tela seletora
+- [ ] AC-6: O valor total exibido vem do BFF formatado — o SDK exibe diretamente sem formatação monetária própria
+- [ ] AC-7: O label do botão de confirmação varia por tipo: "Pagar" para cartões, "Crear factura" para offline
+
+**Priority:** High
+**Complexity:** M
+
+---
+
+### US-6: Seller recebe o resultado do pagamento via callback
+
+**As a** seller integrado ao PaymentBrick Nativo
+**I want** receber o resultado do checkout via callback estruturado
+**So that** eu trate o resultado (aprovação, erro, cancelamento) na experiência do meu app sem precisar consultar a Order API
+
+**Acceptance Criteria:**
+- [ ] AC-1: Pagamento aprovado → `onSuccess(MPPaymentData.OrderTransaction)` com `orderId` (para o seller consultar a Order no seu backend) e `orderStatus` com o status do pagamento
+- [ ] AC-2: Pagamento offline gerado → `onSuccess(MPPaymentData.OrderTransaction)` com `orderId` e `orderStatus`
+- [ ] AC-3: Erro crítico (5xx, Order inválida) → `onError(MercadoPagoCheckoutError)` com o erro classificado
+- [ ] AC-4: Usuário cancelou → `onUserCancelled(UserCancelledContext)` com o contexto de onde o usuário saiu
+- [ ] AC-5: O SDK não retorna token nem dados de cartão — o processamento acontece inteiramente no BFF
+- [ ] AC-6: Os callbacks são exaustivos (sem default/else no switch) em ambas as plataformas
+
+**Priority:** High
+**Complexity:** S
+
+---
+
+### US-7: Comprador cancela ou abandona o checkout
+
+**As a** comprador que desistiu do pagamento em alguma etapa
+**I want** poder sair do checkout a qualquer momento
+**So that** o seller saiba onde abandone o fluxo para analytics de funil
+
+**Acceptance Criteria:**
+- [ ] AC-1: O `UserCancelledContext` identifica em qual tela o comprador saiu: `paymentBrick`, `cardForm`, `installments`, `cvv`, `payerInfo`, `reviewConfirm`
+- [ ] AC-2: O cancelamento não é tratado como erro — `onUserCancelled` é distinto de `onError`
+- [ ] AC-3: O seller recebe o contexto de cancelamento para uso em analytics; nenhuma ação de pagamento foi executada
+
+**Priority:** Medium
+**Complexity:** S
+
+---
+
+## Success Metrics
+
+| Métrica | Baseline | Meta |
+|---|---|---|
+| Taxa de conversão do checkout (sessões que chegam ao /process com status approved) | [A definir com Analytics] | [A definir com Produto] |
+| Taxa de abandono (sessões na inicialização que não chegam ao /process) | [A definir com Analytics] | [A definir com Produto] |
+| Adoção por sellers (sellers ativos usando o PaymentBrick Nativo por semana) | 0 | [A definir com Produto] |
+
+---
+
+## User Experience
+
+### Fluxo principal — payment
+
+```
+Seller cria Order (backend)
+        ↓
+Seller inicializa o SDK com public_key + country_code
+        ↓
+Seller inicializa o PaymentBrick(payment) com order_id [+ customer_id + card_ids]
+        ↓
+Loading (skeleton ou spinner — a definir com UX)
+        ↓
+Tela seletora de meios de pagamento
+  └── [Fluxos de pagamento → ver 003-payment-flows]
+```
+
+### Telas do SDK (Q2.26)
+
+| Tela | Quando exibida | Responsabilidade |
+|---|---|---|
+| Tela seletora de meios | Sempre — tela inicial do Brick | SDK renderiza baseado no response de `/initialization` |
+| Tela de CVV | Cartão salvo com `security_code.screen` presente | SDK exibe campo de CVV |
+| Tela de Revisa e Confirma | Antes de finalizar qualquer pagamento | SDK chama `GET /review_confirm` e renderiza labels do BFF |
+| Status Screen | **Fora de escopo Q2.26** | Prevista para Q3.26 |
+
+### Experiência do seller (integrador)
+
+O seller inicializa o SDK e recebe o resultado via um único closure/callback. Toda lógica de pagamento fica encapsulada no SDK + BFF.
+
+---
+
+## Dependencies
+
+- **Order API**: criação e leitura de `payment_settings` na inicialização; processamento do pagamento via `POST /process` — crítico, impossibilita o fluxo se indisponível
+- **BFF `fury_bricks-api`**: novos endpoints `GET /cho-off/v1/payment_brick/initialization`, `GET /cho-off/v1/payment_brick/review_confirm` e `POST /cho-off/v1/orders/{order_id}/process` a criar
+- **Customers API**: busca de cartões salvos via `customer_id` — parcial; checkout sem cartões salvos ainda funciona
+- **KVS**: cache de configurações da Order entre chamadas do BFF — degradação de performance se indisponível, sem perda de funcionalidade (fallback direto para Order API)
+- **CardPaymentBrick (existente)**: reutilização de módulo de tokenização e Core Methods no SDK
+
+---
+
+## Risks
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|---|---|---|---|
+| Order API adiciona breaking changes nos campos de `payment_settings` | Média | Alto | Contrato versionado (`/cho-off/v1/*`); BFF valida campos antes de cachear no KVS |
+| Order expira durante o checkout (comprador demora para confirmar) | Média | Médio | BFF detecta no `/process` e retorna erro tratado; SDK orienta usuário a reiniciar |
+| Baixa adoção por sellers — complexidade de integração com Order API | Média | Médio | Documentação detalhada; suporte via programa de parceiros; SDK como ponto único de integração |
+| KVS com alta latência afeta tempo de resposta do `/initialization` | Baixa | Médio | TTL curto no KVS; fallback direto para Order API em caso de miss |
+| SDK lança nova versão com breaking changes no contrato de inicialização ou callbacks | Baixa | Alto | O time está trabalhando em padrões que evitem breaking changes (ex: `CheckoutType` enum extensível); versionamento de endpoints como fallback quando necessário |
+
+---
+
+## Edge Cases
+
+- **Order expirada durante o checkout**: BFF retorna `ORDER_EXPIRED` no `/process`; SDK exibe erro tratado e orienta o comprador a reiniciar o checkout
+- **Comprador sem cartões salvos** (nenhum `card_ids`): tela exibe apenas "Novo cartão" e meios offline — sem seção de cartões
+- **Seller exclui todos os meios offline exceto um** (ex: apenas Pago Fácil): comportamento a definir com UX — exibir com 1 opção (Opção A) ou pular direto para Revisa e Confirma (Opção B)
+- **`customer_id` inválido ou Customers API indisponível**: BFF omite a seção de cartões salvos; checkout prossegue com novo cartão e offline
+- **Comprador revoga autorização do cartão entre inicialização e processo**: Order API rejeita no `/process`; SDK devolve `onError` ao seller — sem nova tentativa automática para evitar duplo processamento
+- **Salvamento automático de cartão pós-pagamento** (`payment` / `cardTransaction`): o comportamento padrão é `saveCard = true` — quando `customer_id` é fornecido, o BFF salva o cartão na Customers API após pagamento aprovado, de forma transparente ao comprador. No checkout type `saveCard`, o cartão **não** é salvo automaticamente pois não há processamento de pagamento — o SDK tokeniza e entrega o token ao seller via callback
+
+---
+
+## Critical E2E Test Scenarios
+
+### E2E Summary
+
+| ID | Cenário | Prioridade |
+|---|---|---|
+| E2E-4 | Inicialização com Order expirada | 🔴 Crítico |
+| E2E-6 | Exclusão de tipos via `excludedTypes` | 🟡 Importante |
+| E2E-8 | Exclusão de método específico via `excludedMethods` | 🟡 Importante |
+| E2E-9 | Exclusão de boleto individual via campo de exclusão por grupo (nome TBD) | 🟡 Importante |
+
+---
+
+### E2E-4: Inicialização com Order expirada 🔴
+
+**Contexto**: Seller inicializa o Brick com `order_id` de uma Order expirada
+
+**Steps**:
+1. SDK chama `GET /initialization` com Order expirada
+2. BFF retorna erro `ORDER_EXPIRED`
+
+**Resultado esperado**: `onError(ORDER_EXPIRED)` disparado — seller recebe o erro e é responsável por exibir feedback ao usuário
+
+---
+
+### E2E-6: Exclusão de tipos via `excludedTypes` 🟡
+
+**Contexto**: Seller configura `excludedTypes: ["ticket"]` na inicialização
+
+**Steps**:
+1. Seller inicializa o SDK com `excludedTypes: ["ticket"]`
+2. BFF omite meios offline do response de `/initialization`
+
+**Resultado esperado**: Tela seletora exibe apenas cartões; nenhum item de ticket (Rapipago/Pago Fácil)
+
+---
+
+### E2E-8: Exclusão de método específico via `excludedMethods` 🟡
+
+**Contexto**: Seller configura `excludedMethods: ["visa"]` na inicialização; comprador tem cartão Visa salvo e outros cartões
+
+**Steps**:
+1. Seller inicializa o SDK com `excludedMethods: ["visa"]`
+2. BFF omite cartões Visa do response de `/initialization`
+
+**Resultado esperado**: Cartões Visa não aparecem na tela seletora; demais cartões e meios seguem visíveis
+
+---
+
+### E2E-9: Exclusão de boleto individual via campo de exclusão por grupo (nome TBD) 🟡
+
+**Contexto**: Seller configura exclusão de Rapipago via campo de exclusão por grupo (nome TBD)
+
+**Steps**:
+1. Seller configura exclusão de `rapipago` via `setPaymentMethodConfiguration` (campo nome TBD)
+2. BFF omite Rapipago do response de `/initialization`, mantendo Pago Fácil
+
+**Resultado esperado**: Tela de seleção de offline exibe apenas Pago Fácil; Rapipago não aparece
+
+---
+
+## Open Questions
+
+1. **Estado de loading da tela seletora**: skeleton (Opção A, alinhado com CardPaymentBrick) ou spinner/tela de loading (Opção B)? — Pendência UX
+2. **Experiência com exclusão de tickets para 1 único meio**: exibir na tela seletora (consistência) ou pular diretamente para Revisa e Confirma (menos fricção)? — Pendência UX
+3. **Métricas de baseline**: quais são os valores atuais de conversão e abandono em fluxos nativos sem SDK? — Alinhar com Analytics
+4. **Devolução de dados para pagamentos offline**: o callback `onSuccess` deve retornar apenas `orderId` + `orderStatus` (alinhado com cartões) ou incluir `barcode_content` e `date_of_expiration` para que o seller exiba o boleto sem consultar a Order API? — Decisão de arquitetura pendente
+5. **Integração do card form dentro do PaymentBrick**: como o formulário de novo cartão será integrado ao fluxo do PaymentBrick — reuso do `CardFormBrick` existente como componente embutido, navegação para tela separada ou implementação dedicada? — Decisão de arquitetura pendente
+
+---
+
+## Notes
+
+- Spec funcional baseada na RFC "[RFC] PaymentBrick MLA" v3 (15 mai 2026) — autora: Danielle Ogawa
+- Escopo desta spec é o checkout type `payment` como entrega principal de Q2.26 MLA
+- Os tipos `cardTransaction` e `saveCard` estão definidos na RFC e referenciados nesta spec; roadmap de entrega a alinhar com Produto
+- Pendências UX (seção 14 da RFC) estão refletidas nos Open Questions acima

--- a/meli/SMFINTECH-32897/features/001-selector-de-meios/2-technical/spec.md
+++ b/meli/SMFINTECH-32897/features/001-selector-de-meios/2-technical/spec.md
@@ -1,0 +1,947 @@
+# PaymentBrick Nativo — Selector de Meios — Technical Spec
+
+**Status**: approved
+**Owner**: Danielle Ogawa
+**Jira**: [SMFINTECH-32897](https://mercadolibre.atlassian.net/browse/SMFINTECH-32897)
+**RFC**: [[RFC] PaymentBrick MLA](https://grid.adminml.com/d/01KRE8MW8TVD33X6FDMP0W733W/view)
+**Functional Spec**: [1-functional/spec.md](../1-functional/spec.md)
+**Created**: 2026-05-22
+**Last Updated**: 2026-07-07T00:00:00Z
+
+> **Payment Flows**: Decisões de design e telas dos fluxos de pagamento foram extraídas para spec dedicada → [`003-payment-flows/2-technical/spec.md`](../003-payment-flows/2-technical/spec.md)
+
+> **CVV Screen**: Tudo relacionado à tela de CVV foi extraído para spec dedicada → [`002-cvv-screen/2-technical/spec.md`](../002-cvv-screen/2-technical/spec.md)
+
+> **Revisa e Confirma**: DD-2, contrato do `GET /review_confirm` e tracking events foram extraídos para spec dedicada → [`20260622-payment-review-confirm/2-technical/spec.md`](../../20260622-payment-review-confirm/2-technical/spec.md)
+
+---
+
+## Executive Summary
+
+O PaymentBrick Nativo é uma feature multi-repositório que entrega um SDK de checkout (Android + iOS) integrado a um BFF dedicado em Go. A arquitetura opera no modelo **Order Builder Mode**: o seller cria a Order com `payment_settings` server-side, incluindo `processing_mode`. Em Q2.26, o SDK envia `amount` na inicialização; o `processing_mode` não é enviado pelo SDK — o BFF usa `aggregator` hardcoded internamente, pois o valor já está na Order. O BFF valida o `amount` contra a Order no `/process`, prevenindo fraudes. O endgame (BFF resolvendo ambos diretamente da Order API) é planejado para entregas futuras.
+
+Três novos endpoints REST são adicionados ao BFF `fury_bricks-api`, sob o prefixo `/cho-off/v1/*`, seguindo o padrão layered já existente. A tokenização de cartão acontece dentro do SDK via Core Methods; o `card_token` é enviado ao BFF e nunca é exposto ao seller.
+
+---
+
+## Repositories
+
+| Repositório | Linguagem | Papel | Status |
+|---|---|---|---|
+| [`fury_openplatform-sdk-android`](https://github.com/melisource/fury_openplatform-sdk-android) | Kotlin | SDK Android — UI, navegação, callbacks no módulo `mercadopagocheckout` | Módulo existente; adicionar PaymentBrick |
+| [`fury_openplatform-sdk-ios`](https://github.com/melisource/fury_openplatform-sdk-ios) | Swift | SDK iOS — UI, navegação, callbacks no módulo `mercadopagocheckout` | Módulo existente; adicionar PaymentBrick |
+| [`fury_bricks-api`](https://github.com/melisource/fury_bricks-api) | Go | BFF — novos endpoints `cho-off/v1/*` para nativo | Novos endpoints |
+
+---
+
+## Architecture Overview
+
+### Fluxo end-to-end (Order Builder Mode)
+
+```mermaid
+sequenceDiagram
+    participant SB as Seller Backend
+    participant APP as Seller App Nativo
+    participant SDK as SDK Nativo
+    participant BFF as fury_bricks-api (BFF)
+    participant Order as Order API
+    participant Cust as Customers API
+    participant KVS as KVS Cache
+
+    SB->>Order: POST /v1/orders (amount, items, payment_settings)
+    Order-->>SB: order_id
+    SB-->>APP: order_id
+
+    Note over SDK: SDK já inicializado com public_key + country_code
+    APP->>SDK: Inicializa PaymentBrick (order_id, customer_id?)
+
+    SDK->>BFF: GET /cho-off/v1/payment_brick/initialization (public_key, order_id, total_amount, excluded_*, ...)
+    Note over BFF: Q2: BFF não chama Order API em /init<br/>Endgame: BFF resolve amount da Order diretamente
+    BFF->>Cust: GET cartões salvos (se customer_id)
+    BFF-->>SDK: sections[], methods[], traduções, total
+
+    SDK->>SDK: Renderiza tela seletora
+    Note over SDK: Usuário seleciona meio
+
+    SDK->>BFF: GET /cho-off/v1/payment_brick/review_confirm?type=...
+    BFF-->>SDK: labels da tela de Revisa e Confirma
+
+    SDK->>SDK: Tokeniza cartão (Core Methods)
+    SDK->>BFF: POST /cho-off/v1/orders/{order_id}/process (token, installments, ...)
+    BFF->>KVS: lê processing_mode, amount
+    BFF->>Order: POST /orders/{id}/process
+    Order-->>BFF: status + result
+    BFF-->>SDK: passthrough response
+
+    SDK->>APP: onSuccess / onError / onUserCancelled
+```
+
+### Diagrama ASCII — componentes principais
+
+```
+                       ┌──────────────────────────┐
+                       │  SDK Nativo (Android/iOS)│
+                       │    mercadopagocheckout   │
+                       └────┬────────────┬────────┘
+                            │            │
+              GET /init     │            │  POST /process
+              GET /review   │            │
+                            ▼            ▼
+                       ┌──────────────────────────┐
+                       │  fury_bricks-api (BFF)   │
+                       │  /cho-off/v1/*           │
+                       └─┬──────┬──────┬──────┬───┘
+                         │      │      │      │
+              ┌──────────┘      │      │      └────────────┐
+              ▼                 ▼      ▼                    ▼
+          __________      ┌─────────┐ ┌──────────┐    __________
+         /          \     │ Order   │ │Customers │   /          \
+         |   KVS    |     │  API    │ │   API    |   |Card Tokn.|
+         | (cache)  |     └─────────┘ └──────────┘   \__________/
+         \__________/
+```
+
+---
+
+## Design Decisions
+
+### DD-1: Order Builder Mode
+
+**Selected**: Configurações de pagamento armazenadas na Order pelo backend do seller na criação.
+
+**Q2.26 (entrega atual)**: O SDK envia `public_key`, `order_id`, `total_amount` e os parâmetros opcionais configurados pelo seller (`customer_id`, `card_ids`, `excluded_*`). O `processing_mode` **não é enviado pelo SDK** — o BFF usa `aggregator` hardcoded internamente, pois o valor já está nos `payment_settings` da Order criada pelo seller. A validação do `amount` contra a Order acontece em `/process` — o BFF rejeita pagamentos com valor adulterado. O BFF **não** chama a Order API durante `/initialization` neste Q por restrições de capacidade.
+
+**Endgame**: BFF resolve `amount` e `processing_mode` diretamente da Order API durante `/initialization`. O SDK para de enviar `amount`.
+
+**Rationale**: A validação no `/process` já elimina o vetor de fraude (pagamento com valor adulterado seria rejeitado). A chamada à Order API no `/initialization` é o endgame por questões de capacidade de time no Q2.26.
+
+---
+
+### DD-3: Padrão layered no BFF (Handler → Service → Domain → External)
+
+**Selected**: Endpoints nativos seguem o mesmo padrão do BFF já adotado nas rotas `/cho-off/v1/*`.
+
+**Rationale**: Consistência com o restante do `fury_bricks-api`. Cada endpoint tem Handler para parsing/validação de entrada, Service para orquestração e regras de domínio, Domain Resource para chamadas a APIs externas (Order, Customers, Card Tokenization).
+
+---
+
+### DD-4: Tokenização interna ao SDK (Core Methods)
+
+**Selected**: SDK tokeniza o cartão via Core Methods antes de enviar ao BFF.
+
+**Rationale**: No fluxo `payment`, o `card_token` nunca é exposto ao seller — a tokenização acontece internamente e o token é enviado diretamente ao BFF para processamento. No fluxo `CardSave`, o token é entregue intencionalmente ao seller via `MPPaymentData.CardSave.token` (esse é o propósito do fluxo). Reutiliza o módulo de tokenização já existente do CardPaymentBrick.
+
+---
+
+### DD-5: Cartões salvos resolvidos pelo BFF
+
+**Selected**: SDK envia `customer_id` (+ opcional `card_ids`); o **BFF** consulta a Customers API server-side e devolve a lista de cartões já formatada ao SDK.
+
+**Rationale**: A Customers API É consultada — a decisão é apenas sobre quem faz a chamada. Mantendo no BFF, o SDK recebe a lista pronta para renderizar, sem executar nenhuma lógica de negócio. O BFF é responsável por aplicar os filtros de exclusão configurados pelo seller (`excluded_methods`, `excluded_types` e um campo de exclusão por grupo — ex: tickets, cartões, meios ecosistêmicos; nome exato do campo a definir). Manutenção centralizada e consistência com o padrão dos demais Bricks.
+
+---
+
+### DD-6: Sem retry automático no `/process`
+
+**Selected**: SDK não retenta o `POST /process` em falhas.
+
+**Rationale**: Evita duplo processamento da Order. `GET /initialization` é idempotente e pode ter 1 retry com backoff; `/process` muda estado da Order e qualquer retry deve ser ação explícita do usuário (nova tentativa do checkout). Toda falha é devolvida ao seller via `onError`.
+
+---
+
+### DD-7: `customer_id` alfanumérico vs `user_id` numérico
+
+**Selected**: BFF distingue internamente `customer_id` (alfanumérico, ex: `649457098-FybpOkG6zH8QRm`) de `user_id` (numérico).
+
+**Rationale**: Mantém compatibilidade com o fluxo web (que usa `user_id`) sem mudar o contrato. O serviço de cartões correto é selecionado pelo formato do ID.
+
+---
+
+### DD-8: Devolução de dados para pagamentos offline via callback ✅ Decidido
+
+**Opções analisadas**:
+- **Opção A** — Retornar apenas `orderId` + `orderStatus` (consistente com cartões); seller consulta a Order API para obter dados do boleto
+- **Opção B** — Retornar `orderId`, `orderStatus`, `barcode_content` e `date_of_expiration`; seller não precisa consultar a Order API para exibir o boleto
+
+**Decisão**: Variante da Opção A — callback unificado para todos os meios de pagamento: `orderId`, `orderStatus`, `paymentMethodId` e `paymentTypeId`. Campos `barcode_content` e `date_of_expiration` **não serão expostos** no SDK. Sellers que precisam desses dados devem consultar a Order API. Impacta tasks A2/A10 (Android) e I3/I10 (iOS).
+
+---
+
+## REST API Contracts
+
+### 1. GET /cho-off/v1/payment_brick/initialization
+
+Retorna todos os dados necessários para o SDK renderizar a tela de seleção.
+
+**Query Parameters:**
+
+| Parâmetro | Tipo | Obrigatório | Descrição |
+|---|---|---|---|
+| `public_key` | string | Sim | Public key do seller |
+| `order_id` | string | Sim | ID da Order criada server-side |
+| `customer_id` | string | Não | ID alfanumérico do comprador (cartões salvos) |
+| `card_ids` | string | Condicional | IDs de cartões separados por vírgula. Obrigatório se `customer_id` informado |
+| `excluded_methods` | string | Não | Métodos a excluir, separados por vírgula (ex: `visa,master`) |
+| `excluded_types` | string | Não | Tipos a excluir, separados por vírgula (ex: `credit_card,ticket`) |
+| `excluded_tickets` *(nome TBD)* | string | Não | Exclusão por grupo de meios offline — nome do campo a definir junto com `excluded_groups` |
+| `excluded_groups` *(nome TBD)* | string | Não | Exclusão por grupo de meios (ex: tickets, cartões, meios ecosistêmicos) — nome e estrutura do campo a definir |
+| `total_amount` | number | Sim | Valor da transação. BFF valida contra a Order no `/process` para prevenir adulteração |
+
+**Response:**
+
+```json
+{
+  "header_title": "Elegí cómo pagar",            // BFF: traduzido por locale
+  "sections": [
+    {
+      "title": "Otros medios de pago",            // BFF: título da seção, traduzido
+      "methods": [
+
+        // ── Cartão salvo com CVV e parcelamento ─────────────────────────────
+        {
+          "type": "saved_card",
+          "title": "Visa **** 1234",              // BFF: "{issuer_name} **** {last_four_digits}"
+          "subtitle": "Visa · Crédito",           // BFF: "{brand_name} · {type_label traduzido}"
+          "icon_url": "https://.../{payment_method_id}.png",
+          "card_data": {
+            "id": "123456",                       // ID do cartão salvo na Customers API
+            "bin": "503143",                      // Primeiros 6 dígitos
+            "last_four_digits": "1234",
+            "payment_method_id": "visa",          // Identificador da bandeira
+            "payment_type_id": "credit_card",     // "credit_card" | "debit_card"
+            "issuer_id": 1,                       // ID do banco emissor
+            "security_code": {
+              "length": 3,                        // Comprimento do CVV (3 ou 4)
+              "screen": {                         // PRESENTE = SDK exibe tela de CVV
+                "header_title": "Ingresá el código de seguridad",
+                "field": {
+                  "label": "Código de seguridad",
+                  "placeholder": "Ej.: 123",      // BFF gera baseado no length
+                  "helper": "Está en el reverso de tu tarjeta."
+                },
+                "continue_button_label": "Continuar"
+              }
+              // AUSENTE = SDK pula tela de CVV (has_preapproval_scope=true ou length=0)
+            },
+            "installments": {                     // PRESENTE se cartão suporta parcelamento
+              "header": {
+                "title": "Elegí las cuotas"       // BFF: traduzido por locale
+              },
+              "total_label": "Total",
+              "pay_button_label": "Pagar",
+              "selection_type": "radio_button",   // Sempre "radio_button" nesta entrega
+              "quotas": [
+                {
+                  "installments": 1,              // Número de parcelas
+                  "installment_amount": 500.00,   // Valor por parcela
+                  "total_amount": 500.00,         // Valor total com juros (se houver)
+                  "primary_label": "1x $ 500,00", // BFF: label principal, formatado
+                  "secondary_label": "",          // BFF: vazio se sem juros
+                  "state": "none"                 // "none" | "interest_free" | "recommended"
+                },
+                {
+                  "installments": 3,
+                  "installment_amount": 170.00,
+                  "total_amount": 510.00,
+                  "primary_label": "3x $ 170,00",
+                  "secondary_label": "$ 510,00",  // BFF: total quando há juros
+                  "state": "interest_free"        // SDK exibe badge "sin interés"
+                }
+              ]
+            }
+            // installments AUSENTE se cartão não suporta parcelamento para o valor
+          }
+        },
+
+        // ── Cartão salvo SEM tela de CVV (has_preapproval_scope=true) ────────
+        {
+          "type": "saved_card",
+          "title": "Master **** 5678",
+          "subtitle": "Mastercard · Débito",
+          "icon_url": "https://.../master.png",
+          "card_data": {
+            "id": "789012",
+            "bin": "516105",
+            "last_four_digits": "5678",
+            "payment_method_id": "master",
+            "payment_type_id": "debit_card",
+            "issuer_id": 2,
+            "security_code": {
+              "length": 3
+              // "screen" AUSENTE → SDK pula CVV
+            }
+            // "installments" AUSENTE → débito não parcela
+          }
+        },
+
+        // ── Meios offline (ticket) ────────────────────────────────────────────
+        {
+          "type": "ticket",
+          "title": "Efectivo",
+          "subtitle": "Pago Fácil y Rapipago",   // BFF: monta dinamicamente dos options
+          "options": [                            // Lista dos meios offline disponíveis
+            {
+              "id": "pagofacil",                  // Identificador do meio offline
+              "name": "Pago Fácil",               // Label exibido ao usuário
+              "icon_url": "https://.../pagofacil.png"
+            },
+            {
+              "id": "rapipago",
+              "name": "Rapipago",
+              "icon_url": "https://.../rapipago.png"
+            }
+          ]
+        },
+
+        // ── Novo cartão ───────────────────────────────────────────────────────
+        {
+          "type": "new_card",
+          "title": "Nueva tarjeta",
+          "subtitle": "Crédito y débito",         // BFF: dinâmico por tipos permitidos
+          "icon_url": "https://.../new_card.png"
+          // Sem "card_data" nem "options" — SDK abre CardForm ao selecionar
+        }
+
+      ]
+    }
+  ],
+  "footer": {
+    "total_label": "Total",                       // BFF: traduzido por locale
+    "total_amount": "$ 188.000"                   // BFF: formatado a partir da Order — SDK exibe direto
+  }
+}
+```
+
+**Campos raiz:**
+
+| Campo | Tipo | Presença | Descrição |
+|---|---|---|---|
+| `header_title` | string | Sempre | Título da tela — gerado e traduzido pelo BFF por locale |
+| `sections[]` | array | Sempre | Lista de seções de meios de pagamento |
+| `footer.total_label` | string | Sempre | Label da linha de total — traduzido pelo BFF |
+| `footer.total_amount` | string | Sempre | Valor total formatado pelo BFF (ex: `$ 188.000`) — SDK exibe direto, sem formatação |
+
+**`sections[].methods[]` — campos comuns a todos os tipos:**
+
+| Campo | Tipo | Presença | Descrição |
+|---|---|---|---|
+| `type` | string | Sempre | `saved_card` \| `new_card` \| `ticket` \| `wallet` \| `credits` |
+| `title` | string | Sempre | Nome principal do método — gerado pelo BFF |
+| `subtitle` | string | Opcional | Linha secundária — gerada pelo BFF |
+| `icon_url` | string | Sempre | URL do ícone — BFF fornece, SDK renderiza |
+
+**`card_data` (apenas `type = saved_card`):**
+
+| Campo | Tipo | Presença | Descrição |
+|---|---|---|---|
+| `id` | string | Sempre | ID do cartão na Customers API |
+| `bin` | string | Sempre | Primeiros 6 dígitos |
+| `last_four_digits` | string | Sempre | Últimos 4 dígitos |
+| `payment_method_id` | string | Sempre | Bandeira: `visa`, `master`, etc. |
+| `payment_type_id` | string | Sempre | `credit_card` \| `debit_card` |
+| `issuer_id` | number | Sempre | ID do banco emissor |
+| `security_code` | object | Sempre | Ver tabela abaixo |
+| `installments` | object | Opcional | Presente se cartão suporta parcelamento para o valor da Order |
+
+**`card_data.security_code`:**
+
+| Campo | Tipo | Presença | Descrição |
+|---|---|---|---|
+| `length` | number | Sempre | Comprimento do CVV (3 ou 4) |
+| `screen` | object | Opcional | **Presente** = SDK exibe tela de CVV. **Ausente** = SDK pula CVV (`has_preapproval_scope=true` ou `length=0`) |
+| `screen.header_title` | string | Com `screen` | Título da tela de CVV — traduzido pelo BFF |
+| `screen.field.label` | string | Com `screen` | Label do campo de CVV |
+| `screen.field.placeholder` | string | Com `screen` | Placeholder gerado pelo BFF baseado no `length` |
+| `screen.field.helper` | string | Com `screen` | Texto auxiliar — ex: "Está en el reverso de tu tarjeta." |
+| `screen.continue_button_label` | string | Com `screen` | Label do botão — traduzido pelo BFF |
+
+**`card_data.installments`:**
+
+| Campo | Tipo | Presença | Descrição |
+|---|---|---|---|
+| `header.title` | string | Sempre | Título da tela de parcelas — traduzido pelo BFF |
+| `total_label` | string | Sempre | Label do total — traduzido pelo BFF |
+| `pay_button_label` | string | Sempre | Label do botão de pagamento |
+| `selection_type` | string | Sempre | `radio_button` (único valor nesta entrega) |
+| `quotas[]` | array | Sempre | Lista de opções de parcelamento |
+
+**`card_data.installments.quotas[]`:**
+
+| Campo | Tipo | Descrição |
+|---|---|---|
+| `installments` | number | Número de parcelas |
+| `installment_amount` | number | Valor por parcela |
+| `total_amount` | number | Valor total da compra com os juros |
+| `primary_label` | string | Label principal — ex: `"3x $ 170,00"` |
+| `secondary_label` | string | Label secundário com total quando há juros; vazio se sem juros |
+| `state` | string | `none` (sem destaque) \| `interest_free` (SDK exibe badge "sin interés") \| `recommended` (SDK destaca a opção) |
+
+**`options[]` (apenas `type = ticket`):**
+
+| Campo | Tipo | Descrição |
+|---|---|---|
+| `id` | string | Identificador do meio: `pagofacil`, `rapipago` |
+| `name` | string | Label exibido ao usuário |
+| `icon_url` | string | URL do ícone |
+
+**Notas sobre traduções**: O BFF segue o padrão do CardPaymentBrick — `baseTranslations` (EN/PT/ES) + `localeOverrides` para variantes regionais (es_AR usa forma vos: "Elegí", "Ingresá") + `siteOverrides` para diferenças por site.
+
+**Lógica do BFF — Q2.26:**
+1. Validar `public_key` + `order_id`
+2. Receber `amount` do SDK; cachear no KVS: `{order_id} → {amount (do SDK), processing_mode=aggregator (hardcoded)}`
+3. Se `customer_id`: consultar Customers API → filtrar cartões expirados
+4. Montar `sections[]` com cartões salvos + novo cartão + meios offline (hardcoded para MLA)
+5. Aplicar filtros `excluded_*`
+6. Resolver traduções (baseTranslations + localeOverrides + siteOverrides)
+7. Retornar response
+
+> **Nota de segurança**: em Q2.26 o BFF **não** chama a Order API no `/initialization`. O `amount` vem do SDK e é cacheado no KVS para uso no cálculo de parcelas. A validação real acontece em `/process` — quando o BFF chama a Order API, ela valida o valor contra o que o seller configurou na Order server-side. Se adulterado, a Order API rejeita.
+
+**Lógica do BFF — Endgame:**
+1. Validar `public_key` + `order_id`
+2. Ler Order via Order API → extrair `payment_settings` (incluindo `amount` e `processing_mode`)
+3. Cachear no KVS: `{order_id} → {amount, processing_mode, payment_settings}`
+4. Se `customer_id`: consultar Customers API → filtrar cartões expirados
+5. Montar `sections[]`, aplicar filtros, resolver traduções
+6. Retornar response
+
+**Lógica de `security_code.screen`:**
+
+| `security_code_length` | `has_preapproval_scope` | Resultado |
+|---|---|---|
+| > 0 (ex: 3 para Visa/Master, 4 para Amex) | false | Retorna `screen` — SDK exibe tela de CVV |
+| > 0 | true | Omite `screen` — SDK pula a tela |
+| 0 | qualquer | Omite `screen` — SDK pula a tela |
+
+> **Regra**: qualquer `length > 0` aciona a tela de CVV quando `has_preapproval_scope = false`. O `length` define o número de dígitos do placeholder — o BFF gera automaticamente (ex: `"Ej.: 123"` para 3, `"Ej.: 1234"` para 4).
+
+---
+
+### 2. POST /cho-off/v1/orders/{order_id}/process
+
+Processa o pagamento.
+
+**Headers:**
+
+| Header | Origem |
+|---|---|
+| `X-Client-Id` | BFF deriva da `public_key` |
+| `X-Caller-Id` | BFF deriva da `public_key` |
+| `X-Caller-SiteID` | BFF deriva da `public_key` |
+| `X-Idempotency-Key` | SDK gera e envia (UUID por tentativa de checkout) |
+| `X-Tiger-Token` | BFF resolve internamente |
+
+**Request Body:**
+
+```json
+{
+  "token": "CARD_TOKEN",
+  "installments": 3,
+  "payment_method_id": "visa",
+  "payment_method_type": "credit_card"
+}
+```
+
+**Notas:**
+- `amount` e `processing_mode` resolvidos pelo BFF via KVS — SDK não os envia
+- `token` é o `card_token` gerado pelo SDK; para meios offline pode ser ausente
+
+**Response:** passthrough da Order API (ver RFC seção 4.3).
+
+**Mapeamento de status para callbacks SDK:**
+
+| `order.status` | `status_detail` | Callback | Cenário |
+|---|---|---|---|
+| `processed` | `accredited` | `onSuccess(MPPaymentData.Payment)` | Cartão aprovado |
+| `action_required` | `waiting_payment` | `onSuccess(MPPaymentData.Payment)` com `orderId`, `orderStatus`, `paymentMethodId` e `paymentTypeId` | Ticket/boleto gerado — aguarda pagamento do usuário; seller consulta Order API para `barcode_content`/`date_of_expiration` (decisão DD-8) |
+| `failed` | `cc_rejected_*` | `onError` | Cartão rejeitado |
+| `failed` | `processing_error` | `onError` | Erro interno de processamento |
+| `failed` | `invalid_card_token` | `onError` | Token inválido ou expirado |
+| `failed` | `bad_filled_card_data` | `onError` | Dados do cartão inválidos |
+| qualquer outro | — | `onError` genérico | Fallback para status inesperados |
+
+---
+
+## SDK Architecture (Android + iOS)
+
+### Padrão arquitetural
+
+**MVVM** com camadas: UI (SwiftUI/Compose) → ViewModel → Repository → DataSource (chamadas ao BFF).
+
+### API pública
+
+A API usa **generics** para garantir type-safety end-to-end: o tipo de `MPPaymentData` retornado no callback é inferido diretamente do `CheckoutType` configurado no builder — sem casts nem branches inalcançáveis.
+
+> **Android**: `MPCheckoutType` agora tem dois type params — `<T: MPPaymentData, C: MPUserCancelledContext>` — garantindo type-safety também no callback de cancelamento.
+
+#### Tipos existentes (`CheckoutType`)
+
+| Caso | `MPPaymentData` produzido | Processa pagamento |
+|---|---|---|
+| `cardTransaction(order:)` | `MPPaymentData.CardTransaction` | Sim (token + amount) |
+| `CardSave` | `MPPaymentData.CardSave` | Não (devolve token ao seller) |
+| Android: `Payment(order: MPOrder)` | `MPPaymentData.Payment` | Sim (via Order API no BFF) |
+| iOS: `payment(order: MPOrder)` | `MPPaymentData.Payment` *(a adicionar)* | Sim (via Order API no BFF) |
+
+#### `MPPaymentData` — estado atual por plataforma
+
+Para o `payment`, o pagamento é processado inteiramente no BFF. O SDK não devolve token — devolve o resultado da Order.
+
+**Android** — `MPPaymentData.Payment` implementado. Estado atual da `feature/cardpayment-q2` ainda carrega campos token-based como dívida técnica — a ser migrado pela task A2.
+
+```kotlin
+// Android — estado atual em MPPaymentData.kt (dívida técnica — task A2)
+data class Payment(
+    val orderId: String,
+    val orderStatus: String,
+    val paymentMethodId: String,
+    val paymentTypeId: String,
+    val transactionAmount: BigDecimal?,  // debt: remover em A2
+    val payer: Payer?,                   // debt: remover em A2
+    val installment: Int?,               // debt: remover em A2
+    val issuerId: String?,               // debt: remover em A2
+) : MPPaymentData()
+// TODO A2: remover transactionAmount, payer, installment, issuerId — shape final: orderId, orderStatus, paymentMethodId, paymentTypeId (decisão DD-8)
+```
+
+> **Nota**: `MPPaymentData.CardTransaction` também recebeu `orderId: String` e `orderStatus: String` como primeiros campos, alinhando o contrato entre os dois tipos.
+
+**iOS** — variant `Payment` ainda não adicionada. A ser implementada como `MPPaymentData.Payment`, alinhada ao padrão de `MPCheckoutType.payment` e `MPUserCancelledContext.payment`.
+
+#### `CheckoutType` — estado atual por plataforma
+
+**Android** — implementado como `Payment`, entregando `MPPaymentData.Payment`. `MPCheckoutType` tem dois type params. `cardIds` e `customerId` removidos — resolvidos server-side via Order.
+
+```kotlin
+// Android — estado atual em MPCheckoutType.kt
+sealed class MPCheckoutType<out T : MPPaymentData, out C : MPUserCancelledContext> : Parcelable {
+    // ...
+    @Parcelize
+    data class Payment(
+        val order: MPOrder,
+    ) : MPCheckoutType<MPPaymentData.Payment, MPUserCancelledContext.Payment>()
+}
+```
+
+> **Nota**: `orderId` e `clientToken` são passados via `MPOrder`. `customerId` e `cardIds` não são mais enviados pelo SDK — o BFF os resolve a partir dos `payment_settings` da Order criada server-side pelo seller.
+
+**iOS** — caso `payment` implementado.
+
+```swift
+// iOS — estado atual em MercadoPagoCheckout+CheckoutType.swift
+struct CheckoutType: Sendable {
+    enum Kind: Sendable {
+        case payment(MPOrder)
+        case cardTransaction(MPOrder)
+        case saveCard
+    }
+}
+```
+
+> **Nota**: `MPPaymentData.Payment` e `MPUserCancelledContext.payment` ainda pendentes para iOS.
+
+#### `MPOrder` — estado atual por plataforma
+
+**Android** — `orderId` e `clientToken` adicionados. Estado atual:
+
+```kotlin
+// Android — estado atual em MPOrder.kt
+@Parcelize
+data class MPOrder(
+    val orderId: String,
+    val clientToken: String,
+    val amount: BigDecimal,
+    val payer: MPPayer,
+) : CheckoutTypeConfiguration, Parcelable
+```
+
+**iOS** — `MPOrder` com shape final `orderId` + `clientToken`. `amount` e `payer` removidos — BFF resolve `amount` diretamente da Order API (endgame antecipado).
+
+```swift
+// iOS — estado atual em MPOrder.swift
+public struct MPOrder {
+    public var orderId: String
+    public var clientToken: String
+}
+```
+
+> **Decisão resolvida**: filtros (`excludedTypes`, `excludedMethods`, `minInstallments`, `maxInstallments`, exclusão por grupo), `customerId` e `cardIds` são todos resolvidos server-side — o BFF os obtém dos `payment_settings` da Order. O SDK não os envia mais em nenhuma das plataformas.
+>
+> **iOS (endgame antecipado)**: `amount` e `payer` também foram removidos do `MPOrder` iOS — o BFF resolve `amount` diretamente da Order API. O Android ainda envia `amount` e `payer` via `MPOrder`; a remoção está planejada para entrega futura.
+
+#### Exemplo de integração — Android (Kotlin)
+
+```kotlin
+// Android — integração com API atual
+val checkout = MercadoPagoCheckout.Builder(
+    context = context,
+    checkoutType = MPCheckoutType.Payment(
+        order = MPOrder(
+            orderId = "ORD01J6TC8...",
+            clientToken = "seller_client_token",
+            amount = BigDecimal("188000.0"),
+            payer = MPPayer(email = "buyer@email.com"),
+        ),
+    ),
+    checkoutAppearance = MPCheckoutAppearance()
+)
+.build()
+
+checkout.show { result ->
+    when (result) {
+        is MercadoPagoCheckoutResult.Success -> {
+            val data = result.paymentData  // MPPaymentData.Payment
+            println("Order: ${data.orderId}, Status: ${data.orderStatus}")
+        }
+        is MercadoPagoCheckoutResult.Error -> { /* onError */ }
+        is MercadoPagoCheckoutResult.UserCancelled -> { /* onUserCancelled */ }
+    }
+}
+```
+
+#### Exemplo de integração — iOS (Swift)
+
+> **Nota**: `CheckoutType.payment` implementado. `MPPaymentData.Payment` e `MPUserCancelledContext.payment` ainda pendentes.
+
+```swift
+// iOS — integração com API atual (MPPaymentData.Payment a adicionar)
+let checkout = MercadoPagoCheckout.Builder(
+    checkoutType: .payment(
+        order: MPOrder(
+            orderId: "ORD01J6TC8...",
+            clientToken: "seller_client_token"
+        )
+    ),
+    checkoutAppearance: .init()
+)
+.build()
+
+checkout.show { result in
+    switch result {
+    case .success(let data):  // data: MPPaymentData.Payment (a adicionar)
+        print("Order: \(data.orderId), Status: \(data.orderStatus)")
+    case .error(let error):
+        handleError(error)
+    case .userCancelled(let context):
+        handleCancellation(context)
+    }
+}
+```
+
+**Regra**: switches são exaustivos em ambas as plataformas — sem `default` / `else`.
+
+#### `UserCancelledContext`
+
+**Android** — `MPUserCancelledContext` implementado como sealed class tipada em `MPCheckoutType<T, C>`:
+
+```kotlin
+// Android — estado atual em MPUserCancelledContext.kt
+sealed class MPUserCancelledContext {
+    data class CardSave(val fields: List<MPCancelledFieldState>) : MPUserCancelledContext()
+    data class CardTransaction(
+        val fields: List<MPCancelledFieldState>,
+        val screens: List<Screen>,
+    ) : MPUserCancelledContext()
+    data class Payment(
+        val screens: List<Screen>,  // telas percorridas pelo usuário antes de cancelar
+    ) : MPUserCancelledContext()
+}
+
+// Screen — enum em domain/model/Screen.kt
+enum class Screen {
+    INSTALLMENTS,
+    PAYMENT_METHOD_SELECTOR,
+    CARD_FORM,
+    OFFLINE_METHOD_SELECTOR,
+    // CVV: pendente
+}
+```
+
+**iOS** — `MPUserCancelledContext.payment` ainda pendente de implementação.
+
+**Target spec** (ambas as plataformas):
+
+`MPUserCancelledContext.Payment` devolve `screens: List<Screen>` — lista ordenada das telas percorridas pelo usuário antes de cancelar, permitindo ao seller rastrear o ponto de abandono no funil.
+
+| `Screen` | Status | Quando presente na lista |
+|---|---|---|
+| `INSTALLMENTS` | ✅ Implementado | Usuário chegou à seleção de parcelas |
+| `PAYMENT_METHOD_SELECTOR` | ✅ Implementado | Usuário chegou à tela seletora de meios |
+| `CARD_FORM` | ✅ Implementado | Usuário chegou ao formulário de cartão |
+| `OFFLINE_METHOD_SELECTOR` | ✅ Implementado | Usuário chegou à tela de seleção de meio offline |
+| `CVV` | 🔲 Pendente | Usuário chegou à tela de CVV |
+
+### Telas (Q2.26)
+
+| Tela | Trigger | Origem dos labels |
+|---|---|---|
+| Tela seletora de meios | Sempre — inicial | BFF (`/initialization`) |
+| Tela de CVV | Cartão salvo com `security_code.screen` presente | BFF (`security_code.screen`) |
+| Tela de Revisa e Confirma | Pré-confirmação | Tratada em spec separada |
+
+
+### Loading
+
+- Skeleton durante `GET /initialization` (decisão UX pendente, ver Open Decisions)
+
+---
+
+## Fury Platform Compliance
+
+A implementação acontece em um BFF existente (`fury_bricks-api`) — não há infraestrutura nova a criar além do container KVS. Os requisitos da plataforma Fury já estão atendidos pelo serviço base.
+
+| Requisito | Status | Observação |
+|---|---|---|
+| Dockerfile | ✅ Existente | `fury_bricks-api` já em produção com imagem aprovada `hub.furycloud.io/mercadolibre/distroless-go` |
+| Dockerfile.runtime | ✅ Existente | Runtime config já configurada no serviço base |
+| Endpoint `/ping` | ✅ Existente | Health check já implementado (retorna `pong`) |
+| Versionamento de rotas | ✅ Existente | Novos endpoints sob `/cho-off/v1/*` (`RegisterRoutes`) |
+| Padrão layered | ✅ Existente | Handler → Service → Domain Resource → External API |
+| Autenticação Tiger-Token | ✅ Existente | BFF resolve internamente — SDK não traz |
+| Observabilidade (logs/metrics) | ✅ Existente | Reutiliza configuração do BFF |
+| Container KVS | 🆕 A criar/reusar | Ver "Fury Services" abaixo |
+
+**Stack técnico**:
+- Linguagem: **Go**
+- Framework: padrão interno do `fury_bricks-api`
+- Imagem base: `hub.furycloud.io/mercadolibre/distroless-go` (já configurada)
+
+> **Nota**: Os endpoints novos aproveitam toda a infraestrutura compliant já existente. Não há mudanças no Dockerfile, no Dockerfile.runtime, no `/ping`, ou na configuração base do serviço — apenas adição de rotas no roteador existente.
+
+---
+
+## Fury Services
+
+### KVS — Order Configuration Cache
+
+- **Container**: `payment_brick_order_cache` (a confirmar via `fury services kvs list`)
+- **Key**: `order_id`
+- **Value Q2.26**: `{ processing_mode=aggregator, amount (do SDK), cached_at }`
+- **Value Endgame**: `{ processing_mode, amount, payment_settings, cached_at }` (após chamar Order API em /init)
+- **TTL**: 15 minutos (compatível com tempo médio de checkout)
+- **Criticality**: Médio — fallback direto para Order API em caso de miss
+
+**Rationale**: Evita N round-trips à Order API entre `/initialization`, `/review_confirm` e `/process` dentro da mesma sessão de checkout. TTL curto reduz risco de inconsistência se a Order mudar.
+
+> **Live Discovery**: container instance a confirmar com `fury services kvs list` no momento do build. Spec marca como **(A DEFINIR)** até a discovery.
+
+---
+
+## Data Model
+
+### KVS — Order Config Cache
+
+```json
+// Q2.26 — amount vem do SDK, processing_mode hardcoded, sem payment_settings
+{
+  "order_id": "ORD01J6TC8...",
+  "processing_mode": "aggregator",
+  "amount": 188000.00,
+  "cached_at": "2026-05-22T15:00:00Z"
+}
+
+// Endgame — após chamar Order API em /initialization
+{
+  "order_id": "ORD01J6TC8...",
+  "processing_mode": "aggregator",
+  "amount": 188000.00,
+  "payment_settings": { /* trecho relevante da Order */ },
+  "cached_at": "2026-05-22T15:00:00Z"
+}
+```
+
+### Response Payload — /initialization (resumo)
+
+```json
+{
+  "header_title": "Elegí cómo pagar",
+  "sections": [
+    {
+      "title": "Otros medios de pago",
+      "methods": [
+        { "type": "saved_card", "title": "Visa **** 1234", "card_data": { ... } },
+        { "type": "ticket", "title": "Efectivo", "options": [...] },
+        { "type": "new_card", "title": "Nueva tarjeta" }
+      ]
+    }
+  ],
+  "footer": { "total_label": "Total", "total_amount": "$ 188.000" }
+}
+```
+
+### Tracking — Melidata
+
+Eventos sob `/checkout_api_native/checkout/payment_brick/*`:
+
+| Path | Tipo | Trigger |
+|---|---|---|
+| `/initialize` | VIEW | Inicialização do brick |
+| `/initialize_error` | EVENT | Erro impede renderização |
+| `/selected` | EVENT | Comprador seleciona meio |
+
+
+Schemas completos: ver RFC seção 10.
+
+---
+
+## Security
+
+### Tamper-proof por arquitetura
+
+- **Q2.26**: SDK envia `public_key`, `order_id`, `total_amount` e parâmetros opcionais na inicialização. `processing_mode` não é enviado pelo SDK — o BFF usa `aggregator` hardcoded internamente (o valor já está na Order, criada pelo seller com `payment_settings`). O BFF valida `amount` contra a Order no `/process` — pagamentos com valor adulterado são rejeitados.
+- **Endgame**: BFF resolverá `amount` e `processing_mode` diretamente da Order API, sem dependência do SDK.
+- `card_token` nunca exposto ao seller — SDK tokeniza internamente via Core Methods e envia direto ao BFF.
+
+### Headers de segurança
+
+| Header | Quem gera | Propósito |
+|---|---|---|
+| `X-Idempotency-Key` | SDK | Idempotência do POST /process (UUID por sessão de checkout) |
+| `X-Tiger-Token` | BFF | Autenticação interna entre BFF e APIs MP — nunca exposto ao SDK |
+| `X-Client-Id` / `X-Caller-Id` / `X-Caller-SiteID` | BFF | Derivados da `public_key` |
+
+### Erros — mensagens genéricas para rejeições de cartão
+
+Erros de rejeição (`PAYMENT_REJECTED`) devem ser **genéricos** — expor o motivo específico (CVV inválido, saldo insuficiente, bloqueio) abre vetor para card testing. O BFF retorna `PAYMENT_REJECTED` sem detalhe.
+
+### Segredos / Credenciais
+
+Nenhum segredo novo precisa ser criado. Reutiliza:
+- Tiger-Token do BFF (já configurado)
+- Credenciais de Order API e Customers API (já configuradas no `fury_bricks-api`)
+
+---
+
+## Error Handling
+
+### Estrutura padrão (apierror)
+
+```json
+{
+  "code": "not_found",
+  "error_code": "ORDER_NOT_FOUND",
+  "message": "Order not found"
+}
+```
+
+### Severidade
+
+| HTTP | Severidade | Comportamento SDK |
+|---|---|---|
+| 4xx | Non-critical | Devolve ao seller via `onError` — seller decide UI |
+| 5xx | Critical | Devolve ao seller via `onError` — fluxo encerrado |
+
+### Cenários mapeados
+
+| Cenário | `error_code` | Endpoint | Callback |
+|---|---|---|---|
+| public_key inválida | TBD | /initialization | onError |
+| Order não encontrada | `ORDER_NOT_FOUND` | /initialization, /process | onError |
+| Order expirada | `ORDER_EXPIRED` | /initialization, /process | onError |
+| Order já processada | `ORDER_ALREADY_PROCESSED` | /initialization, /process | onError |
+| Cartão expirado | — | /initialization | BFF omite o cartão da lista |
+| Pagamento rejeitado | `PAYMENT_REJECTED` | /process | onError (sem retry) |
+| Timeout/erro interno | TBD | ambos | onError |
+
+### Estratégia de retry
+
+| Operação | Retry automático | Motivo |
+|---|---|---|
+| `GET /initialization` | 1 retry com backoff | Idempotente |
+
+| `POST /process` | **Não** | Risco de duplo processamento — DD-6 |
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+**Backend (`fury_bricks-api`)** — cobertura alvo: >80%
+- Handler: validação de input (query params obrigatórios/opcionais, formatos)
+- Service: regras de negócio (filtros `excluded_*`, lógica de `security_code.screen`, hardcode MLA Rapipago/Pago Fácil, formatação de labels, resolução de traduções)
+- Domain Resource: mappers de Order API e Customers API com payloads mockados
+
+**SDK (Android + iOS)** — cobertura alvo: >80%
+- ViewModel: estado de telas, transições, eventos de seleção
+- Repository: chamadas ao BFF com mocks (sucesso, erro 4xx, erro 5xx, timeout)
+- Mappers: response BFF → modelo interno do SDK
+
+### Integration Tests
+
+**Backend** — cobertura alvo: >70%
+- Pipeline Handler → Service → Domain Resource com mocks de Order API, Customers API e KVS
+- Cenários: Order válida com customer, Order válida sem customer, Order expirada, KVS miss (fallback Order API), filtros aplicados
+
+**SDK**
+- Integração SDK ↔ BFF stub em ambiente de teste (Sprint 3)
+- Snapshot tests com payloads cobrindo: cartões salvos, sem cartões, só offline, só novo cartão, com CVV, sem CVV (preapproval)
+- Screenshot tests por tela em iOS e Android
+
+### E2E Tests
+
+Cenários definidos na spec funcional (E2E-1 a E2E-9). Integração SDK ↔ BFF real concentrada no Sprint 3 conforme roadmap da RFC. QA manual em MLA antes do release.
+
+---
+
+## Performance
+
+| Métrica | Target |
+|---|---|
+| Latência `GET /initialization` p95 | < 500ms (com KVS hit); < 1.2s (cold miss) |
+
+| Latência `POST /process` p95 | < 2s (limitado pela Order API) |
+| Tempo de render inicial do SDK | < 1.5s (incluindo skeleton) |
+
+**Otimizações**:
+- KVS TTL 15min reduz round-trip à Order entre `/initialization` e `/process`
+- `/review_confirm` não consulta Order (labels estáticos por type) — minimiza latência
+- Tokenização local no SDK paraleliza com loading da tela de Revisa e Confirma
+
+---
+
+## Deployment Strategy
+
+Conforme roadmap da RFC (seção 13):
+
+| Sprint | Período | Foco |
+|---|---|---|
+| Sprint 1 | 18 Mai – 30 Mai | Mobile: componentes base + tela seletora. BFF: setup endpoints + /initialization + Orders+KVS |
+| Sprint 2 | 2 Jun – 13 Jun | Mobile: email, modal. BFF: /review_confirm, /process, Customers. Revisa e Confirma (nativo): spec separada |
+| Sprint 3 | 16 Jun – 30 Jun | Integração SDK↔BFF, callbacks, tracks, E2E, QA MLA, bug fixes |
+
+**Estratégia de release**:
+- BFF: deploy contínuo via Fury, endpoints versionados (`v1`)
+- SDK: nova versão do módulo `mercadopagocheckout` em ambas as plataformas
+- Multi-versão ativa em paralelo no BFF se houver breaking change futuro
+
+---
+
+## Open Decisions
+
+1. **`total_amount` na inicialização** — ✅ Resolvido: SDK envia `total_amount` como query param obrigatório. BFF valida contra Order API em `/process`. Endgame (BFF resolvendo da Order em `/initialization`) é planejado para Q futuro por restrições de capacidade em Q2.26.
+2. **HTTP status + error_code para `public_key` inválida e timeout/erro interno** — definir durante implementação e adicionar ao enum `config.ErrorCode` no `fury_bricks-api`
+3. **Container/instance específica do KVS** — confirmar via `fury services kvs list` no momento do build (live discovery)
+
+---
+
+## Dependencies
+
+| Dependência | Tipo | Status |
+|---|---|---|
+| Order API | API interna MP | Existente — leitura de `payment_settings`, processamento de pagamento |
+| Customers API | API interna MP | Existente — busca de cartões salvos |
+| Card Tokenization API | API interna MP | Existente — usada pelo SDK via Core Methods |
+| KVS (Fury) | Serviço Fury | Container a criar/reusar |
+| `fury_bricks-api` | BFF (Go) | Existente — adicionar endpoints `cho-off/v1/*` |
+| `fury_openplatform-sdk-android` (módulo `mercadopagocheckout`) | SDK | Existente — adicionar PaymentBrick |
+| `fury_openplatform-sdk-ios` (módulo `mercadopagocheckout`) | SDK | Existente — adicionar PaymentBrick |
+| `CardPaymentBrick` (módulo interno) | Lib interna | Reutilizar tokenização e Core Methods |
+
+---
+
+## Notes
+
+- Esta spec técnica deriva diretamente da RFC v3 — referenciar a RFC para schemas completos de payload e exemplos de código
+- Repositório atual é `core-frontend-specs` (specs-only) — implementação acontece em `sdk-android`, `sdk-ios` e `fury_bricks-api`
+- Decisões marcadas como TBD são esperadas — serão fechadas durante a implementação (Sprint 1)

--- a/meli/SMFINTECH-32897/features/001-selector-de-meios/3-tasks/android.md
+++ b/meli/SMFINTECH-32897/features/001-selector-de-meios/3-tasks/android.md
@@ -1,0 +1,61 @@
+# SDK Android — Implementation Tasks: PaymentBrick (SMFINTECH-32897)
+
+**Jira**: [SMFINTECH-32897](https://mercadolibre.atlassian.net/browse/SMFINTECH-32897)
+**Repositório**: [`fury_openplatform-sdk-android`](https://github.com/melisource/fury_openplatform-sdk-android)
+**Branch principal**: `feature/cardpayment-q2`
+**Specs**: [functional](../1-functional/spec.md) · [technical](../2-technical/spec.md) · [BFF tasks](./bricks-api.md)
+
+> **Payment Flows**: As tasks A17–A25 e A27–A29 (fluxos de pagamento) foram extraídas para spec dedicada → [`003-payment-flows/3-tasks/android.md`](../003-payment-flows/3-tasks/android.md)
+
+> **CVV Screen**: As tasks A13–A16 (tela de CVV) foram extraídas para spec dedicada → [`002-cvv-screen/3-tasks/android.md`](../002-cvv-screen/3-tasks/android.md)
+
+> **Revisa e Confirma**: Tudo relacionado à tela de Revisa e Confirma foi extraído para spec dedicada → [`20260622-payment-review-confirm`](../../20260622-payment-review-confirm/)
+
+---
+
+## Bloqueadores
+
+| Bloqueador | Afeta | Status |
+|---|---|---|
+| Pixel perfect da tela de Installments (`feature/installments-flow`) | A4 — enum `Screen.kt` aguarda merge para `feature/cardpayment-q2` | ✅ Concluído |
+
+---
+
+## Tasks
+
+> **Regra**: toda tarefa deve incluir testes unitários com cobertura mínima de **80%**.
+
+| Task | Arquivo | Descrição | Branch | Status |
+|---|---|---|---|---|
+| A1 | `MPOrder.kt` | Adicionar `orderId: String` e `clientToken: String` | `feature/installments-flow` / `feature/cardpayment-q2` | ✅ Feito |
+| A2 | `MPPaymentData.kt` | Remover campos token-based de `MPPaymentData.Payment` (dívida técnica da branch atual: `transactionAmount`, `payer`, `installment`, `issuerId`) — target fixo: `orderId`, `orderStatus`, `paymentMethodId` e `paymentTypeId` para todos os meios de pagamento, incluindo meios offline (decisão DD-8: callback unificado, sem campos extras como `barcodeContent` ou `dateOfExpiration`) | `feature/cardpayment-q2` | 🔲 Pendente |
+| A3 | `MPUserCancelledContext.kt` | Migrar `Payment` de `object` para `data class(screens: List<Screen>)` | `feature/cardpayment-q2` | 🔲 Pendente |
+| A4 | `Screen.kt` | Adicionar `OFFLINE_METHOD_SELECTOR` e demais valores ao enum conforme telas implementadas | `feature/installments-flow` | ✅ Feito |
+| A5 | Novos modelos | Criar e mapear modelos do response `GET /initialization`: `PaymentBrickInitializationResponse`, `PaymentSection`, `PaymentMethod`, `CardData`, `SecurityCode`, `SecurityCodeScreen`, `Installments`, `Quota`, `TicketOption`, `PaymentBrickFooter` | `feature/cardpayment-q2` | 🔲 Pendente |
+| A6 | Camada de repositório `/initialization` | Criar toda a camada de data/domain para `GET /initialization` seguindo a estrutura do módulo `checkout`: `data/remote/datasource/PaymentBrickInitializationRemoteDataSource.kt` (interface + impl), `data/remote/mapper/PaymentBrickInitializationResponseMapper.kt`, `data/repository/PaymentBrickInitializationRepositoryImpl.kt`, `domain/repository/PaymentBrickInitializationRepository.kt` (interface), `domain/mapper/PaymentBrickInitializationMapper.kt` | `feature/cardpayment-q2` | 🔲 Pendente |
+
+| A7 | ViewModel + UseCase `/initialization` | Criar `domain/usecase/FetchPaymentBrickInitializationUseCase.kt` e injetá-lo em `PaymentBrickViewModel.kt` — ViewModel expõe `StateFlow<PaymentBrickScreenState>` com loading, sucesso (seções mapeadas) e erro | `feature/cardpayment-q2` | 🔲 Pendente |
+
+| A8 | Refinamento do layout da tela PaymentBrick | Refinar a `PaymentBrickScreen` com os dados reais vindos do response de `/initialization` via ViewModel — renderizar `sections[]`, `methods[]` com ícone, título e subtítulo, e `footer` com total. Garantir estados de loading e erro | `feature/cardpayment-q2` | 🔲 Pendente |
+
+| A9 | `processOrderUseCase` no ViewModel | Injetar `ProcessOrderUseCase` em `PaymentBrickViewModel` e realizar a chamada a `POST /process` ao confirmar o meio de pagamento — cobre **todos os meios**, incluindo cartão salvo, novo cartão e meios offline (ticket); para offline, o `card_token` é ausente. Mapear response para `MPPaymentData.Payment` e emitir resultado via callback (`onSuccess`, `onError`) | `feature/cardpayment-q2` | 🔲 Pendente |
+
+| A10 | Callback `onSuccess` | Após processamento bem-sucedido da Order, emitir `MercadoPagoCheckoutResult.Success(MPPaymentData.Payment)` para o seller via callback — garantir que o switch é exaustivo (sem `default`/`else`) e que `MPPaymentData.Payment` carrega `orderId`, `orderStatus`, `paymentMethodId` e `paymentTypeId` | `feature/cardpayment-q2` | 🔲 Pendente |
+
+| A11 | Callback `onUserCancelled` | Ao usuário sair do fluxo em qualquer tela, emitir `MercadoPagoCheckoutResult.UserCancelled(MPUserCancelledContext.Payment(screens))` — popular `screens: List<Screen>` com as telas percorridas antes do cancelamento | `feature/cardpayment-q2` | 🔲 Pendente |
+
+| A12 | Callback `onError` | Ao ocorrer erro crítico (5xx, Order inválida, pagamento rejeitado), emitir `MercadoPagoCheckoutResult.Error(MercadoPagoCheckoutError)` para o seller — sem retry automático | `feature/cardpayment-q2` | 🔲 Pendente |
+
+
+| A26 | Pixel Perfect — tela PaymentBrick | Revisão visual completa da tela seletora de meios com dados reais — validar espaçamentos, tipografia, ícones, footer e estados de loading/erro conforme especificação de design | `feature/cardpayment-q2` | 🔲 Pendente |
+
+---
+
+## Notas
+
+- **Cobertura de testes**: mínimo 80% de cobertura unitária em todas as tasks
+- **`cardIds`**: permanece em `MPCheckoutType.Payment` — necessário para o BFF buscar cartões salvos via Customers API
+- **Filtros excluídos** (`excludedTypes`, `excludedMethods`): configurados server-side via Order — SDK não os envia
+- **Tela de Revisa e Confirma**: tratada em spec separada
+- **`Screen` enum**: existe em `domain/model/Screen.kt` com `INSTALLMENTS`. Demais valores adicionados conforme cada tela for entregue
+- **Meios offline — callback unificado (DD-8)**: `MPPaymentData.Payment` devolve `orderId`, `orderStatus`, `paymentMethodId` e `paymentTypeId` para todos os meios, incluindo offline. Campos como `barcodeContent`, `dateOfExpiration`, `transactionAmount`, `payer`, `installment` e `issuerId` **não serão expostos** no SDK

--- a/meli/SMFINTECH-32897/features/001-selector-de-meios/3-tasks/bricks-api.md
+++ b/meli/SMFINTECH-32897/features/001-selector-de-meios/3-tasks/bricks-api.md
@@ -1,0 +1,458 @@
+# `fury_bricks-api` — Implementation Tasks: PaymentBrick Nativo (SMFINTECH-32897)
+
+**Jira**: [SMFINTECH-32897](https://mercadolibre.atlassian.net/browse/SMFINTECH-32897)
+**Status**: Partial — TASK 1.5 and TASK 6 are blocked (see Blockers section)
+**Specs**: [functional](../1-functional/spec.md) · [technical](../2-technical/spec.md)
+
+---
+
+## Blockers
+
+| Blocker | Needed by | Status |
+|---|---|---|
+| [`fury_bricks-api` PR #433](https://github.com/melisource/fury_bricks-api/pull/433) — `POST /orders/{order_id}/process` base implementation | TASK 1.5 must amend this PR before merge | Open |
+| [`fury_bricks-api` PR #448](https://github.com/melisource/fury_bricks-api/pull/448) — excluded filter + MLA accessibility label on `/card_payment_brick/card` | TASK 6 (`/payment_brick/card`) delegates to this service; must be merged first | Open |
+| `fury_bricks-api` release/1.47.2 — `Quota` struct with `primary_label`, `secondary_label`, `state`, `tertiary_label`, `accessibility_label` and builder logic | TASK 2 (`initializationservice`) needs the `installmentformat` shared package extracted from this release | Released |
+
+---
+
+## Endpoint Contracts
+
+### 1. `POST /cho-off/v1/orders/{order_id}/process` — MODIFIED (TASK 1.5)
+
+Amends PR #433 to support offline methods (ticket) and saved cards. The existing implementation treats `token` and `installments` as always-required, which breaks for offline payments.
+
+**Path param**: `order_id` (string, required)
+
+**Headers**: `X-Client-Id`, `X-Caller-Id`, `X-Caller-SiteID`, `X-Idempotency-Key`
+
+**Request — card payment (new card or saved card)**:
+```json
+{
+  "amount": "500.00",
+  "payment_method_id": "visa",
+  "payment_method_type": "credit_card",
+  "token": "677859ef5f18ea7e3a87c41d02c3fbe3",
+  "installments": 3
+}
+```
+
+**Request — offline payment (ticket)**:
+```json
+{
+  "amount": "500.00",
+  "payment_method_id": "rapipago",
+  "payment_method_type": "ticket",
+  "payer_email": "comprador@email.com"
+}
+```
+
+> `token` and `installments` are absent for ticket. `payer_email` is required for ticket, absent for cards.
+
+**Response — card approved** (HTTP 200):
+```json
+{
+  "id": "ORD01J6TC8BYRR0T4ZKY0QR39WGYE",
+  "status": "approved",
+  "status_detail": "accredited",
+  "total_amount": "500.00",
+  "transactions": {
+    "payments": [
+      {
+        "id": "PAY01J6TC8BYRR0T4ZKY0QRTZ0E24",
+        "amount": "500.00",
+        "status": "approved",
+        "status_detail": "accredited",
+        "payment_method": {
+          "id": "visa",
+          "type": "credit_card",
+          "installments": 3
+        }
+      }
+    ]
+  }
+}
+```
+
+**Response — offline pending** (HTTP 200):
+```json
+{
+  "id": "ORD01J6TC8BYRR0T4ZKY0QR39WGYE",
+  "status": "action_required",
+  "status_detail": "waiting_payment",
+  "total_amount": "500.00",
+  "transactions": {
+    "payments": [
+      {
+        "id": "PAY01J6TC8BYRR0T4ZKY0QRTZ0E24",
+        "amount": "500.00",
+        "status": "action_required",
+        "status_detail": "waiting_payment",
+        "expiration_time": "P1D",
+        "date_of_expiration": "2026-05-26T22:04:01.000-03:00",
+        "payment_method": {
+          "id": "rapipago",
+          "type": "ticket",
+          "barcode_content": "3335008800000000006004835002100020000242462010",
+          "ticket_url": "https://www.mercadopago.com.ar/payments/..."
+        }
+      }
+    ]
+  }
+}
+```
+
+**Error responses**:
+- `400` — missing required fields or invalid amount
+- `422` — amount mismatch with Order
+- `423` — Order locked (concurrent request)
+- `500` — internal error
+
+---
+
+### 2. `GET /cho-off/v1/payment_brick/initialization` — NEW (TASK 2 + TASK 3)
+
+Returns all data needed for the SDK to render the payment method selector screen.
+
+**Headers**: `X-Caller-SiteID`
+
+**Query params**:
+
+| Param | Required | Description |
+|---|---|---|
+| `public_key` | Yes | Seller public key |
+| `order_id` | Yes | Order ID created server-side by the seller |
+| `customer_id` | No | Buyer customer ID (enables saved cards section) |
+| `cards_ids` | No | Comma-separated card IDs (used with `customer_id`) |
+| `excluded_methods` | No | Comma-separated payment method IDs to exclude (e.g. `visa,master`) |
+| `excluded_types` | No | Comma-separated payment types to exclude (e.g. `ticket,debit_card`) |
+| `excluded_tickets` | No | Comma-separated offline methods to exclude (e.g. `rapipago`) |
+| `min_installments` | No | Minimum number of installments to include in quotas (inclusive) |
+| `max_installments` | No | Maximum number of installments to include in quotas (inclusive) |
+
+**Response** (HTTP 200):
+```json
+{
+  "header_title": "Elegí cómo pagar",
+  "sections": [
+    {
+      "title": "Otros medios de pago",
+      "methods": [
+        {
+          "type": "saved_card",
+          "title": "Visa **** 1234",
+          "subtitle": "Visa · Crédito",
+          "icon_url": "https://http2.mlstatic.com/storage/mobile-on-demand-resources/image/cho_off-visa_mdpi",
+          "card_data": {
+            "id": "123456789",
+            "bin": "503143",
+            "last_four_digits": "1234",
+            "payment_method_id": "visa",
+            "payment_type_id": "credit_card",
+            "issuer_id": 1,
+            "security_code": {
+              "length": 3,
+              "screen": {
+                "header_title": "Ingresá el código de seguridad",
+                "field": {
+                  "label": "Código de seguridad",
+                  "placeholder": "Ej.: ***",
+                  "helper": "Está en el reverso de tu tarjeta."
+                },
+                "continue_button_label": "Continuar"
+              }
+            },
+            "installments": {
+              "selection_type": "radio_button",
+              "quotas": [
+                {
+                  "installments": 1,
+                  "installment_amount": 500.00,
+                  "total_amount": 500.00,
+                  "primary_label": "1x $ 500,00",
+                  "secondary_label": "",
+                  "state": "none",
+                  "accessibility_label": "1 cuota de 500,00 pesos, sin interés"
+                },
+                {
+                  "installments": 3,
+                  "installment_amount": 170.00,
+                  "total_amount": 510.00,
+                  "primary_label": "3x $ 170,00",
+                  "secondary_label": "Sin interés",
+                  "state": "success",
+                  "accessibility_label": "3 cuotas de 170,00 pesos, sin interés"
+                },
+                {
+                  "installments": 6,
+                  "installment_amount": 95.00,
+                  "total_amount": 570.00,
+                  "primary_label": "6x $ 95,00",
+                  "secondary_label": "$ 570,00",
+                  "state": "none",
+                  "accessibility_label": "6 cuotas de 95,00 pesos"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type": "saved_card",
+          "title": "Master **** 5678",
+          "subtitle": "Mastercard · Débito",
+          "icon_url": "https://http2.mlstatic.com/storage/mobile-on-demand-resources/image/cho_off-master_mdpi",
+          "card_data": {
+            "id": "987654321",
+            "bin": "516105",
+            "last_four_digits": "5678",
+            "payment_method_id": "master",
+            "payment_type_id": "debit_card",
+            "issuer_id": 2,
+            "security_code": {
+              "length": 3
+            }
+          }
+        },
+        {
+          "type": "ticket",
+          "title": "Efectivo",
+          "subtitle": "Pago Fácil y Rapipago",
+          "options": [
+            {
+              "id": "pagofacil",
+              "name": "Pago Fácil",
+              "icon_url": "https://http2.mlstatic.com/storage/mobile-on-demand-resources/image/cho_off-pagofacil_mdpi"
+            },
+            {
+              "id": "rapipago",
+              "name": "Rapipago",
+              "icon_url": "https://http2.mlstatic.com/storage/mobile-on-demand-resources/image/cho_off-rapipago_mdpi"
+            }
+          ]
+        },
+        {
+          "type": "new_card",
+          "title": "Nueva tarjeta",
+          "subtitle": "Crédito y débito",
+          "icon_url": "https://http2.mlstatic.com/storage/mobile-on-demand-resources/image/cho_off-new_card_mdpi"
+        }
+      ]
+    }
+  ],
+  "footer": {
+    "total_label": "Total",
+    "total_amount": "$ 500,00"
+  },
+  "translations": {
+    "installments": {
+      "header": {
+        "chevron": "Elegí las cuotas",
+        "radio": "Elegí las cuotas",
+        "title": "Elegí las cuotas"
+      },
+      "interest_free_label": "Sin interés",
+      "total_label": "Total"
+    }
+  }
+}
+```
+
+**Notes**:
+- Second saved card (debit, `has_preapproval_scope=true`): `security_code` has no `screen` field → SDK skips CVV; no `installments` field (debit)
+- Offline section only present when `order.site_id == "MLA"` (hardcoded Q2.26)
+- `footer.total_amount` is `order.total_amount` passed through from Order API
+- BFF merges `order.config.payment_method.not_allowed_ids` with `excluded_methods` query param
+- `min_installments` / `max_installments` filter the `quotas` array for every saved card: only quotas where `installments >= min_installments` and `installments <= max_installments` are returned. `order.config.payment_method.max_installments` is applied first (server-side cap), then the query-param range is applied on top
+
+**Error responses**:
+- `400` — missing `public_key` or `order_id`
+- `404` — Order not found
+- `500` — internal error
+
+---
+
+### 3. `GET /cho-off/v1/payment_brick/review_confirm` — NEW (TASK 4 + TASK 5)
+
+Returns labels for the "Revisá y Confirmá" screen. Pure BFF logic — no external API calls.
+
+**Query params**:
+
+| Param | Required | Values |
+|---|---|---|
+| `public_key` | Yes | |
+| `order_id` | Yes | |
+| `payment_method_type` | Yes | `saved_card` \| `new_card` \| `ticket` \| `wallet` \| `credits` |
+
+**Response — `payment_method_type=ticket`** (HTTP 200):
+```json
+{
+  "header_title": "Revisá los datos antes de crear la factura",
+  "confirm_button_label": "Crear factura",
+  "change_payment_method_label": "Cambiar medio de pago",
+  "items": [
+    {
+      "type": "payment_method",
+      "label": "Medio de pago"
+    },
+    {
+      "type": "payer_email",
+      "label": "Email",
+      "placeholder": "Ej.: usuario@email.com",
+      "is_editable": true
+    }
+  ]
+}
+```
+
+**Response — `payment_method_type=saved_card` / `new_card` / `wallet` / `credits`** (HTTP 200):
+```json
+{
+  "header_title": "Revisá los datos antes de pagar",
+  "confirm_button_label": "Pagar",
+  "change_payment_method_label": "Cambiar medio de pago",
+  "items": [
+    {
+      "type": "payment_method",
+      "label": "Medio de pago"
+    }
+  ]
+}
+```
+
+**Error responses**:
+- `400` — missing required params or unknown `payment_method_type`
+
+---
+
+### 4. `GET /cho-off/v1/payment_brick/card` — NEW (TASK 6) 🔴 Blocked on PR #448
+
+Returns card form configuration when the buyer selects "Nueva tarjeta". Delegates to the existing `cardpaymentbrickservice.CardDataService` after resolving `amount` and payment restrictions from the Order.
+
+**Headers**: `X-Public-Key` (required)
+
+**Query params**:
+
+| Param | Required | Description |
+|---|---|---|
+| `order_id` | Yes | Replaces `amount` — BFF reads amount from Order API |
+| `bin` | Yes | First 6–8 digits of the card entered by the buyer |
+| `product_id` | Yes | Caller product ID |
+
+> `amount`, `excluded_payment_methods`, `excluded_payment_types`, and `processing_mode` are all resolved server-side from the Order. The SDK does not send them.
+
+**Response** (HTTP 200) — same shape as `GET /cho-off/v1/card_payment_brick/card`:
+```json
+{
+  "translations": {
+    "card_form_title": "Ingresá tu tarjeta",
+    "card_form_footer_button_label": "Pagar",
+    "card_number": {
+      "label": "Número de tarjeta",
+      "placeholder": "1234 1234 1234 1234",
+      "error_empty_field": "Completá este campo.",
+      "error_incomplete_field": "Ingresá el número completo.",
+      "error_invalid_field": "Ingresalo como figura en la tarjeta."
+    },
+    "security_code": {
+      "label": "Código de seguridad",
+      "placeholder": "Ej.: ***",
+      "tooltip": "Es un número de 3 dígitos que está en el reverso de tu tarjeta.",
+      "error_empty_field": "Completá este campo.",
+      "error_incomplete_field": "Ingresá el código completo."
+    },
+    "expiration_date": {
+      "label": "Fecha de vencimiento",
+      "placeholder": "MM/AA",
+      "error_empty_field": "Completá este campo.",
+      "error_incomplete_field": "Ingresá la fecha completa.",
+      "error_invalid_field": "Ingresá una fecha válida."
+    },
+    "holder_name": {
+      "label": "Titular de tarjeta",
+      "placeholder": "Ej.: Maria Lopez",
+      "helper": "Como aparece en la tarjeta"
+    },
+    "installments": {
+      "header": {
+        "chevron": "Elegí las cuotas",
+        "radio": "Elegí las cuotas",
+        "title": "Elegí las cuotas"
+      },
+      "interest_free_label": "Sin interés",
+      "total_label": "Total"
+    }
+  },
+  "installment": {
+    "selection_type": "radio_button",
+    "quotas": [
+      {
+        "installments": 1,
+        "installment_amount": 500.00,
+        "total_amount": 500.00,
+        "primary_label": "1x $ 500,00",
+        "secondary_label": "",
+        "state": "none",
+        "accessibility_label": "1 cuota de $ 500,00. Total $ 500,00. Costo financiero total 0,00%. Tasa Efectiva Anual 0,00%."
+      },
+      {
+        "installments": 3,
+        "installment_amount": 170.00,
+        "total_amount": 510.00,
+        "primary_label": "3x $ 170,00",
+        "secondary_label": "Sin interés",
+        "state": "success",
+        "accessibility_label": "3 cuotas de $ 170,00. Total $ 510,00. Costo financiero total 0,00%. Tasa Efectiva Anual 0,00%."
+      }
+    ]
+  },
+  "payment_methods": [
+    {
+      "id": "visa",
+      "payment_type_id": "credit_card",
+      "card_number": {
+        "type": "Number",
+        "length": { "min": 16, "max": 16 },
+        "mask": "#### #### #### ####"
+      },
+      "security_code": {
+        "mode": "mandatory",
+        "length": 3,
+        "type": "Number",
+        "tooltip": "Es un número de 3 dígitos que está en el reverso de tu tarjeta.",
+        "placeholder": "Ej.: ***"
+      },
+      "issuers": [
+        { "id": "1", "name": "Visa" }
+      ]
+    }
+  ]
+}
+```
+
+**Notes**:
+- MLA accessibility label uses PR #448 format: `"{N} cuota(s) de $ {amount}. Total $ {total}. Costo financiero total X%. Tasa Efectiva Anual Y%."`
+- `order.config.payment_method.not_allowed_ids` forwarded as `excluded_payment_methods` to the delegate service
+- `order.config.payment_method.max_installments` caps quotas in post-processing
+
+**Error responses**:
+- `400` — missing `X-Public-Key`, `order_id`, or `bin`; access token used as public key
+- `404` — Order not found or payment method not found for BIN
+- `500` — internal error
+
+---
+
+## Task Summary
+
+| Task | Description | Status |
+|---|---|---|
+| TASK 1 | Extend `orders.Order` domain model (`processing_mode`, `site_id`, `config`) | Ready to implement |
+| TASK 1.5 | Update `POST /process` for offline (ticket) + saved cards — amends PR #433 | Ready to implement |
+| TASK 2 | `initializationservice` — orchestrates Order API, Customers API, Installments API; applies `min_installments`/`max_installments` filter on quotas | Ready to implement |
+| TASK 3 | Handler `GET /payment_brick/initialization` | Ready to implement |
+| TASK 4 | `reviewconfirmservice` — pure BFF labels by payment type | Ready to implement |
+| TASK 5 | Handler `GET /payment_brick/review_confirm` | Ready to implement |
+| TASK 6 | `paymentbrickcarddataservice` + Handler `GET /payment_brick/card` | 🔴 Blocked on PR #448 |
+| TASK 7 | App wiring (`app.go`, `routes.go`, `config.go`) | ✅ Done (PR #469) |
+| TASK 8 | Bruno docs + Swagger | Ready to implement |
+
+Full implementation details: [bricks-api.md](./bricks-api.md)

--- a/meli/SMFINTECH-32897/features/001-selector-de-meios/3-tasks/ios.md
+++ b/meli/SMFINTECH-32897/features/001-selector-de-meios/3-tasks/ios.md
@@ -1,0 +1,63 @@
+# SDK iOS — Implementation Tasks: PaymentBrick (SMFINTECH-32897)
+
+**Jira**: [SMFINTECH-32897](https://mercadolibre.atlassian.net/browse/SMFINTECH-32897)
+**Repositório**: [`fury_openplatform-sdk-ios`](https://github.com/melisource/fury_openplatform-sdk-ios)
+**Branch principal**: `feature/cardpayment-q2`
+**Specs**: [functional](../1-functional/spec.md) · [technical](../2-technical/spec.md) · [BFF tasks](./bricks-api.md)
+
+> **Payment Flows**: As tasks I17–I25 e I27–I28 (fluxos de pagamento) foram extraídas para spec dedicada → [`003-payment-flows/3-tasks/ios.md`](../003-payment-flows/3-tasks/ios.md)
+
+> **CVV Screen**: As tasks I13–I16 (tela de CVV) foram extraídas para spec dedicada → [`002-cvv-screen/3-tasks/ios.md`](../002-cvv-screen/3-tasks/ios.md)
+
+> **Revisa e Confirma**: Tudo relacionado à tela de Revisa e Confirma foi extraído para spec dedicada → [`20260622-payment-review-confirm`](../../20260622-payment-review-confirm/)
+
+---
+
+## Bloqueadores
+
+| Bloqueador | Afeta | Status |
+|---|---|---|
+| Pixel perfect da tela de Installments (`feature/checkout/card_payment_installments`) | I1 aguarda merge para `feature/cardpayment-q2` | ✅ Concluído |
+
+---
+
+## Tasks
+
+> **Regra**: toda tarefa deve incluir testes unitários com cobertura mínima de **80%**.
+
+| Task | Arquivo | Descrição | Branch | Status |
+|---|---|---|---|---|
+| I1 | `MPOrder.swift` | Adicionar `orderId: String` | `feature/checkout/card_payment_installments` | ✅ Feito |
+| I2 | `MercadoPagoCheckout+CheckoutType.swift` | Adicionar caso `payment(order:)` entregando `MPPaymentData.Payment` | `feature/cardpayment-q2` | 🔲 Pendente |
+| I3 | `MPPaymentData.swift` | Adicionar variant `Payment` com campos Order-based: `orderId`, `orderStatus`, `paymentMethodId` e `paymentTypeId` — contrato unificado para todos os meios, incluindo offline (decisão DD-8) | `feature/cardpayment-q2` | 🔲 Pendente |
+| I4 | `MPUserCancelledContext.swift` | Adicionar `Payment` com `screens: List<Screen>` | `feature/cardpayment-q2` | 🔲 Pendente |
+| I5 | Novos modelos | Criar e mapear modelos do response `GET /initialization`: `PaymentBrickInitializationResponse`, `PaymentSection`, `PaymentMethod`, `CardData`, `SecurityCode`, `SecurityCodeScreen`, `Installments`, `Quota`, `TicketOption`, `PaymentBrickFooter` | `feature/cardpayment-q2` | 🔲 Pendente |
+| I6 | Camada de repositório `/initialization` | Criar toda a camada de data para `GET /initialization` seguindo a estrutura do módulo `MercadoPagoCheckout`: `Data/Network/PaymentBrickInitializationEndpoint.swift`, `Data/Repositories/RemotePaymentBrickInitializationRepository.swift`, `Domain/Repositories/PaymentBrickInitializationRepository.swift` (protocol) | `feature/cardpayment-q2` | 🔲 Pendente |
+
+| I7 | ViewModel + UseCase `/initialization` | Criar `Domain/UseCases/FetchPaymentBrickInitializationUseCase.swift` e injetá-lo em `PaymentBrickViewModel.swift` — ViewModel expõe `@Published` state com loading, sucesso (seções mapeadas) e erro | `feature/cardpayment-q2` | 🔲 Pendente |
+
+| I8 | Refinamento do layout da tela PaymentBrick | Refinar a `PaymentBrickScreen` com os dados reais vindos do response de `/initialization` via ViewModel — renderizar `sections[]`, `methods[]` com ícone, título e subtítulo, e `footer` com total. Garantir estados de loading e erro | `feature/cardpayment-q2` | 🔲 Pendente |
+
+| I9 | `processOrderUseCase` no ViewModel | Injetar `ProcessOrderUseCase` em `PaymentBrickViewModel` e realizar a chamada a `POST /process` ao confirmar o meio de pagamento — mapear response para `MPPaymentData.Payment` e emitir resultado via callback (`onSuccess`, `onError`) | `feature/cardpayment-q2` | 🔲 Pendente |
+
+| I10 | Callback `onSuccess` | Após processamento bem-sucedido da Order, emitir `MercadoPagoCheckoutResult.Success(MPPaymentData.Payment)` para o seller via callback — garantir que o switch é exaustivo (sem `default`/`else`) e que `MPPaymentData.Payment` carrega `orderId`, `orderStatus`, `paymentMethodId` e `paymentTypeId` | `feature/cardpayment-q2` | 🔲 Pendente |
+
+| I11 | Callback `onUserCancelled` | Ao usuário sair do fluxo em qualquer tela, emitir `MercadoPagoCheckoutResult.UserCancelled(MPUserCancelledContext.Payment(screens))` — popular `screens: List<Screen>` com as telas percorridas antes do cancelamento | `feature/cardpayment-q2` | 🔲 Pendente |
+
+| I12 | Callback `onError` | Ao ocorrer erro crítico (5xx, Order inválida, pagamento rejeitado), emitir `MercadoPagoCheckoutResult.Error(MercadoPagoCheckoutError)` para o seller — sem retry automático | `feature/cardpayment-q2` | 🔲 Pendente |
+
+
+| I26 | Pixel Perfect — tela PaymentBrick | Revisão visual completa da tela seletora de meios com dados reais — validar espaçamentos, tipografia, ícones, footer e estados de loading/erro conforme especificação de design | `feature/cardpayment-q2` | 🔲 Pendente |
+| I29 | Implementar caso `payment` no builder `MPCheckoutType` | Adicionar `clientToken: String` a `MPOrder.swift` e implementar o caso `payment(order: MPOrder, cardIds: [String]?)` em `MercadoPagoCheckout+CheckoutType.swift`, entregando `MPPaymentData.Payment` — alinhado ao contrato Android; `orderId` e `clientToken` são passados via `MPOrder`; `cardIds` permanece no SDK para o BFF buscar cartões salvos via Customers API | `feature/cardpayment-q2` | 🔲 Pendente |
+
+
+---
+
+## Notas
+
+- **Cobertura de testes**: mínimo 80% de cobertura unitária em todas as tasks
+- **`cardIds`**: permanece em `MPCheckoutType.Payment` — necessário para o BFF buscar cartões salvos via Customers API
+- **Filtros excluídos** (`excludedTypes`, `excludedMethods`): configurados server-side via Order — SDK não os envia
+- **Tela de Revisa e Confirma**: tratada em spec separada
+- **`Screen` enum**: a criar em Swift alinhado ao Android (`INSTALLMENTS` + demais conforme entrega)
+- **Tracks Melidata**: cobertos pela task **A29** no spec Android — task única para análise e implementação nas duas plataformas

--- a/meli/SMFINTECH-32897/features/001-selector-de-meios/README.md
+++ b/meli/SMFINTECH-32897/features/001-selector-de-meios/README.md
@@ -1,0 +1,52 @@
+# PaymentBrick Nativo — Selector de Meios
+
+**Feature**: `001-selector-de-meios`
+**Jira**: [SMFINTECH-32897](https://mercadolibre.atlassian.net/browse/SMFINTECH-32897)
+**Owner**: Danielle Ogawa / William Santos (Core Frontend)
+**Quarter**: 2026-Q2
+**Site**: MLA (Argentina)
+
+---
+
+## O que foi especificado
+
+SDK de checkout nativo (Android + iOS) com tela de seleção de meios de pagamento integrada à Order API no modelo Order Builder Mode.
+
+- **Seller** cria a Order com `payment_settings` no backend
+- **SDK** recebe `orderId` + `clientToken` e renderiza a tela seletora via BFF
+- **BFF** (`fury_bricks-api`) processa o pagamento — `card_token` nunca exposto ao seller
+- **Seller** recebe o resultado via callback (`onSuccess` / `onError` / `onUserCancelled`)
+
+## Escopo Q2.26
+
+| Entregável | Plataformas |
+|---|---|
+| Tela seletora de meios (cartões salvos, novo cartão, offline) | Android + iOS |
+| Fluxo de CVV | Android + iOS (spec separada: `002-cvv-screen`) |
+| Fluxos de pagamento (novo cartão, cartão salvo, offline) | Android + iOS (spec separada: `003-payment-flows`) |
+| Tela de Revisa e Confirma | Android + iOS (spec separada: `20260622-payment-review-confirm`) |
+| BFF endpoints `/cho-off/v1/*` | `fury_bricks-api` (Go) |
+
+## Repositórios de implementação
+
+| Repositório | Linguagem | Papel |
+|---|---|---|
+| `fury_openplatform-sdk-android` | Kotlin | SDK Android — módulo `mercadopagocheckout` |
+| `fury_openplatform-sdk-ios` | Swift | SDK iOS — módulo `mercadopagocheckout` |
+| `fury_bricks-api` | Go | BFF — endpoints `cho-off/v1/*` |
+
+## Specs
+
+- [Functional Spec](1-functional/spec.md)
+- [Technical Spec](2-technical/spec.md)
+- [Tasks Android](3-tasks/android.md)
+- [Tasks iOS](3-tasks/ios.md)
+- [Tasks BFF](3-tasks/bricks-api.md)
+
+## Decisões arquiteturais chave
+
+- **Order Builder Mode**: configurações sensíveis (`amount`, `customerId`, `cardIds`, filtros) nunca passam pelo SDK — resolvidos via Order API no BFF
+- **iOS**: `MPOrder` tem shape final `orderId` + `clientToken` (endgame antecipado)
+- **Android**: `MPOrder` com `orderId`, `clientToken`, `amount`, `payer` — remoção de `amount`/`payer` planejada
+- **Callbacks type-safe**: generics garantem que o tipo de `MPPaymentData` é inferido do `CheckoutType`
+- **Sem retry no `/process`**: evita duplo processamento da Order

--- a/meli/SMFINTECH-32897/features/001-selector-de-meios/implementation-summary.md
+++ b/meli/SMFINTECH-32897/features/001-selector-de-meios/implementation-summary.md
@@ -1,0 +1,40 @@
+# Implementation Summary — 001-selector-de-meios
+
+**Arquivado em**: 2026-07-07
+**Status final**: Specs aprovadas — implementação em andamento nos repositórios de código
+
+---
+
+## Timeline de especificação
+
+| Fase | Data | Responsável |
+|---|---|---|
+| Functional spec iniciada | 2026-04-12 | Danielle Ogawa |
+| Functional spec aprovada | 2026-05-22 | Danielle Ogawa |
+| Technical spec aprovada | 2026-05-25 | Danielle Ogawa |
+| Spec iterada (alinhamento com código) | 2026-07-07 | Danielle Ogawa |
+
+## Iterações da spec técnica
+
+- **Iteração 1** (2026-07-07): alinhamento com estado atual dos SDKs
+  - Android: `MPCheckoutType.Payment` removeu `cardIds`; tipo param atualizado para `MPUserCancelledContext.Payment`
+  - Android: `MPUserCancelledContext.CardTransaction` ganhou campo `screens`; `Screen` enum com 3 novos valores
+  - iOS: `CheckoutType.payment` implementado; `MPOrder` com shape final `orderId` + `clientToken`
+  - Decisão resolvida: `customerId` e `cardIds` também server-side
+
+## Specs derivadas (extraídas desta)
+
+| Feature | Conteúdo |
+|---|---|
+| `002-cvv-screen` | Tela de CVV — spec funcional e técnica dedicada |
+| `003-payment-flows` | Fluxos de pagamento (novo cartão, cartão salvo, offline) |
+| `20260622-payment-review-confirm` | Tela de Revisa e Confirma |
+
+## Pendências de implementação conhecidas
+
+| Item | Plataforma | Status |
+|---|---|---|
+| `MPPaymentData.Payment` | iOS | Pendente |
+| `MPUserCancelledContext.payment` | iOS | Pendente |
+| `Screen.CVV` no enum | Android | Pendente |
+| Remoção de `amount`/`payer` do `MPOrder` | Android | Planejado |

--- a/meli/SMFINTECH-32897/features/001-selector-de-meios/meta.md
+++ b/meli/SMFINTECH-32897/features/001-selector-de-meios/meta.md
@@ -1,0 +1,73 @@
+# Feature Metadata
+
+**Feature Name**: selector-de-meios
+**Feature Number**: 001
+**Feature ID**: feat-001
+**Mode**: greenfield
+**Project Type**: production
+**User Profile**: technical
+**Created**: 2026-04-12
+**Last Updated**: 2026-04-12
+**Current Stage**: finished
+
+---
+
+## Context
+
+```yaml
+context:
+  repository_type: specs-only
+  initiative: SMFINTECH-32897
+  quarter: 2026-Q2
+  description: "Selector de Meios - componente nativo para selecao de meios de pagamento"
+  branch: enhancement/selector-de-meios
+  note: "Repositorio de specs funcionais apenas."
+```
+
+---
+
+## Team
+
+**Owner**: William Santos
+**Team Members**: Core Frontend
+
+---
+
+## Stage History
+
+```yaml
+stages:
+  functional:
+    started: 2026-04-12
+    completed: 2026-05-22
+    status: approved
+    owner: Danielle Nozaki Ogawa
+    approved_by: Danielle Nozaki Ogawa
+    approved_at: 2026-05-22T15:12:22Z
+    iterations: 1
+
+  technical:
+    started: 2026-05-22
+    completed: 2026-05-25
+    status: approved
+    owner: Danielle Nozaki Ogawa
+    approved_by: Danielle Nozaki Ogawa
+    approved_at: 2026-05-25T14:38:33Z
+    iterations: 1
+
+  tasks:
+    started: null
+    completed: null
+    status: pending
+
+  implementation:
+    started: null
+    completed: null
+    status: pending
+```
+
+---
+
+## Notes
+
+- Componente nativo chamado Selector de Meios


### PR DESCRIPTION
## Summary

- Adiciona specs funcionais e técnicas do PaymentBrick Nativo — Selector de Meios
- Origem: [core-frontend-specs #36](https://github.com/melisource/fury_core-frontend-specs/pull/36)

## Conteúdo

```
meli/SMFINTECH-32897/features/001-selector-de-meios/
├── 1-functional/spec.md
├── 2-technical/spec.md
├── 3-tasks/ios.md
├── 3-tasks/android.md
├── 3-tasks/bricks-api.md
├── README.md
└── implementation-summary.md
```

## Jira

[SMFINTECH-32897](https://mercadolibre.atlassian.net/browse/SMFINTECH-32897)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[SMFINTECH-32897]: https://mercadolibre.atlassian.net/browse/SMFINTECH-32897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ