### PR TITLE
refactor: rename CardFormOutput to CardFormSubmitResult

### DIFF
--- a/Sources/MercadoPagoCheckout/Domain/Model/CardFormSubmitResult.swift
+++ b/Sources/MercadoPagoCheckout/Domain/Model/CardFormSubmitResult.swift
@@ -1,11 +1,11 @@
 //
-//  CardFormOutput.swift
+//  CardFormSubmitResult.swift
 //  MercadoPagoSDK
 //
-//  Created by Guilherme Prata Costa on 29/05/26.
+//  Created by Guilherme Prata Costa on 21/07/26.
 //
 
-struct CardFormOutput: Sendable {
+struct CardFormSubmitResult: Sendable {
     let token: String
     let paymentMethodId: String
     let paymentTypeId: String

--- a/Sources/MercadoPagoCheckout/Presentation/Bricks/CardForm/CardFormBrickViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Presentation/Bricks/CardForm/CardFormBrickViewModel.swift
@@ -173,7 +173,7 @@ final class CardFormBrickViewModel<T: MPPaymentData.Kind>: ObservableObject {
 
     // MARK: - Payment Data Mapping
 
-    func buildPaymentData(from output: CardFormOutput) -> T? {
+    func buildPaymentData(from output: CardFormSubmitResult) -> T? {
         let payer = output.payer.map {
             MPPaymentData.Payer(documentType: $0.documentType, documentNumber: $0.documentNumber)
         }

--- a/Sources/MercadoPagoCheckout/Presentation/Screens/CardForm/CardFormScreen.swift
+++ b/Sources/MercadoPagoCheckout/Presentation/Screens/CardForm/CardFormScreen.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct CardFormScreen: View {
     private let onBack: (MPCardFormUserCancelledContext) -> Void
     private let onDismiss: (MPCardFormUserCancelledContext) -> Void
-    private let onSuccess: (CardFormOutput) -> Void
+    private let onSuccess: (CardFormSubmitResult) -> Void
     private let onFailure: (MercadoPagoCheckoutError) -> Void
 
     @ObservedObject private var viewModel: CardFormViewModel
@@ -35,7 +35,7 @@ struct CardFormScreen: View {
         viewModel: CardFormViewModel,
         onBack: @escaping (MPCardFormUserCancelledContext) -> Void = { _ in },
         onDismiss: @escaping (MPCardFormUserCancelledContext) -> Void = { _ in },
-        onSuccess: @escaping (CardFormOutput) -> Void = { _ in },
+        onSuccess: @escaping (CardFormSubmitResult) -> Void = { _ in },
         onFailure: @escaping (MercadoPagoCheckoutError) -> Void = { _ in }
     ) {
         self.onBack = onBack

--- a/Sources/MercadoPagoCheckout/Presentation/Screens/CardForm/CardFormViewModel.swift
+++ b/Sources/MercadoPagoCheckout/Presentation/Screens/CardForm/CardFormViewModel.swift
@@ -276,12 +276,12 @@ final class CardFormViewModel: ObservableObject {
         )
     }
 
-    // MARK: - Card Form Output
+    // MARK: - Card Form Submit Result
 
-    private func buildCardFormOutput(
+    private func buildCardFormSubmitResult(
         cardToken: CardToken,
         cardFormData: CardFormData
-    ) throws(MercadoPagoCheckoutError) -> CardFormOutput {
+    ) throws(MercadoPagoCheckoutError) -> CardFormSubmitResult {
         guard let paymentMethod = cardData?.paymentMethods.first else {
             throw MercadoPagoCheckoutError(
                 code: .unknown,
@@ -290,13 +290,13 @@ final class CardFormViewModel: ObservableObject {
             )
         }
 
-        let payer: CardFormOutput.Payer? = {
+        let payer: CardFormSubmitResult.Payer? = {
             guard let selectTypeDocument else { return nil }
             let docNumber = cardFormData.documentHolder.filter { $0.isLetter || $0.isNumber }
             return .init(documentType: selectTypeDocument.id, documentNumber: docNumber)
         }()
 
-        return CardFormOutput(
+        return CardFormSubmitResult(
             token: cardToken.token,
             paymentMethodId: paymentMethod.id,
             paymentTypeId: paymentMethod.paymentTypeId,
@@ -323,7 +323,7 @@ final class CardFormViewModel: ObservableObject {
 
     func submitCardData(
         cardForm: CardFormData,
-        onSuccess: (CardFormOutput) -> Void,
+        onSuccess: (CardFormSubmitResult) -> Void,
         onFailure: (MercadoPagoCheckoutError) -> Void
     ) async {
         self.isTokenizing = true
@@ -331,7 +331,7 @@ final class CardFormViewModel: ObservableObject {
 
         do {
             let cardToken = try await self.createCardToken(cardForm: cardForm)
-            let output = try self.buildCardFormOutput(cardToken: cardToken, cardFormData: cardForm)
+            let output = try self.buildCardFormSubmitResult(cardToken: cardToken, cardFormData: cardForm)
             self.trackSubmit(
                 paymentMethodId: output.paymentMethodId,
                 paymentTypeId: output.paymentTypeId,

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormBrickViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormBrickViewModelTests.swift
@@ -113,7 +113,7 @@ final class CardFormBrickViewModelTests: XCTestCase {
             configuration: configuration,
             initializeUseCase: InitializeCardFormUseCase(repository: MockCardFormInitializationRepository())
         )
-        let output = CardFormOutput(
+        let output = CardFormSubmitResult(
             token: "token",
             paymentMethodId: "visa",
             paymentTypeId: "credit_card",
@@ -144,7 +144,7 @@ final class CardFormBrickViewModelTests: XCTestCase {
             configuration: configuration,
             initializeUseCase: InitializeCardFormUseCase(repository: repository)
         )
-        let output = CardFormOutput(
+        let output = CardFormSubmitResult(
             token: "token",
             paymentMethodId: "visa",
             paymentTypeId: "credit_card",

--- a/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
+++ b/Tests/MercadoPagoCheckoutTests/ViewModels/CardFormViewModelTests.swift
@@ -760,7 +760,7 @@ final class CardFormViewModelTests: XCTestCase {
         let sut = self.makeSUT()
         await self.setupCardData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
-        var capturedOutput: CardFormOutput?
+        var capturedOutput: CardFormSubmitResult?
 
         // Act
         await sut.viewModel.submitCardData(
@@ -778,7 +778,7 @@ final class CardFormViewModelTests: XCTestCase {
         let sut = self.makeSUTWithAmount(100.0)
         await self.setupCardData(sut)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
-        var capturedOutput: CardFormOutput?
+        var capturedOutput: CardFormSubmitResult?
 
         // Act
         await sut.viewModel.submitCardData(
@@ -931,7 +931,7 @@ final class CardFormViewModelTests: XCTestCase {
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
         var cardForm = CardFormDataStub.validForm
         cardForm.documentHolder = "12345678900"
-        var capturedOutput: CardFormOutput?
+        var capturedOutput: CardFormSubmitResult?
 
         // Act
         await sut.viewModel.submitCardData(
@@ -952,7 +952,7 @@ final class CardFormViewModelTests: XCTestCase {
         sut.viewModel.onCardNumberChange("12345678")
         await self.waitForChange(sut.viewModel.$cardData)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
-        var capturedOutput: CardFormOutput?
+        var capturedOutput: CardFormSubmitResult?
 
         // Act
         await sut.viewModel.submitCardData(
@@ -973,7 +973,7 @@ final class CardFormViewModelTests: XCTestCase {
         sut.viewModel.onCardNumberChange("12345678")
         await self.waitForChange(sut.viewModel.$cardData)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
-        var capturedOutput: CardFormOutput?
+        var capturedOutput: CardFormSubmitResult?
 
         // Act
         await sut.viewModel.submitCardData(
@@ -993,7 +993,7 @@ final class CardFormViewModelTests: XCTestCase {
         sut.viewModel.onCardNumberChange("12345678")
         await self.waitForChange(sut.viewModel.$cardData)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
-        var capturedOutput: CardFormOutput?
+        var capturedOutput: CardFormSubmitResult?
 
         // Act
         await sut.viewModel.submitCardData(
@@ -1015,7 +1015,7 @@ final class CardFormViewModelTests: XCTestCase {
         sut.viewModel.onCardNumberChange("12345678")
         await self.waitForChange(sut.viewModel.$cardData)
         await sut.service.setCreateCardTokenResult(.success(CardTokenStub.valid))
-        var capturedOutput: CardFormOutput?
+        var capturedOutput: CardFormSubmitResult?
 
         // Act
         await sut.viewModel.submitCardData(


### PR DESCRIPTION
## Summary
- Renames `CardFormOutput` to `CardFormSubmitResult` in the `MercadoPagoCheckout` module's Domain layer, since the type represents the result of a card form submission (tokenized card + payment method/payer data), not backend-driven initialization data — avoiding confusion with the `*InitializationOutput` naming used for screen config (`CardFormInitializationOutput`, `EmailInitializationOutput`, `PaymentInitializationOutput`).

## Test plan
- [x] `xcodebuild build` for the `MercadoPagoCheckout` scheme succeeds
- [x] No remaining references to the old `CardFormOutput` name in `Sources/` or `Tests/`