### PR TITLE
(Chore): Exclude meli/ folder from public mirror

### DIFF
--- a/.mirrorignore
+++ b/.mirrorignore
@@ -9,3 +9,4 @@ Example/Example.xcodeproj/project.pbxproj.rej
 
 Example/Sources/MainListView.swift
 .claude/
+meli/


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
N/A

## Description
- Added `meli/` to `.mirrorignore` to prevent the local SDD workflow folder from being mirrored to the public repository
- The previous entry `.meli` only excluded a hidden file with that exact name, not the `meli/` directory

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `swiftlint` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.